### PR TITLE
[0.5.0] add service context arg to graphs + revert use_async=True

### DIFF
--- a/gpt_index/indices/composability/graph.py
+++ b/gpt_index/indices/composability/graph.py
@@ -62,11 +62,13 @@ class ComposableGraph:
         query_str: Union[str, QueryBundle],
         query_configs: Optional[List[QUERY_CONFIG_TYPE]] = None,
         query_transform: Optional[BaseQueryTransform] = None,
+        service_context: Optional[ServiceContext] = None,
     ) -> RESPONSE_TYPE:
         """Query the index."""
+        service_context = service_context or self._service_context
         query_runner = QueryRunner(
             index_struct=self._index_struct,
-            service_context=self._service_context,
+            service_context=service_context,
             docstore=self._docstore,
             query_configs=query_configs,
             query_transform=query_transform,
@@ -79,11 +81,13 @@ class ComposableGraph:
         query_str: Union[str, QueryBundle],
         query_configs: Optional[List[QUERY_CONFIG_TYPE]] = None,
         query_transform: Optional[BaseQueryTransform] = None,
+        service_context: Optional[ServiceContext] = None,
     ) -> RESPONSE_TYPE:
         """Query the index."""
+        service_context = service_context or self._service_context
         query_runner = QueryRunner(
             index_struct=self._index_struct,
-            service_context=self._service_context,
+            service_context=service_context,
             docstore=self._docstore,
             query_configs=query_configs,
             query_transform=query_transform,

--- a/gpt_index/indices/query/base.py
+++ b/gpt_index/indices/query/base.py
@@ -117,7 +117,7 @@ class BaseGPTIndexQuery(Generic[IS], ABC):
         response_kwargs: Optional[Dict] = None,
         # TODO: deprecated
         similarity_cutoff: Optional[float] = None,
-        use_async: bool = True,
+        use_async: bool = False,
         streaming: bool = False,
         doc_ids: Optional[List[str]] = None,
         optimizer: Optional[BaseTokenUsageOptimizer] = None,


### PR DESCRIPTION
before, the user could pass the llm_predictor as an arg through the graph.

The graph can be initialized with a service context, but users may still want to specify a separate service context during query-time. This is a convenience arg that would allow us to not modify existing notebooks too much.

Also reverted use_async back to False by default 