### PR TITLE
Prevent duplicate embeddings when traversing a tree

### DIFF
--- a/gpt_index/indices/query/list/embedding_query.py
+++ b/gpt_index/indices/query/list/embedding_query.py
@@ -75,16 +75,14 @@ class GPTListIndexEmbeddingQuery(BaseGPTListIndexQuery):
         self, query_bundle: QueryBundle, nodes: List[Node]
     ) -> Tuple[List[float], List[List[float]]]:
         """Get top nodes by similarity to the query."""
-        query_embedding = self._embed_model.get_agg_embedding_from_queries(
-            query_bundle.embedding_strs
-        )
+        if query_bundle.embedding is None:
+            query_bundle.embedding = self._embed_model.get_agg_embedding_from_queries(
+                query_bundle.embedding_strs
+            )
         node_embeddings: List[List[float]] = []
         for node in self.index_struct.nodes:
-            if node.embedding is not None:
-                text_embedding = node.embedding
-            else:
-                text_embedding = self._embed_model.get_text_embedding(node.get_text())
-                node.embedding = text_embedding
+            if node.embedding is None:
+                node.embedding = self._embed_model.get_text_embedding(node.get_text())
 
-            node_embeddings.append(text_embedding)
-        return query_embedding, node_embeddings
+            node_embeddings.append(node.embedding)
+        return query_bundle.embedding, node_embeddings

--- a/gpt_index/indices/query/schema.py
+++ b/gpt_index/indices/query/schema.py
@@ -132,10 +132,12 @@ class QueryBundle(DataClassJsonMixin):
             This is currently used by all non embedding-based queries.
         embedding_strs (list[str]): list of strings used for embedding the query.
             This is currently used by all embedding-based queries.
+        embedding (list[float]): the stored embedding for the query.
     """
 
     query_str: str
     custom_embedding_strs: Optional[List[str]] = None
+    embedding: Optional[List[float]] = None
 
     @property
     def embedding_strs(self) -> List[str]:

--- a/gpt_index/indices/query/tree/embedding_query.py
+++ b/gpt_index/indices/query/tree/embedding_query.py
@@ -97,18 +97,18 @@ class GPTTreeIndexEmbeddingQuery(GPTTreeIndexLeafQuery):
         Cache the query embedding and the node text embedding.
 
         """
-        query_embedding = self._embed_model.get_agg_embedding_from_queries(
-            query_bundle.embedding_strs
-        )
+        if query_bundle.embedding is None:
+            query_bundle.embedding = self._embed_model.get_agg_embedding_from_queries(
+                query_bundle.embedding_strs
+            )
         similarities = []
         for node in nodes:
-            if node.embedding is not None:
-                text_embedding = node.embedding
-            else:
-                text_embedding = self._embed_model.get_text_embedding(node.get_text())
-                node.embedding = text_embedding
+            if node.embedding is None:
+                node.embedding = self._embed_model.get_text_embedding(node.get_text())
 
-            similarity = self._embed_model.similarity(query_embedding, text_embedding)
+            similarity = self._embed_model.similarity(
+                query_bundle.embedding, node.embedding
+            )
             similarities.append(similarity)
         return similarities
 


### PR DESCRIPTION
Hey guys, I noticed my queries were getting embedded many times as the query traverses the tree_index.

This would be one way to solve the problem, another might be adding a `@cache` to the embedding function.
The PR should reduce the time and cost of running tree embedding queries.