### PR TITLE
Batched Upserts to Pinecone

### DIFF
--- a/gpt_index/vector_stores/utils.py
+++ b/gpt_index/vector_stores/utils.py
@@ -1,0 +1,12 @@
+import itertools
+from typing import Iterable, List
+
+
+def chunk_iterable(iterable: Iterable, batch_size: int) -> List[tuple]:
+    """A helper function to break an iterable into chunks of size batch_size."""
+    it = iter(iterable)
+    chunks = []
+    chunk = tuple(itertools.islice(it, batch_size))
+    for chunk in iter(lambda: tuple(itertools.islice(it, batch_size)), ()):
+        chunks.append(chunk)
+    return chunks


### PR DESCRIPTION
Pinecone upserts are currently done via an upsert call for each embedding result. This is slower than batching upserts (which is recommended in: https://docs.pinecone.io/docs/insert-data).

As an example, for a set of 850 documents I have, batching upserts takes 6 seconds (whereas the current one-by-one upserting takes 50 seconds), so batching is much faster.

This change should lead to faster index construction/updating/adding for GPTPineconeIndex.