### PR TITLE
Move `RESPONSE_TEXT_TYPE` to top-level types 

### DIFF
--- a/gpt_index/indices/query/base.py
+++ b/gpt_index/indices/query/base.py
@@ -26,7 +26,6 @@ from gpt_index.indices.postprocessor.node import (
 from gpt_index.indices.query.embedding_utils import SimilarityTracker
 from gpt_index.indices.query.schema import QueryBundle
 from gpt_index.indices.response.builder import (
-    RESPONSE_TEXT_TYPE,
     ResponseBuilder,
     ResponseMode,
     TextChunk,
@@ -42,6 +41,7 @@ from gpt_index.response.schema import (
     StreamingResponse,
 )
 from gpt_index.token_counter.token_counter import llm_token_counter
+from gpt_index.types import RESPONSE_TEXT_TYPE
 from gpt_index.utils import truncate_text
 
 # to prevent us from having to remove all instances of v2 later

--- a/gpt_index/indices/response/builder.py
+++ b/gpt_index/indices/response/builder.py
@@ -10,7 +10,7 @@ Will support different modes, from 1) stuffing chunks into prompt,
 import logging
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, Generator, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, Generator, List, Optional, Tuple, cast
 
 from gpt_index.data_structs.data_structs_v2 import IndexGraph
 from gpt_index.data_structs.node_v2 import Node, NodeWithScore
@@ -21,9 +21,8 @@ from gpt_index.indices.utils import get_sorted_node_list, truncate_text
 from gpt_index.logger.base import LlamaLogger
 from gpt_index.prompts.prompts import QuestionAnswerPrompt, RefinePrompt, SummaryPrompt
 from gpt_index.response.utils import get_response_text
+from gpt_index.types import RESPONSE_TEXT_TYPE
 from gpt_index.utils import temp_set_attrs
-
-RESPONSE_TEXT_TYPE = Union[str, Generator]
 
 logger = logging.getLogger(__name__)
 

--- a/gpt_index/types.py
+++ b/gpt_index/types.py
@@ -1,0 +1,4 @@
+from typing import Generator, Union
+
+
+RESPONSE_TEXT_TYPE = Union[str, Generator]


### PR DESCRIPTION
An attempt to fix circular dependency issue (still cannot repro)