### PR TITLE
Update faiss.py

### DIFF
--- a/gpt_index/vector_stores/faiss.py
+++ b/gpt_index/vector_stores/faiss.py
@@ -135,7 +135,7 @@ class FaissVectorStore(VectorStore):
         """
         query_embedding_np = np.array(query_embedding, dtype="float32")[np.newaxis, :]
         dists, indices = self._faiss_index.search(query_embedding_np, similarity_top_k)
-        dists = [d[0] for d in dists]
+        dists = [d for d in dists[0]]
         # if empty, then return an empty response
         if len(indices) == 0:
             return VectorStoreQueryResult(similarities=[], ids=[])


### PR DESCRIPTION
In the previous implementation, only the top result's similarity score was being provided, and the rest was set to "None". This is fixed.