### PR TITLE
make chroma db insert operation compatible with older versions of python

### DIFF
--- a/gpt_index/vector_stores/chroma.py
+++ b/gpt_index/vector_stores/chroma.py
@@ -65,7 +65,7 @@ class ChromaVectorStore(VectorStore):
         for result in embedding_results:
             embeddings.append(result.embedding)
             extra_info = result.node.extra_info or {}
-            metadatas.append(extra_info | {"document_id": result.doc_id})
+            metadatas.append({**extra_info, **{"document_id": result.doc_id}})
             ids.append(result.id)
             documents.append(result.node.get_text())
 


### PR DESCRIPTION
python<3.9 doesn't support | as dict union operation 

Closes #836 