### PR TITLE
[0.5.0] Remove `IndexRegistry`

### DIFF
--- a/gpt_index/composability/graph.py
+++ b/gpt_index/composability/graph.py
@@ -36,35 +36,6 @@ from gpt_index.response.schema import Response
 QUERY_CONFIG_TYPE = Union[Dict, QueryConfig]
 
 
-# this is a map from type to outer index class
-# we extract the type_to_struct and type_to_query
-# fields from the index class
-DEFAULT_INDEX_REGISTRY_MAP: Dict[IndexStructType, Type[BaseGPTIndex]] = {
-    IndexStructType.TREE: GPTTreeIndex,
-    IndexStructType.LIST: GPTListIndex,
-    IndexStructType.KEYWORD_TABLE: GPTKeywordTableIndex,
-    IndexStructType.SIMPLE_DICT: GPTSimpleVectorIndex,
-    IndexStructType.DICT: GPTFaissIndex,
-    IndexStructType.WEAVIATE: GPTWeaviateIndex,
-    IndexStructType.PINECONE: GPTPineconeIndex,
-    IndexStructType.QDRANT: GPTQdrantIndex,
-    IndexStructType.CHROMA: GPTChromaIndex,
-    IndexStructType.VECTOR_STORE: GPTVectorStoreIndex,
-    IndexStructType.SQL: GPTSQLStructStoreIndex,
-    IndexStructType.KG: GPTKnowledgeGraphIndex,
-    IndexStructType.EMPTY: GPTEmptyIndex,
-}
-
-
-def _get_default_index_registry() -> IndexRegistry:
-    """Get default index registry."""
-    index_registry = IndexRegistry()
-    for index_type, index_class in DEFAULT_INDEX_REGISTRY_MAP.items():
-        index_registry.type_to_struct[index_type] = index_class.index_struct_cls
-        index_registry.type_to_query[index_type] = index_class.get_query_map()
-    return index_registry
-
-
 def _safe_get_index_struct(
     docstore: DocumentStore, index_struct_id: str
 ) -> IndexStruct:

--- a/gpt_index/composability/graph.py
+++ b/gpt_index/composability/graph.py
@@ -125,11 +125,7 @@ class ComposableGraph:
     ) -> BaseGPTIndex:
         """Get index."""
         index_struct = _safe_get_index_struct(self._docstore, index_struct_id)
-        return index_cls(
-            index_struct=index_struct,
-            docstore=self._docstore,
-            **kwargs
-        )
+        return index_cls(index_struct=index_struct, docstore=self._docstore, **kwargs)
 
     @classmethod
     def load_from_string(cls, index_string: str, **kwargs: Any) -> "ComposableGraph":
@@ -148,9 +144,7 @@ class ComposableGraph:
 
         """
         result_dict = json.loads(index_string)
-        docstore = DocumentStore.load_from_dict(
-            result_dict["docstore"]
-        )
+        docstore = DocumentStore.load_from_dict(result_dict["docstore"])
         index_struct = _safe_get_index_struct(docstore, result_dict["index_struct_id"])
         return cls(docstore, index_struct, **kwargs)
 

--- a/gpt_index/docstore.py
+++ b/gpt_index/docstore.py
@@ -65,6 +65,8 @@ class DocumentStore(DataClassJsonMixin):
             doc_type = doc_dict.pop(TYPE_KEY, None)
             if doc_type == "Document" or doc_type is None:
                 doc: BaseDocument = Document.from_dict(doc_dict)
+            elif doc_type == Node.get_type():
+                doc: Node = Node.from_dict(doc_dict)
             else:
                 if type_to_struct is None:
                     raise ValueError(

--- a/gpt_index/docstore.py
+++ b/gpt_index/docstore.py
@@ -8,6 +8,7 @@ from dataclasses_json import DataClassJsonMixin
 
 from gpt_index.data_structs.data_structs_v2 import V2IndexStruct as IndexStruct
 from gpt_index.data_structs.node_v2 import Node
+from gpt_index.indices.registry import INDEX_STRUCT_TYPE_TO_INDEX_STRUCT_CLASS
 from gpt_index.readers.schema.base import Document
 from gpt_index.schema import BaseDocument
 
@@ -57,6 +58,8 @@ class DocumentStore(DataClassJsonMixin):
         type_to_struct: Optional[Dict[str, Type[BaseDocument]]] = None,
     ) -> "DocumentStore":
         """Load from dict."""
+        type_to_struct = type_to_struct or INDEX_STRUCT_TYPE_TO_INDEX_STRUCT_CLASS
+
         docs_obj_dict = {}
         for doc_id, doc_dict in docs_dict["docs"].items():
             doc_type = doc_dict.pop(TYPE_KEY, None)

--- a/gpt_index/indices/base.py
+++ b/gpt_index/indices/base.py
@@ -30,8 +30,9 @@ logger = logging.getLogger(__name__)
 # map from mode to query class
 QueryMap = Dict[str, Type[BaseGPTIndexQuery]]
 
+
 class BaseGPTIndex(Generic[IS]):
-    
+
     """Base LlamaIndex.
 
     Args:

