### PR TITLE
default prompt optimize for gpt-3.5-turbo

### DIFF
--- a/gpt_index/prompts/default_prompts.py
+++ b/gpt_index/prompts/default_prompts.py
@@ -97,7 +97,7 @@ DEFAULT_REFINE_PROMPT_TMPL = (
     "------------\n"
     "Given the new context, refine the original answer to better "
     "answer the question. "
-    "If the context isn't useful, return the original answer."
+    "If the context isn't useful or the original answer is good enough, return the original answer and do not add any text to it."
 )
 DEFAULT_REFINE_PROMPT = RefinePrompt(DEFAULT_REFINE_PROMPT_TMPL)
 


### PR DESCRIPTION
related thread in discord:
<img width="600" alt="企业微信截图_8266a52b-d8c9-472b-93f7-acaaaeceeaa2(1)" src="https://user-images.githubusercontent.com/5595819/227472820-5969a6de-6a8e-409a-8fec-894708fcb781.png">


-------------

I read the contrib.md and ran the tests. But I found that I can't  reproduce this question in the tests without api key. So I just commit the change of the prompt.

If I should do any further work, please tell me.

------------
And I think. If different LLM needs different prompts, different nature language also needs different prompts. Maybe we should build a hub to store all these prompts? Just like the readers.