### PR TITLE
add _aquery for StructStoreIndexQuery and fix get_query_map

### DIFF
--- a/gpt_index/indices/query/struct_store/sql.py
+++ b/gpt_index/indices/query/struct_store/sql.py
@@ -51,6 +51,10 @@ class GPTSQLStructStoreIndexQuery(BaseGPTIndexQuery[SQLStructTable]):
         response = Response(response=response_str, extra_info=extra_info)
         return response
 
+    @llm_token_counter("query")
+    async def aquery(self, query_bundle: QueryBundle) -> Response:
+        return self.query(query_bundle)
+
 
 class GPTNLStructStoreIndexQuery(BaseGPTIndexQuery[SQLStructTable]):
     """GPT natural language query over a structured database.
@@ -138,6 +142,7 @@ class GPTNLStructStoreIndexQuery(BaseGPTIndexQuery[SQLStructTable]):
         extra_info["sql_query"] = sql_query_str
         response = Response(response=response_str, extra_info=extra_info)
         return response
+
     async def _aquery(self, query_bundle: QueryBundle) -> Response:
         """Answer a query."""
         table_desc_str = self._get_table_context(query_bundle)

--- a/gpt_index/indices/struct_store/sql.py
+++ b/gpt_index/indices/struct_store/sql.py
@@ -128,7 +128,7 @@ class GPTSQLStructStoreIndex(BaseGPTStructStoreIndex[SQLStructTable]):
         data_extractor.insert_datapoint_from_document(document)
 
     @classmethod
-    def get_query_map(self) -> Dict[str, Type[BaseGPTIndexQuery]]:
+    def get_query_map(cls) -> Dict[str, Type[BaseGPTIndexQuery]]:
         """Get query map."""
         return {
             QueryMode.DEFAULT: GPTNLStructStoreIndexQuery,


### PR DESCRIPTION
- Add _aquery method for GPTNLStructStoreIndexQuery and GPTSQLStructStoreIndexQuery
- Change self to cls in the get_query_map method of GPTSQLStructStoreIndex
- Add tests