--- a/gpt_index/indices/empty/base.py
+++ b/gpt_index/indices/empty/base.py
@@ -5,12 +5,11 @@ pure LLM calls.
 
 """
 
-from typing import Any, Dict, Optional, Sequence, Type
+from typing import Any, Optional, Sequence
 
 from gpt_index.data_structs.data_structs_v2 import EmptyIndex
 from gpt_index.data_structs.node_v2 import Node
-from gpt_index.indices.base import BaseGPTIndex
-from gpt_index.indices.query.base import BaseGPTIndexQuery
+from gpt_index.indices.base import BaseGPTIndex, QueryMap
 from gpt_index.indices.query.empty.base import GPTEmptyIndexQuery
 from gpt_index.indices.query.schema import QueryMode
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor

--- a/gpt_index/indices/empty/base.py
+++ b/gpt_index/indices/empty/base.py
@@ -47,7 +47,7 @@ class GPTEmptyIndex(BaseGPTIndex[EmptyIndex]):
         )
 
     @classmethod
-    def get_query_map(self) -> Dict[str, Type[BaseGPTIndexQuery]]:
+    def get_query_map(self) -> QueryMap:
         """Get query map."""
         return {
             QueryMode.DEFAULT: GPTEmptyIndexQuery,

--- a/gpt_index/indices/keyword_table/base.py
+++ b/gpt_index/indices/keyword_table/base.py
@@ -9,14 +9,13 @@ existing keywords in the table.
 """
 
 from abc import abstractmethod
-from typing import Any, Dict, Optional, Sequence, Set, Type
+from typing import Any, Optional, Sequence, Set
 
 from gpt_index.async_utils import run_async_tasks
 from gpt_index.data_structs.data_structs_v2 import KeywordTable
 from gpt_index.data_structs.node_v2 import Node
-from gpt_index.indices.base import BaseGPTIndex
+from gpt_index.indices.base import BaseGPTIndex, QueryMap
 from gpt_index.indices.keyword_table.utils import extract_keywords_given_response
-from gpt_index.indices.query.base import BaseGPTIndexQuery
 from gpt_index.indices.query.keyword_table.query import (
     GPTKeywordTableGPTQuery,
     GPTKeywordTableRAKEQuery,

--- a/gpt_index/indices/keyword_table/base.py
+++ b/gpt_index/indices/keyword_table/base.py
@@ -87,7 +87,7 @@ class BaseGPTKeywordTableIndex(BaseGPTIndex[KeywordTable]):
         )
 
     @classmethod
