### PR TITLE
fix: add date filtering when paginating through channel

### DIFF
--- a/gpt_index/readers/slack.py
+++ b/gpt_index/readers/slack.py
@@ -124,11 +124,15 @@ class SlackReader(BaseReader):
                 result = self.client.conversations_history(
                     channel=channel_id,
                     cursor=next_cursor,
+                    oldest=str(self.earliest_date_timestamp),
+                    latest=str(self.latest_date_timestamp),
                 )
                 conversation_history = result["messages"]
                 # Print results
                 logger.info(
-                    "{} messages found in {}".format(len(conversation_history), id)
+                    "{} messages found in {}".format(
+                        len(conversation_history), channel_id
+                    )
                 )
                 result_messages.extend(
                     self._read_message(channel_id, message["ts"])


### PR DESCRIPTION
Hi,

For big Slack channel we filter on dates when reading messages but not when paginating the slack channel which makes a lof of redundant calls to slack api.

Thanks