### PR TITLE
Fix a bug with file metadata in SimpleDirectoryReader.load_data

### DIFF
--- a/gpt_index/readers/file/base.py
+++ b/gpt_index/readers/file/base.py
@@ -1,5 +1,6 @@
 """Simple reader that reads files of different formats from a directory."""
 import logging
+from copy import deepcopy
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Union
 
@@ -141,7 +142,7 @@ class SimpleDirectoryReader(BaseReader):
         """
         data: Union[str, List[str]] = ""
         data_list: List[str] = []
-        metadata_list = []
+        metadata_list: List[dict] = []
         for input_file in self.input_files:
             if input_file.suffix in self.file_extractor:
                 parser = self.file_extractor[input_file.suffix]
@@ -157,7 +158,12 @@ class SimpleDirectoryReader(BaseReader):
             else:
                 data_list.append(str(data))
             if self.file_metadata is not None:
-                metadata_list.append(self.file_metadata(str(input_file)))
+                metadata: dict = self.file_metadata(str(input_file))
+                if isinstance(data, List):
+                    repeated_metadata = [deepcopy(metadata) for _ in range(len(data))]
+                    metadata_list.extend(repeated_metadata)
+                else:
+                    metadata_list.append(metadata)
 
         if concatenate:
             return [Document("\n".join(data_list))]


### PR DESCRIPTION
Fix the bug mentioned in [this issue](https://github.com/jerryjliu/gpt_index/issues/708): when `file_metadata` is specified, the number of returned documents is equal to the number of files, not the number of constructed documents, because `metadata` is added to `metadata_list` only once per file, so the lengths of `data_list` and `metadata_list` are not equal.

This PR:
- Fixes this by repeating the constructed metadata for each file
- Adds some missing type annotations

The more elegant way would be to do `data = [f.read()]`, and then get rid of all downstream `if`s but this can be done only if `parser.parse_file` always returns a list, which seems to be true now but may be changed in the future, so I suggest choosing the option implemented in this PR

Resolves: https://github.com/jerryjliu/llama_index/issues/708