-    def get_query_map(self) -> Dict[str, Type[BaseGPTIndexQuery]]:
+    def get_query_map(self) -> QueryMap:
         """Get query map."""
         return {
             QueryMode.DEFAULT: GPTKeywordTableGPTQuery,

--- a/gpt_index/indices/knowledge_graph/base.py
+++ b/gpt_index/indices/knowledge_graph/base.py
@@ -9,12 +9,11 @@ existing keywords in the table.
 """
 
 import logging
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Type
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from gpt_index.data_structs.data_structs_v2 import KG
 from gpt_index.data_structs.node_v2 import Node
-from gpt_index.indices.base import BaseGPTIndex
-from gpt_index.indices.query.base import BaseGPTIndexQuery
+from gpt_index.indices.base import BaseGPTIndex, QueryMap
 from gpt_index.indices.query.knowledge_graph.query import GPTKGTableQuery, KGQueryMode
 from gpt_index.indices.query.schema import QueryMode
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor

--- a/gpt_index/indices/knowledge_graph/base.py
+++ b/gpt_index/indices/knowledge_graph/base.py
@@ -74,7 +74,7 @@ class GPTKnowledgeGraphIndex(BaseGPTIndex[KG]):
         )
 
     @classmethod
-    def get_query_map(self) -> Dict[str, Type[BaseGPTIndexQuery]]:
+    def get_query_map(self) -> QueryMap:
         """Get query map."""
         return {
             QueryMode.DEFAULT: GPTKGTableQuery,

--- a/gpt_index/indices/list/base.py
+++ b/gpt_index/indices/list/base.py
@@ -63,7 +63,7 @@ class GPTListIndex(BaseGPTIndex[IndexList]):
         )
 
     @classmethod
-    def get_query_map(self) -> Dict[str, Type[BaseGPTIndexQuery]]:
+    def get_query_map(self) -> QueryMap:
         """Get query map."""
         return {
             QueryMode.DEFAULT: GPTListIndexQuery,

--- a/gpt_index/indices/list/base.py
+++ b/gpt_index/indices/list/base.py
@@ -5,12 +5,11 @@ in sequence in order to answer a given query.
 
 """
 
-from typing import Any, Dict, Optional, Sequence, Type
+from typing import Any, Optional, Sequence
 
 from gpt_index.data_structs.data_structs_v2 import IndexList
 from gpt_index.data_structs.node_v2 import Node
-from gpt_index.indices.base import BaseGPTIndex
-from gpt_index.indices.query.base import BaseGPTIndexQuery
+from gpt_index.indices.base import BaseGPTIndex, QueryMap
 from gpt_index.indices.query.list.embedding_query import GPTListIndexEmbeddingQuery
 from gpt_index.indices.query.list.query import GPTListIndexQuery
 from gpt_index.indices.query.schema import QueryMode

--- a/gpt_index/indices/query/query_runner.py
+++ b/gpt_index/indices/query/query_runner.py
@@ -16,7 +16,6 @@ from gpt_index.indices.query.query_transform.base import (
     IdentityQueryTransform,
 )
 from gpt_index.indices.query.schema import QueryBundle, QueryConfig, QueryMode
-from gpt_index.indices.registry import IndexRegistry
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.response.schema import Response
 
@@ -37,7 +36,6 @@ class QueryRunner(BaseQueryRunner):
         prompt_helper: PromptHelper,
         embed_model: BaseEmbedding,
         docstore: DocumentStore,
-        index_registry: IndexRegistry,
         query_configs: Optional[List[QUERY_CONFIG_TYPE]] = None,
         query_transform: Optional[BaseQueryTransform] = None,
         query_combiner: Optional[BaseQueryCombiner] = None,

--- a/gpt_index/indices/query/query_runner.py
+++ b/gpt_index/indices/query/query_runner.py
@@ -16,6 +16,7 @@ from gpt_index.indices.query.query_transform.base import (
     IdentityQueryTransform,
 )
 from gpt_index.indices.query.schema import QueryBundle, QueryConfig, QueryMode
+from gpt_index.indices.registry import INDEX_STRUT_TYPE_TO_QUERY_MAP
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.response.schema import Response
 
@@ -65,7 +66,6 @@ class QueryRunner(BaseQueryRunner):
         self._prompt_helper = prompt_helper
         self._embed_model = embed_model
         self._docstore = docstore
-        self._index_registry = index_registry
         self._query_transform = query_transform or IdentityQueryTransform()
         self._query_combiner = query_combiner
         self._recursive = recursive
@@ -141,7 +141,7 @@ class QueryRunner(BaseQueryRunner):
         config = self._get_query_config(index_struct)
         mode = config.query_mode
 
-        query_cls = self._index_registry.type_to_query[index_struct_type][mode]
+        query_cls = INDEX_STRUT_TYPE_TO_QUERY_MAP[index_struct_type][mode]
         # if recursive, pass self as query_runner to each individual query
         query_runner = self
         query_kwargs = self._get_query_kwargs(config)

--- a/gpt_index/indices/query/query_runner.py
+++ b/gpt_index/indices/query/query_runner.py
@@ -16,7 +16,6 @@ from gpt_index.indices.query.query_transform.base import (
     IdentityQueryTransform,
 )
 from gpt_index.indices.query.schema import QueryBundle, QueryConfig, QueryMode
-from gpt_index.indices.registry import INDEX_STRUT_TYPE_TO_QUERY_MAP
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.response.schema import Response
 
@@ -141,6 +140,7 @@ class QueryRunner(BaseQueryRunner):
         config = self._get_query_config(index_struct)
         mode = config.query_mode
 
+        from gpt_index.indices.registry import INDEX_STRUT_TYPE_TO_QUERY_MAP
         query_cls = INDEX_STRUT_TYPE_TO_QUERY_MAP[index_struct_type][mode]
         # if recursive, pass self as query_runner to each individual query
         query_runner = self

--- a/gpt_index/indices/registry.py
+++ b/gpt_index/indices/registry.py
@@ -1,47 +1,44 @@
 """Index registry."""
 
-from typing import Any, Dict, Type
+from typing import Dict
 
-from gpt_index.data_structs.struct_type import IndexStructType
-from gpt_index.indices.base import BaseGPTIndex, QueryMap
-from gpt_index.indices.empty.base import GPTEmptyIndex
-from gpt_index.indices.keyword_table.base import GPTKeywordTableIndex
-from gpt_index.indices.knowledge_graph.base import GPTKnowledgeGraphIndex
-from gpt_index.indices.list.base import GPTListIndex
-from gpt_index.indices.struct_store.sql import GPTSQLStructStoreIndex
-from gpt_index.indices.tree.base import GPTTreeIndex
-from gpt_index.indices.vector_store.base import GPTVectorStoreIndex
-from gpt_index.indices.vector_store.vector_indices import (
-    GPTChromaIndex,
-    GPTFaissIndex,
-    GPTPineconeIndex,
-    GPTQdrantIndex,
-    GPTSimpleVectorIndex,
-    GPTWeaviateIndex,
+from gpt_index.data_structs.data_structs import PineconeIndexDict, SimpleIndexDict
+from gpt_index.data_structs.data_structs_v2 import (
+    KG,
+    ChromaIndexDict,
+    EmptyIndex,
+    FaissIndexDict,
+    IndexDict,
+    IndexGraph,
+    IndexList,
+    KeywordTable,
+    QdrantIndexDict,
+    V2IndexStruct,
+    WeaviateIndexDict,
 )
+from gpt_index.data_structs.node_v2 import Node
+from gpt_index.data_structs.struct_type import IndexStructType
+from gpt_index.data_structs.table_v2 import SQLStructTable
+from gpt_index.indices.base import QueryMap
 
-INDEX_STRUCT_TYPE_TO_INDEX_CLASS: Dict[IndexStructType, Type[BaseGPTIndex]] = {
-    IndexStructType.TREE: GPTTreeIndex,
-    IndexStructType.LIST: GPTListIndex,
-    IndexStructType.KEYWORD_TABLE: GPTKeywordTableIndex,
-    IndexStructType.SIMPLE_DICT: GPTSimpleVectorIndex,
-    IndexStructType.DICT: GPTFaissIndex,
-    IndexStructType.WEAVIATE: GPTWeaviateIndex,
-    IndexStructType.PINECONE: GPTPineconeIndex,
-    IndexStructType.QDRANT: GPTQdrantIndex,
-    IndexStructType.CHROMA: GPTChromaIndex,
-    IndexStructType.VECTOR_STORE: GPTVectorStoreIndex,
-    IndexStructType.SQL: GPTSQLStructStoreIndex,
-    IndexStructType.KG: GPTKnowledgeGraphIndex,
-    IndexStructType.EMPTY: GPTEmptyIndex,
+INDEX_STRUCT_TYPE_TO_INDEX_STRUCT_CLASS: Dict[IndexStructType, V2IndexStruct] = {
+    IndexStructType.TREE: IndexGraph,
+    IndexStructType.LIST: IndexList,
+    IndexStructType.KEYWORD_TABLE: KeywordTable,
+    IndexStructType.SIMPLE_DICT: SimpleIndexDict,
+    IndexStructType.DICT: FaissIndexDict,
+    IndexStructType.WEAVIATE: WeaviateIndexDict,
+    IndexStructType.PINECONE: PineconeIndexDict,
+    IndexStructType.QDRANT: QdrantIndexDict,
+    IndexStructType.CHROMA: ChromaIndexDict,
+    IndexStructType.VECTOR_STORE: IndexDict,
+    IndexStructType.SQL: SQLStructTable,
+    IndexStructType.KG: KG,
+    IndexStructType.EMPTY: EmptyIndex,
 }
 
-INDEX_STRUCT_TYPE_TO_INDEX_STRUCT_CLASS: Dict[IndexStructType, Any] = {
-    index_type: index_cls.index_struct_cls
-    for index_type, index_cls in INDEX_STRUCT_TYPE_TO_INDEX_CLASS.items()
-}
-
+# TODO: figure out how to avoid importing all indices while not centralizing all query map
 INDEX_STRUT_TYPE_TO_QUERY_MAP: Dict[IndexStructType, QueryMap] = {
     index_type: index_cls.get_query_map()
-    for index_type, index_cls in INDEX_STRUCT_TYPE_TO_INDEX_CLASS.items()
+    for index_type, index_cls in INDEX_STRUCT_TYPE_TO_INDEX_STRUCT_CLASS.items()
 }

--- a/gpt_index/indices/struct_store/pandas.py
+++ b/gpt_index/indices/struct_store/pandas.py
@@ -1,12 +1,12 @@
 """Pandas csv structured store."""
 
-from typing import Any, Dict, Optional, Sequence, Type
+from typing import Any, Optional, Sequence
 
 import pandas as pd
 
 from gpt_index.data_structs.node_v2 import Node
 from gpt_index.data_structs.table_v2 import PandasStructTable
-from gpt_index.indices.query.base import BaseGPTIndexQuery
+from gpt_index.indices.base import QueryMap
 from gpt_index.indices.query.schema import QueryMode
 from gpt_index.indices.query.struct_store.pandas import GPTNLPandasIndexQuery
 from gpt_index.indices.struct_store.base import BaseGPTStructStoreIndex

--- a/gpt_index/indices/struct_store/pandas.py
+++ b/gpt_index/indices/struct_store/pandas.py
@@ -74,7 +74,7 @@ class GPTPandasIndex(BaseGPTStructStoreIndex[PandasStructTable]):
         query_kwargs["df"] = self.df
 
     @classmethod
-    def get_query_map(self) -> Dict[str, Type[BaseGPTIndexQuery]]:
+    def get_query_map(self) -> QueryMap:
         """Get query map."""
         return {
             QueryMode.DEFAULT: GPTNLPandasIndexQuery,

--- a/gpt_index/indices/struct_store/sql.py
+++ b/gpt_index/indices/struct_store/sql.py
@@ -125,7 +125,7 @@ class GPTSQLStructStoreIndex(BaseGPTStructStoreIndex[SQLStructTable]):
         data_extractor.insert_datapoint_from_nodes(nodes)
 
     @classmethod
-    def get_query_map(self) -> Dict[str, Type[BaseGPTIndexQuery]]:
+    def get_query_map(self) -> QueryMap:
         """Get query map."""
         return {
             QueryMode.DEFAULT: GPTNLStructStoreIndexQuery,

--- a/gpt_index/indices/struct_store/sql.py
+++ b/gpt_index/indices/struct_store/sql.py
@@ -1,15 +1,14 @@
 """SQL Structured Store."""
 import json
-from typing import Any, Dict, Optional, Sequence, Type
+from typing import Any, Dict, Optional, Sequence
 
 from sqlalchemy import Table
 
 from gpt_index.data_structs.node_v2 import Node
 from gpt_index.data_structs.table_v2 import SQLStructTable
-from gpt_index.indices.base import BaseGPTIndex
+from gpt_index.indices.base import BaseGPTIndex, QueryMap
 from gpt_index.indices.common.struct_store.schema import SQLContextContainer
 from gpt_index.indices.common.struct_store.sql import SQLStructDatapointExtractor
-from gpt_index.indices.query.base import BaseGPTIndexQuery
 from gpt_index.indices.query.schema import QueryMode
 from gpt_index.indices.query.struct_store.sql import (
     GPTNLStructStoreIndexQuery,

--- a/gpt_index/indices/tree/base.py
+++ b/gpt_index/indices/tree/base.py
@@ -1,13 +1,12 @@
 """Tree-based index."""
 
-from typing import Any, Dict, Optional, Sequence, Type
+from typing import Any, Dict, Optional, Sequence
 
 # from gpt_index.data_structs.data_structs import IndexGraph
 from gpt_index.data_structs.data_structs_v2 import IndexGraph
 from gpt_index.data_structs.node_v2 import Node
-from gpt_index.indices.base import BaseGPTIndex
+from gpt_index.indices.base import BaseGPTIndex, QueryMap
 from gpt_index.indices.common.tree.base import GPTTreeIndexBuilder
-from gpt_index.indices.query.base import BaseGPTIndexQuery
 from gpt_index.indices.query.schema import QueryMode
 from gpt_index.indices.query.tree.embedding_query import GPTTreeIndexEmbeddingQuery
 from gpt_index.indices.query.tree.leaf_query import GPTTreeIndexLeafQuery

--- a/gpt_index/indices/tree/base.py
+++ b/gpt_index/indices/tree/base.py
@@ -81,7 +81,7 @@ class GPTTreeIndex(BaseGPTIndex[IndexGraph]):
         )
 
     @classmethod
-    def get_query_map(self) -> Dict[str, Type[BaseGPTIndexQuery]]:
+    def get_query_map(self) -> QueryMap:
         """Get query map."""
         return {
             QueryMode.DEFAULT: GPTTreeIndexLeafQuery,

--- a/gpt_index/indices/vector_store/base.py
+++ b/gpt_index/indices/vector_store/base.py
@@ -4,14 +4,13 @@ An index that that is built on top of an existing vector store.
 
 """
 
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Type
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 
 from gpt_index.async_utils import run_async_tasks
 from gpt_index.data_structs.data_structs_v2 import IndexDict
 from gpt_index.data_structs.node_v2 import Node
 from gpt_index.embeddings.base import BaseEmbedding
-from gpt_index.indices.base import BaseGPTIndex
-from gpt_index.indices.query.base import BaseGPTIndexQuery
+from gpt_index.indices.base import BaseGPTIndex, QueryMap
 from gpt_index.indices.query.schema import QueryMode
 from gpt_index.indices.query.vector_store.base import GPTVectorStoreIndexQuery
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor

--- a/gpt_index/indices/vector_store/base.py
+++ b/gpt_index/indices/vector_store/base.py
@@ -70,7 +70,7 @@ class GPTVectorStoreIndex(BaseGPTIndex[IndexDict]):
         )
 
     @classmethod
-    def get_query_map(self) -> Dict[str, Type[BaseGPTIndexQuery]]:
+    def get_query_map(self) -> QueryMap:
         """Get query map."""
         return {
             QueryMode.DEFAULT: GPTVectorStoreIndexQuery,

--- a/gpt_index/indices/vector_store/vector_indices.py
+++ b/gpt_index/indices/vector_store/vector_indices.py
@@ -14,8 +14,7 @@ from gpt_index.data_structs.data_structs_v2 import (
 )
 from gpt_index.data_structs.node_v2 import Node
 from gpt_index.embeddings.base import BaseEmbedding
-from gpt_index.indices.base import BaseGPTIndex
-from gpt_index.indices.query.base import BaseGPTIndexQuery
+from gpt_index.indices.base import BaseGPTIndex, QueryMap
 from gpt_index.indices.query.schema import QueryMode
 from gpt_index.indices.query.vector_store.queries import (
     GPTChromaIndexQuery,

--- a/gpt_index/indices/vector_store/vector_indices.py
+++ b/gpt_index/indices/vector_store/vector_indices.py
@@ -99,7 +99,7 @@ class GPTSimpleVectorIndex(GPTVectorStoreIndex):
         self._docstore.add_documents([self.index_struct], allow_update=True)
 
     @classmethod
-    def get_query_map(self) -> Dict[str, Type[BaseGPTIndexQuery]]:
+    def get_query_map(self) -> QueryMap:
         """Get query map."""
         return {
             QueryMode.DEFAULT: GPTSimpleVectorIndexQuery,
@@ -165,7 +165,7 @@ class GPTFaissIndex(GPTVectorStoreIndex):
         )
 
     @classmethod
-    def get_query_map(self) -> Dict[str, Type[BaseGPTIndexQuery]]:
+    def get_query_map(self) -> QueryMap:
         """Get query map."""
         return {
             QueryMode.DEFAULT: GPTFaissIndexQuery,
@@ -304,7 +304,7 @@ class GPTPineconeIndex(GPTVectorStoreIndex):
         )
 
     @classmethod
-    def get_query_map(self) -> Dict[str, Type[BaseGPTIndexQuery]]:
+    def get_query_map(self) -> QueryMap:
         """Get query map."""
         return {
             QueryMode.DEFAULT: GPTPineconeIndexQuery,
@@ -372,7 +372,7 @@ class GPTWeaviateIndex(GPTVectorStoreIndex):
         )
 
     @classmethod
-    def get_query_map(self) -> Dict[str, Type[BaseGPTIndexQuery]]:
+    def get_query_map(self) -> QueryMap:
         """Get query map."""
         return {
             QueryMode.DEFAULT: GPTWeaviateIndexQuery,
@@ -442,7 +442,7 @@ class GPTQdrantIndex(GPTVectorStoreIndex):
         )
 
     @classmethod
-    def get_query_map(self) -> Dict[str, Type[BaseGPTIndexQuery]]:
+    def get_query_map(self) -> QueryMap:
         """Get query map."""
         return {
             QueryMode.DEFAULT: GPTQdrantIndexQuery,
@@ -509,7 +509,7 @@ class GPTChromaIndex(GPTVectorStoreIndex):
         )
 
     @classmethod
-    def get_query_map(self) -> Dict[str, Type[BaseGPTIndexQuery]]:
+    def get_query_map(self) -> QueryMap:
         """Get query map."""
         return {
             QueryMode.DEFAULT: GPTChromaIndexQuery,
@@ -579,7 +579,7 @@ class GPTOpensearchIndex(GPTVectorStoreIndex):
         )
 
     @classmethod
-    def get_query_map(self) -> Dict[str, Type[BaseGPTIndexQuery]]:
+    def get_query_map(self) -> QueryMap:
         """Get query map."""
         return {
             QueryMode.DEFAULT: GPTOpensearchIndexQuery,


### PR DESCRIPTION
Removing IndexRegistry class, use hard-coded mappings instead since there's not much value for users to customize this mapping. 