### PR TITLE
expand pinecone index: add metadata_filter

### DIFF
--- a/docs/how_to/vector_stores.md
+++ b/docs/how_to/vector_stores.md
@@ -146,9 +146,16 @@ pinecone.create_index(
 )
 index = pinecone.Index("quickstart")
 
+# can define filters specific to this vector index (so you can
+# reuse pinecone indexes)
+metadata_filters = {"title": "paul_graham_essay"}
+
+
 # Load documents, build the GPTPineconeIndex
 documents = SimpleDirectoryReader('../paul_graham_essay/data').load_data()
-index = GPTPineconeIndex(documents, pinecone_index=index)
+index = GPTPineconeIndex(
+    documents, pinecone_index=index, metadata_filters=metadata_filters
+)
 
 # Query index
 response = index.query("What did the author do growing up?")

--- a/examples/composable_indices/city_analysis/PineconeDemo-CityAnalysis.ipynb
+++ b/examples/composable_indices/city_analysis/PineconeDemo-CityAnalysis.ipynb
@@ -1,0 +1,1968 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cfb64210-9c6b-47d7-81f4-67dbdab68e4c",
+   "metadata": {
+    "id": "cfb64210-9c6b-47d7-81f4-67dbdab68e4c",
+    "tags": []
+   },
+   "source": [
+    "# Using LlamaIndex with Pinecone\n",
+    "\n",
+    "Test complex queries over both text-davinci-003 and ChatGPT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "D2ZI8iKch-V_",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "D2ZI8iKch-V_",
+    "outputId": "bc63c640-8508-4c74-8bd9-3fc1495b7839"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install llama-index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "d35ov8dk_6WP",
+   "metadata": {
+    "id": "d35ov8dk_6WP"
+   },
+   "outputs": [],
+   "source": [
+    "# My OpenAI Key\n",
+    "import os\n",
+    "os.environ['OPENAI_API_KEY'] = \"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "fa0e62b6",
+   "metadata": {
+    "id": "fa0e62b6",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "import sys\n",
+    "\n",
+    "logging.basicConfig(stream=sys.stdout, level=logging.INFO)\n",
+    "logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e27b0473-4bda-47f0-b6ed-fd482eac1a13",
+   "metadata": {
+    "id": "e27b0473-4bda-47f0-b6ed-fd482eac1a13",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from llama_index import (\n",
+    "    GPTPineconeIndex, \n",
+    "    GPTSimpleKeywordTableIndex, \n",
+    "    GPTListIndex, \n",
+    "    SimpleDirectoryReader,\n",
+    "    LLMPredictor\n",
+    ")\n",
+    "from langchain.llms.openai import OpenAIChat, OpenAI\n",
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49e0d841-680f-4a0c-b455-788b54978ebf",
+   "metadata": {
+    "id": "49e0d841-680f-4a0c-b455-788b54978ebf"
+   },
+   "source": [
+    "#### Load Datasets\n",
+    "\n",
+    "Load Wikipedia pages as well as Paul Graham's \"What I Worked On\" essay"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "fc4692a1",
+   "metadata": {
+    "id": "fc4692a1",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "wiki_titles = [\"Toronto\", \"Seattle\", \"San Francisco\", \"Chicago\", \"Boston\", \"Washington, D.C.\", \"Cambridge, Massachusetts\", \"Houston\"]\n",
+    "pinecone_titles = [\"toronto\", \"seattle\", \"san-francisco\", \"chicago\", \"boston\", \"dc\", \"cambridge\", \"houston\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "9ec16a8b-6aae-4bf7-9b83-b82087b4ea52",
+   "metadata": {
+    "id": "9ec16a8b-6aae-4bf7-9b83-b82087b4ea52",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import requests\n",
+    "for title in wiki_titles:\n",
+    "    response = requests.get(\n",
+    "        'https://en.wikipedia.org/w/api.php',\n",
+    "        params={\n",
+    "            'action': 'query',\n",
+    "            'format': 'json',\n",
+    "            'titles': title,\n",
+    "            'prop': 'extracts',\n",
+    "            # 'exintro': True,\n",
+    "            'explaintext': True,\n",
+    "        }\n",
+    "    ).json()\n",
+    "    page = next(iter(response['query']['pages'].values()))\n",
+    "    wiki_text = page['extract']\n",
+    "\n",
+    "    data_path = Path('data')\n",
+    "    if not data_path.exists():\n",
+    "        Path.mkdir(data_path)\n",
+    "\n",
+    "    with open(data_path / f\"{title}.txt\", 'w') as fp:\n",
+    "        fp.write(wiki_text)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "39c00aeb-adef-4ce3-8134-031de18e64ea",
+   "metadata": {
+    "id": "39c00aeb-adef-4ce3-8134-031de18e64ea",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Load all wiki documents\n",
+    "city_docs = {}\n",
+    "for wiki_title in wiki_titles:\n",
+    "    city_docs[wiki_title] = SimpleDirectoryReader(input_files=[f\"data/{wiki_title}.txt\"]).load_data()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84bfcaa1-db15-45ba-8af1-fee548354965",
+   "metadata": {},
+   "source": [
+    "### Initialize Pinecone Indexes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "06b261d7-f2a3-47b3-89ce-5f6103926174",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import pinecone"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "73a0cf0f-62b4-4f52-9c7f-726838d71f9a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "api_key = \"<pinecone_api_key>\"\n",
+    "pinecone.init(api_key=api_key, environment=\"us-west1-gcp\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "7bfbbf9d-4432-4af9-94ff-01e084c0cde0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "index = pinecone.Index(\"quickstart\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f1782198-c0de-4679-8951-1297c21b8639",
+   "metadata": {
+    "id": "f1782198-c0de-4679-8951-1297c21b8639"
+   },
+   "source": [
+    "### Building the document indices\n",
+    "Build a vector index for the wiki pages about cities and persons, and PG essay"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "M0GylZB-C2zL",
+   "metadata": {
+    "id": "M0GylZB-C2zL",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# LLM Predictor (gpt-3.5-turbo)\n",
+    "llm_predictor_chatgpt = LLMPredictor(llm=OpenAIChat(temperature=0, model_name=\"gpt-3.5-turbo\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5431e83e-428b-4473-bad1-24b7a6c4db38",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 183,
+     "referenced_widgets": [
+      "b5566e3db2914ddebd80d7bde75b2559",
+      "208d404f405a42a3b06d65ad67fb7322",
+      "7da29a2b6508494282acbc459eccbb96",
+      "47838fa763ca40598b2622a9d1e79444",
+      "ff32a3f12e814740a1cd5dd12bd731d4",
+      "3fef46c902524717b377dee6c1dfc929",
+      "fd8b887c1f7149f2876cf8a31e534ad6",
+      "7438aea716f44d85ad1c2b49a93acd83",
+      "fe39f994fa9b4d7daa232e1dcd2b0e8b",
+      "b102e756f9b848a98f58396fc825be84",
+      "fbd7219af1924d2ead5310eb7b35aab0",
+      "3b4c1066797b43a586611ec2d63e7ca1",
+      "c06865c1e01a441698dacf48600dd03c",
+      "9d229e5dd56e4d539ca2c1b9f0a37812",
+      "868aa268dd28498d902782215e53c6fa",
+      "46f644cf589e4a48a6fad1742f0c0575",
+      "adb40ef11f094594b14776e238955224",
+      "7b47c78391a4431aa2d3f84677f24046",
+      "398f1c0f56fe4f218d999df138adfdac",
+      "f1839e86863948f68314f81ba6bca4c9",
+      "3c37e72850c746ce9c919add5340dede",
+      "2053e6adef1b4dba89f861eaf3d916fd",
+      "eab4127882d24acfa9518ebff6f4e22a",
+      "64b754f563834be0a6963349b1f2dcf2",
+      "c7636a6d7380465895b8c86d34caf500",
+      "f7803dea63994cc2a31acf805bd19e67",
+      "380a0c11434241b191b17421e395be8b",
+      "a02534c347aa4865ab4ab3de3a3ee2f5",
+      "b0ccb9d9d96e4ed8bec4d540c34d337c",
+      "f22e9615de674e05978f332eb88750cf",
+      "b53e8481f6d64018988dc03081bf2765",
+      "b458d6fa793d4fa080b9f1e5013af3de",
+      "119d6d7a8d524aa49170f5784ebc6b9e",
+      "d55f842766484d299c75f74e31e7aa6a",
+      "1bdaf4dab16f48dbaeed3fb9bf268e45",
+      "026cc1a42e154f1f92b5236869311929",
+      "a2edbc4195d843e0acfba83726a08e78",
+      "40e148c291ad4f739998a7eac55a8af6",
+      "028aa5d1f7a74d538b5c606d4a6d146f",
+      "c078fe9a056a473dab7d474cd7907154",
+      "4cc9ec6ba46647aba2d53e352f91c137",
+      "f2a1c5087d0e44909139697ed90474e8",
+      "7b24b46d6c3643e581ba003a9c473745",
+      "3f748152b9274556afad2555572aa9f4"
+     ]
+    },
+    "id": "5431e83e-428b-4473-bad1-24b7a6c4db38",
+    "outputId": "5721e863-d460-4f5c-9e36-5a586180b669",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Build city document index\n",
+    "city_indices = {}\n",
+    "for pinecone_title, wiki_title in zip(pinecone_titles, wiki_titles):\n",
+    "    metadata_filters = {\"wiki_title\": wiki_title}\n",
+    "    city_indices[wiki_title] = GPTPineconeIndex(\n",
+    "        city_docs[wiki_title], pinecone_index=index, metadata_filters=metadata_filters\n",
+    "    )\n",
+    "    # set summary text for city\n",
+    "    city_indices[wiki_title].set_text(f\"Wikipedia articles about {wiki_title}\")\n",
+    "    city_indices[wiki_title].set_doc_id(pinecone_title)\n",
+    "    city_indices[wiki_title].save_to_disk(f'index_{wiki_title}.json')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8aaf556-df77-4fac-812b-0b6c6d1da0ef",
+   "metadata": {
+    "id": "b8aaf556-df77-4fac-812b-0b6c6d1da0ef"
+   },
+   "source": [
+    "### Loading the indices\n",
+    "Build a vector index for the NYC wiki page and PG essay"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "id": "98068ef8-aead-46e7-8dac-0d05b5a86e6a",
+   "metadata": {
+    "id": "98068ef8-aead-46e7-8dac-0d05b5a86e6a"
+   },
+   "outputs": [],
+   "source": [
+    "# If indices already saved, try loading\n",
+    "city_indices = {}\n",
+    "for wiki_title in wiki_titles:\n",
+    "    city_indices[wiki_title] = GPTPineconeIndex.load_from_disk(\n",
+    "      f'index_{wiki_title}.json', pinecone_index=index\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17605939-09ce-4405-a92a-8f296c941893",
+   "metadata": {},
+   "source": [
+    "### Query Index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d5865649-16c2-4681-a6cf-ccee589dcaa7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = city_indices[\"Boston\"].query(\n",
+    "    \"Tell me about the arts and culture of Boston\",\n",
+    "    llm_predictor=llm_predictor_chatgpt\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "id": "f8ec6f33-73d1-46cb-93f0-d76f9c42d78d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Boston has a rich arts and culture scene, with notable museums such as the Isabella Stewart Gardner Museum, the Institute of Contemporary Art, and the Museum of Science. The South End Art and Design District and Newbury St. are popular destinations for art galleries. The city also has a strong religious history, with the Roman Catholic Archdiocese of Boston and the Episcopal Diocese of Massachusetts both based in the city. Boston is also known for its sports teams, with championships won in all four major North American men's professional sports leagues plus Major League Soccer. The New England Patriots of the National Football League were founded in 1960 as the Boston Patriots and have won six Super Bowl championships. The area's many colleges and universities are active in college athletics, with four NCAA Division I members playing in the area—Boston College, Boston University, Harvard University, and Northeastern University.\n",
+      "> Source (Doc id: None): \n",
+      "\n",
+      "Isabella Stewart Gardner Museum. The Institute of Contemporary Art is housed in a contemporary ...\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(str(response))\n",
+    "print(response.get_formatted_sources())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4d3cd8b-4134-4cfa-8002-e0a34694d2e1",
+   "metadata": {
+    "id": "d4d3cd8b-4134-4cfa-8002-e0a34694d2e1",
+    "tags": []
+   },
+   "source": [
+    "### Build Graph: Keyword Table Index on top of vector indices! \n",
+    "\n",
+    "We compose a keyword table index on top of all the vector indices."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "id": "76c251ca-b06b-42e9-ac99-aa0a0a5187d4",
+   "metadata": {
+    "id": "76c251ca-b06b-42e9-ac99-aa0a0a5187d4"
+   },
+   "outputs": [],
+   "source": [
+    "# set query config\n",
+    "# NOTE: we need to specify a query config for every pinecone index \n",
+    "query_configs = []\n",
+    "for pinecone_title, wiki_title in zip(pinecone_title, wiki_title):\n",
+    "    query_config = {\n",
+    "        \"index_struct_id\": pinecone_title,\n",
+    "        \"index_struct_type\": \"pinecone\",\n",
+    "        \"query_mode\": \"default\",\n",
+    "        \"query_kwargs\": {\n",
+    "            \"similarity_top_k\": 1,\n",
+    "            \"pinecone_index\": index,\n",
+    "        }\n",
+    "    }\n",
+    "    query_configs.append(query_config)\n",
+    "\n",
+    "query_configs.append({\n",
+    "    \"index_struct_type\": \"keyword_table\",\n",
+    "    \"query_mode\": \"simple\",\n",
+    "    \"query_kwargs\": {\n",
+    "        \"response_mode\": \"tree_summarize\"\n",
+    "    }\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f975514f-fddd-4737-91de-97bc61394ea9",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "f975514f-fddd-4737-91de-97bc61394ea9",
+    "outputId": "fc875b0e-c8bf-439b-c794-fcae25954cfb"
+   },
+   "outputs": [],
+   "source": [
+    "keyword_table = GPTSimpleKeywordTableIndex(\n",
+    "    [index for _, index in city_indices.items()], max_keywords_per_chunk=50\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eebbc448-1e0b-402c-b37e-f93bfcc0bf4f",
+   "metadata": {
+    "id": "eebbc448-1e0b-402c-b37e-f93bfcc0bf4f"
+   },
+   "source": [
+    "### Define Graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "id": "6d68750c-e5ae-481a-8b03-6173020c9bf3",
+   "metadata": {
+    "id": "6d68750c-e5ae-481a-8b03-6173020c9bf3"
+   },
+   "outputs": [],
+   "source": [
+    "from llama_index.composability import ComposableGraph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "id": "822ada9f-fb43-472e-95ce-0036d508e528",
+   "metadata": {
+    "id": "822ada9f-fb43-472e-95ce-0036d508e528"
+   },
+   "outputs": [],
+   "source": [
+    "graph = ComposableGraph.build_from_index(keyword_table)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "id": "ae127943-afac-48b4-b22d-84a37e553e4b",
+   "metadata": {
+    "id": "ae127943-afac-48b4-b22d-84a37e553e4b"
+   },
+   "outputs": [],
+   "source": [
+    "# [optional] save to disk\n",
+    "graph.save_to_disk(\"index_multi_doc_graph.json\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "id": "dca2b64b-9af1-456f-8dab-822bfdc5d0ac",
+   "metadata": {
+    "id": "dca2b64b-9af1-456f-8dab-822bfdc5d0ac"
+   },
+   "outputs": [],
+   "source": [
+    "# [optional] load from disk\n",
+    "graph = ComposableGraph.load_from_disk(\"index_multi_doc_graph.json\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49c900ee-a31f-4fcd-bb44-ff2cd12a41eb",
+   "metadata": {
+    "id": "49c900ee-a31f-4fcd-bb44-ff2cd12a41eb"
+   },
+   "source": [
+    "### Compare Queries (text-davinci-003 vs. ChatGPT)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e0a8fa6a-e96e-4341-bb43-7547415f766e",
+   "metadata": {
+    "id": "e0a8fa6a-e96e-4341-bb43-7547415f766e"
+   },
+   "source": [
+    "**Simple Query**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "OVnzf3myEz88",
+   "metadata": {
+    "id": "OVnzf3myEz88",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "query_str = \"Tell me more about Boston\"\n",
+    "response_chatgpt = graph.query(query_str, query_configs=query_configs, llm_predictor=llm_predictor_chatgpt)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
+   "id": "29f32345-6f28-4545-afa9-e3c5849dfb82",
+   "metadata": {
+    "id": "29f32345-6f28-4545-afa9-e3c5849dfb82",
+    "outputId": "904002ea-f062-4f7d-8fe6-3e6b7b13b420"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Boston is the capital and largest city of the Commonwealth of Massachusetts and is located in the New England region of the Northeastern United States. It has a population of 675,647 as of 2020 and is the economic and cultural anchor of a larger metropolitan area known as Greater Boston, home to a census-estimated 4.8 million people in 2016. Boston is one of the oldest municipalities in America, founded in 1630 by Puritan settlers from the English town of the same name. It played a significant role in the American Revolution and the nation's founding, with events such as the Boston Massacre, the Boston Tea Party, the Battle of Bunker Hill, and the siege of Boston taking place there. Today, Boston is a center of scientific research, higher education, finance, professional and business services, biotechnology, information technology, and government activities. It is also considered to be a global pioneer in innovation and entrepreneurship, with nearly 5,000 startups. Boston's economic base includes finance, professional and business services, biotechnology, information technology, and government activities.\n",
+      "> Source (Doc id: boston): Wikipedia articles about Boston...\n",
+      "\n",
+      "> Source (Doc id: None): \n",
+      "\n",
+      "Boston (US: ), officially the City of Boston, is the capital and largest city of the Commonweal...\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(response_chatgpt)\n",
+    "print(response_chatgpt.get_formatted_sources())"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "llama_index",
+   "language": "python",
+   "name": "llama_index"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "87ec1eea00c24d6a3e8d99aeed087f5b444094e8604d83efa2f111696e36cf57"
+   }
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "026cc1a42e154f1f92b5236869311929": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "FloatProgressModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "FloatProgressModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "ProgressView",
+      "bar_style": "success",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_4cc9ec6ba46647aba2d53e352f91c137",
+      "max": 665,
+      "min": 0,
+      "orientation": "horizontal",
+      "style": "IPY_MODEL_f2a1c5087d0e44909139697ed90474e8",
+      "value": 665
+     }
+    },
+    "028aa5d1f7a74d538b5c606d4a6d146f": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "119d6d7a8d524aa49170f5784ebc6b9e": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "1bdaf4dab16f48dbaeed3fb9bf268e45": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_028aa5d1f7a74d538b5c606d4a6d146f",
+      "placeholder": "​",
+      "style": "IPY_MODEL_c078fe9a056a473dab7d474cd7907154",
+      "value": "Downloading (…)lve/main/config.json: 100%"
+     }
+    },
+    "2053e6adef1b4dba89f861eaf3d916fd": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "208d404f405a42a3b06d65ad67fb7322": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_3fef46c902524717b377dee6c1dfc929",
+      "placeholder": "​",
+      "style": "IPY_MODEL_fd8b887c1f7149f2876cf8a31e534ad6",
+      "value": "Downloading (…)olve/main/vocab.json: 100%"
+     }
+    },
+    "380a0c11434241b191b17421e395be8b": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "398f1c0f56fe4f218d999df138adfdac": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "3b4c1066797b43a586611ec2d63e7ca1": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HBoxModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HBoxModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HBoxView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_c06865c1e01a441698dacf48600dd03c",
+       "IPY_MODEL_9d229e5dd56e4d539ca2c1b9f0a37812",
+       "IPY_MODEL_868aa268dd28498d902782215e53c6fa"
+      ],
+      "layout": "IPY_MODEL_46f644cf589e4a48a6fad1742f0c0575"
+     }
+    },
+    "3c37e72850c746ce9c919add5340dede": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "3f748152b9274556afad2555572aa9f4": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "3fef46c902524717b377dee6c1dfc929": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "40e148c291ad4f739998a7eac55a8af6": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "46f644cf589e4a48a6fad1742f0c0575": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "47838fa763ca40598b2622a9d1e79444": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_b102e756f9b848a98f58396fc825be84",
+      "placeholder": "​",
+      "style": "IPY_MODEL_fbd7219af1924d2ead5310eb7b35aab0",
+      "value": " 1.04M/1.04M [00:00&lt;00:00, 23.7MB/s]"
+     }
+    },
+    "4cc9ec6ba46647aba2d53e352f91c137": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "64b754f563834be0a6963349b1f2dcf2": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_a02534c347aa4865ab4ab3de3a3ee2f5",
+      "placeholder": "​",
+      "style": "IPY_MODEL_b0ccb9d9d96e4ed8bec4d540c34d337c",
+      "value": "Downloading (…)/main/tokenizer.json: 100%"
+     }
+    },
+    "7438aea716f44d85ad1c2b49a93acd83": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "7b24b46d6c3643e581ba003a9c473745": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "7b47c78391a4431aa2d3f84677f24046": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "7da29a2b6508494282acbc459eccbb96": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "FloatProgressModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "FloatProgressModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "ProgressView",
+      "bar_style": "success",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_7438aea716f44d85ad1c2b49a93acd83",
+      "max": 1042301,
+      "min": 0,
+      "orientation": "horizontal",
+      "style": "IPY_MODEL_fe39f994fa9b4d7daa232e1dcd2b0e8b",
+      "value": 1042301
+     }
+    },
+    "868aa268dd28498d902782215e53c6fa": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_3c37e72850c746ce9c919add5340dede",
+      "placeholder": "​",
+      "style": "IPY_MODEL_2053e6adef1b4dba89f861eaf3d916fd",
+      "value": " 456k/456k [00:00&lt;00:00, 11.9MB/s]"
+     }
+    },
+    "9d229e5dd56e4d539ca2c1b9f0a37812": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "FloatProgressModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "FloatProgressModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "ProgressView",
+      "bar_style": "success",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_398f1c0f56fe4f218d999df138adfdac",
+      "max": 456318,
+      "min": 0,
+      "orientation": "horizontal",
+      "style": "IPY_MODEL_f1839e86863948f68314f81ba6bca4c9",
+      "value": 456318
+     }
+    },
+    "a02534c347aa4865ab4ab3de3a3ee2f5": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "a2edbc4195d843e0acfba83726a08e78": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_7b24b46d6c3643e581ba003a9c473745",
+      "placeholder": "​",
+      "style": "IPY_MODEL_3f748152b9274556afad2555572aa9f4",
+      "value": " 665/665 [00:00&lt;00:00, 22.7kB/s]"
+     }
+    },
+    "adb40ef11f094594b14776e238955224": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "b0ccb9d9d96e4ed8bec4d540c34d337c": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "b102e756f9b848a98f58396fc825be84": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "b458d6fa793d4fa080b9f1e5013af3de": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "b53e8481f6d64018988dc03081bf2765": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "ProgressStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "ProgressStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "bar_color": null,
+      "description_width": ""
+     }
+    },
+    "b5566e3db2914ddebd80d7bde75b2559": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HBoxModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HBoxModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HBoxView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_208d404f405a42a3b06d65ad67fb7322",
+       "IPY_MODEL_7da29a2b6508494282acbc459eccbb96",
+       "IPY_MODEL_47838fa763ca40598b2622a9d1e79444"
+      ],
+      "layout": "IPY_MODEL_ff32a3f12e814740a1cd5dd12bd731d4"
+     }
+    },
+    "c06865c1e01a441698dacf48600dd03c": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_adb40ef11f094594b14776e238955224",
+      "placeholder": "​",
+      "style": "IPY_MODEL_7b47c78391a4431aa2d3f84677f24046",
+      "value": "Downloading (…)olve/main/merges.txt: 100%"
+     }
+    },
+    "c078fe9a056a473dab7d474cd7907154": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "c7636a6d7380465895b8c86d34caf500": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "FloatProgressModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "FloatProgressModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "ProgressView",
+      "bar_style": "success",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_f22e9615de674e05978f332eb88750cf",
+      "max": 1355256,
+      "min": 0,
+      "orientation": "horizontal",
+      "style": "IPY_MODEL_b53e8481f6d64018988dc03081bf2765",
+      "value": 1355256
+     }
+    },
+    "d55f842766484d299c75f74e31e7aa6a": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HBoxModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HBoxModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HBoxView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_1bdaf4dab16f48dbaeed3fb9bf268e45",
+       "IPY_MODEL_026cc1a42e154f1f92b5236869311929",
+       "IPY_MODEL_a2edbc4195d843e0acfba83726a08e78"
+      ],
+      "layout": "IPY_MODEL_40e148c291ad4f739998a7eac55a8af6"
+     }
+    },
+    "eab4127882d24acfa9518ebff6f4e22a": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HBoxModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HBoxModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HBoxView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_64b754f563834be0a6963349b1f2dcf2",
+       "IPY_MODEL_c7636a6d7380465895b8c86d34caf500",
+       "IPY_MODEL_f7803dea63994cc2a31acf805bd19e67"
+      ],
+      "layout": "IPY_MODEL_380a0c11434241b191b17421e395be8b"
+     }
+    },
+    "f1839e86863948f68314f81ba6bca4c9": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "ProgressStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "ProgressStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "bar_color": null,
+      "description_width": ""
+     }
+    },
+    "f22e9615de674e05978f332eb88750cf": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "f2a1c5087d0e44909139697ed90474e8": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "ProgressStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "ProgressStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "bar_color": null,
+      "description_width": ""
+     }
+    },
+    "f7803dea63994cc2a31acf805bd19e67": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_b458d6fa793d4fa080b9f1e5013af3de",
+      "placeholder": "​",
+      "style": "IPY_MODEL_119d6d7a8d524aa49170f5784ebc6b9e",
+      "value": " 1.36M/1.36M [00:00&lt;00:00, 30.3MB/s]"
+     }
+    },
+    "fbd7219af1924d2ead5310eb7b35aab0": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "fd8b887c1f7149f2876cf8a31e534ad6": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "fe39f994fa9b4d7daa232e1dcd2b0e8b": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "ProgressStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "ProgressStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "bar_color": null,
+      "description_width": ""
+     }
+    },
+    "ff32a3f12e814740a1cd5dd12bd731d4": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    }
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/vector_indices/PineconeIndexDemo.ipynb
+++ b/examples/vector_indices/PineconeIndexDemo.ipynb
@@ -69,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "index = pinecone.Index(\"quickstart\")"
+    "pinecone_index = pinecone.Index(\"quickstart\")"
    ]
   },
   {
@@ -109,7 +109,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "index = GPTPineconeIndex(documents, pinecone_index=index)"
+    "# initialize without metadata filter\n",
+    "index = GPTPineconeIndex(documents, pinecone_index=pinecone_index)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ee6eeecb-d54f-4a71-b5fe-0cda8a5c3e10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# [optional] initialize with metadata filters\n",
+    "# can define filters specific to this vector index (so you can\n",
+    "# reuse pinecone indexes)\n",
+    "metadata_filters = {\"title\": \"paul_graham_essay\"}\n",
+    "\n",
+    "index = GPTPineconeIndex(documents, pinecone_index=pinecone_index, metadata_filters=metadata_filters)"
    ]
   },
   {
@@ -173,7 +189,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.1"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,

--- a/gpt_index/indices/query/vector_store/queries.py
+++ b/gpt_index/indices/query/vector_store/queries.py
@@ -103,14 +103,23 @@ class GPTPineconeIndexQuery(GPTVectorStoreIndexQuery):
         self,
         index_struct: IndexDict,
         pinecone_index: Optional[Any] = None,
+        metadata_filters: Optional[Dict[str, Any]] = None,
         pinecone_kwargs: Optional[Dict] = None,
+        insert_kwargs: Optional[Dict] = None,
+        query_kwargs: Optional[Dict] = None,
+        delete_kwargs: Optional[Dict] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize params."""
         if pinecone_index is None and pinecone_kwargs is None:
             raise ValueError("pinecone_index or pinecone_kwargs is required.")
         vector_store = PineconeVectorStore(
-            pinecone_index=pinecone_index, pinecone_kwargs=pinecone_kwargs
+            pinecone_index=pinecone_index,
+            metadata_filters=metadata_filters,
+            pinecone_kwargs=pinecone_kwargs,
+            insert_kwargs=insert_kwargs,
+            query_kwargs=query_kwargs,
+            delete_kwargs=delete_kwargs,
         )
         super().__init__(index_struct=index_struct, vector_store=vector_store, **kwargs)
 

--- a/gpt_index/indices/vector_store/vector_indices.py
+++ b/gpt_index/indices/vector_store/vector_indices.py
@@ -263,6 +263,7 @@ class GPTPineconeIndex(GPTVectorStoreIndex):
             embedding similarity.
         chunk_size_limit (int): Maximum number of tokens per chunk. NOTE:
             in Pinecone the default is 2048 due to metadata size restrictions.
+
     """
 
     index_struct_cls: Type[IndexDict] = PineconeIndexDict
@@ -271,7 +272,11 @@ class GPTPineconeIndex(GPTVectorStoreIndex):
         self,
         documents: Optional[Sequence[DOCUMENTS_INPUT]] = None,
         pinecone_index: Optional[Any] = None,
+        metadata_filters: Optional[Dict[str, Any]] = None,
         pinecone_kwargs: Optional[Dict] = None,
+        insert_kwargs: Optional[Dict] = None,
+        query_kwargs: Optional[Dict] = None,
+        delete_kwargs: Optional[Dict] = None,
         index_struct: Optional[IndexDict] = None,
         text_qa_template: Optional[QuestionAnswerPrompt] = None,
         llm_predictor: Optional[LLMPredictor] = None,
@@ -284,10 +289,16 @@ class GPTPineconeIndex(GPTVectorStoreIndex):
             raise ValueError("pinecone_index is required.")
         if pinecone_kwargs is None:
             pinecone_kwargs = {}
+
         vector_store = kwargs.pop(
             "vector_store",
             PineconeVectorStore(
-                pinecone_index=pinecone_index, pinecone_kwargs=pinecone_kwargs
+                pinecone_index=pinecone_index,
+                metadata_filters=metadata_filters,
+                pinecone_kwargs=pinecone_kwargs,
+                insert_kwargs=insert_kwargs,
+                query_kwargs=query_kwargs,
+                delete_kwargs=delete_kwargs,
             ),
         )
 
@@ -316,7 +327,11 @@ class GPTPineconeIndex(GPTVectorStoreIndex):
         del query_kwargs["vector_store"]
         vector_store = cast(PineconeVectorStore, self._vector_store)
         query_kwargs["pinecone_index"] = vector_store._pinecone_index
+        query_kwargs["metadata_filters"] = vector_store._metadata_filters
         query_kwargs["pinecone_kwargs"] = vector_store._pinecone_kwargs
+        query_kwargs["insert_kwargs"] = vector_store._insert_kwargs
+        query_kwargs["query_kwargs"] = vector_store._query_kwargs
+        query_kwargs["delete_kwargs"] = vector_store._delete_kwargs
 
 
 class GPTWeaviateIndex(GPTVectorStoreIndex):


### PR DESCRIPTION
allows users to define multiple vector indexes using the same underlying pinecone index, by specifying a metadata_filter for each vector index 