### PR TITLE
on refinement, previous-answer was included twice in prompt

### DIFF
--- a/gpt_index/indices/query/tree/leaf_query.py
+++ b/gpt_index/indices/query/tree/leaf_query.py
@@ -108,7 +108,7 @@ class GPTTreeIndexLeafQuery(BaseGPTIndexQuery[IndexGraph]):
         if prev_response is None:
             return cur_response
         else:
-            context_msg = "\n".join([selected_node.get_text(), cur_response])
+            context_msg = selected_node.get_text()
             cur_response, formatted_refine_prompt = self._llm_predictor.predict(
                 self.refine_template,
                 query_str=query_str,


### PR DESCRIPTION
For refinement queries, the "existing answer" was passed twice:
- as part of context_msg (was "new context" from current node + previous answer)
- standalone as {existing_answer} 
Removed existing_answer from content_msg to save tokens an make query more precise.