### PR TITLE
Fix breaking changes from Langchain update to 0.0.119

### DIFF
--- a/gpt_index/output_parsers/langchain.py
+++ b/gpt_index/output_parsers/langchain.py
@@ -3,7 +3,7 @@
 from string import Formatter
 from typing import Any, Optional
 
-from langchain.output_parsers import BaseOutputParser as LCOutputParser
+from langchain.agents.conversational_chat.base import BaseOutputParser as LCOutputParser
 
 from gpt_index.output_parsers.base import BaseOutputParser
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,6 @@ mypy==0.991
 flake8==6.0.0
 flake8-docstrings==1.6.0
 pylint==2.15.10
+
+# lock
+langchain==0.0.118

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ flake8-docstrings==1.6.0
 pylint==2.15.10
 
 # lock
-langchain==0.0.118
+langchain==0.0.119

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 install_requires = [
     "dataclasses_json",
-    "langchain",
+    "langchain==0.0.118",
     "numpy",
     "tenacity>=8.2.0,<9.0.0",
     "openai>=0.26.4",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 install_requires = [
     "dataclasses_json",
-    "langchain==0.0.118",
+    "langchain==0.0.119",
     "numpy",
     "tenacity>=8.2.0,<9.0.0",
     "openai>=0.26.4",

--- a/setup_llama.py
+++ b/setup_llama.py
@@ -12,7 +12,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 install_requires = [
     "dataclasses_json",
-    "langchain",
+    "langchain==0.0.118",
     "numpy",
     "tenacity>=8.2.0,<9.0.0",
     "openai>=0.26.4",

--- a/setup_llama.py
+++ b/setup_llama.py
@@ -12,7 +12,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 install_requires = [
     "dataclasses_json",
-    "langchain==0.0.118",
+    "langchain==0.0.119",
     "numpy",
     "tenacity>=8.2.0,<9.0.0",
     "openai>=0.26.4",

--- a/tests/output_parsers/test_base.py
+++ b/tests/output_parsers/test_base.py
@@ -1,7 +1,7 @@
 """Test Output parsers."""
 
 
-from langchain.output_parsers import BaseOutputParser as LCOutputParser
+from langchain.agents.conversational_chat.base import BaseOutputParser as LCOutputParser
 from langchain.output_parsers import ResponseSchema
 
 from gpt_index.output_parsers.langchain import LangchainOutputParser


### PR DESCRIPTION
Langchain is a package that is under constant change and development; breaking changes can come at any time.

I propose to lock the langchain version Llama index so that it will always be stable on any fresh install.

Then the Langchain version can be updated periodically, any breaking changes fixed and a new Llama index version can be released, with the sureness of stability.

Langchain just had a newly published version 0.0.119. It has some breaking changes on the import path of the [BaseOutputParser](https://github.com/hwchase17/langchain/commit/ce5d97bcb3e263f6aa69da6c334e35e20bf4db11)