### PR TITLE
Fix `GPTSQLStructStoreIndex.load_from_disk`

### DIFF
--- a/gpt_index/indices/struct_store/sql.py
+++ b/gpt_index/indices/struct_store/sql.py
@@ -74,9 +74,6 @@ class GPTSQLStructStoreIndex(BaseGPTStructStoreIndex[SQLStructTable]):
         self._table_name = table_name
         self._table = table
 
-        # if documents aren't specified, pass in a blank []
-        documents = documents or []
-
         super().__init__(
             documents=documents,
             index_struct=index_struct,

--- a/gpt_index/indices/struct_store/sql.py
+++ b/gpt_index/indices/struct_store/sql.py
@@ -74,6 +74,9 @@ class GPTSQLStructStoreIndex(BaseGPTStructStoreIndex[SQLStructTable]):
         self._table_name = table_name
         self._table = table
 
+        if index_struct is None:
+            documents = documents or []
+
         super().__init__(
             documents=documents,
             index_struct=index_struct,


### PR DESCRIPTION
Defaulting to an empty list for `documents` doesn't work here, because it would later fail the check against `None` on this line: https://github.com/jerryjliu/llama_index/blob/main/gpt_index/indices/base.py#L82-L83, which leads to `Only one of documents or index_struct can be provided.` when loading the index from disk.