### PR TITLE
pin langchain version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 install_requires = [
     "dataclasses_json",
-    "langchain",
+    "langchain==0.0.127",
     "numpy",
     "tenacity>=8.2.0,<9.0.0",
     "openai>=0.26.4",


### PR DESCRIPTION
Currently LLaMa index does not work for older langchain versions (it didn't work for 0.0.113 for me).

It might be a good idea to pin langchain version.

Of course exact version is not the best approach, but it is advisable to at least provide a minimal version.

Currently I've pinned to the most current langchain version, it works from what I've checked