### PR TITLE
Add custom SSL support for SlackReader

### DIFF
--- a/gpt_index/readers/slack.py
+++ b/gpt_index/readers/slack.py
@@ -3,6 +3,7 @@ import logging
 import os
 import time
 from datetime import datetime
+from ssl import SSLContext
 from typing import List, Optional
 
 from gpt_index.readers.base import BaseReader
@@ -31,6 +32,7 @@ class SlackReader(BaseReader):
     def __init__(
         self,
         slack_token: Optional[str] = None,
+        ssl: Optional[SSLContext] = None,
         earliest_date: Optional[datetime] = None,
         latest_date: Optional[datetime] = None,
     ) -> None:
@@ -44,7 +46,10 @@ class SlackReader(BaseReader):
                 "Must specify `slack_token` or set environment "
                 "variable `SLACK_BOT_TOKEN`."
             )
-        self.client = WebClient(token=slack_token)
+        if ssl is None:
+            self.client = WebClient(token=slack_token)
+        else:
+            self.client = WebClient(token=slack_token, ssl=ssl)
         if latest_date is not None and earliest_date is None:
             raise ValueError(
                 "Must specify `earliest_date` if `latest_date` is specified."

--- a/gpt_index/readers/slack.py
+++ b/gpt_index/readers/slack.py
@@ -22,6 +22,8 @@ class SlackReader(BaseReader):
     Args:
         slack_token (Optional[str]): Slack token. If not provided, we
             assume the environment variable `SLACK_BOT_TOKEN` is set.
+        ssl (Optional[str]): Custom SSL context. If not provided, it is assumed
+            there is already an SSL context available.
         earliest_date (Optional[datetime]): Earliest date from which
             to read conversations. If not provided, we read all messages.
         latest_date (Optional[datetime]): Latest date from which to


### PR DESCRIPTION
I noticed the SlackReader was missing support for a custom SSL context. This PR adds this.

Changes required:
 - Add an optional parameter `ssl: Optional[SSLContext]` to the `SlackReader` constructor.
 - Branch the instantiation of the `client` object based on the availability of this parameter. If it is `None`, the `client` is instantiated as before. If the `ssl` parameter is available, it is passed into the `WebClient` constructor.