### PR TITLE
change allow_update=True behavior, rename docstore, expose docstore in docs

### DIFF
--- a/docs/guides/primer/usage_pattern.md
+++ b/docs/guides/primer/usage_pattern.md
@@ -87,8 +87,29 @@ index = GPTSimpleVectorIndex(nodes)
 
 ```
 
-
 Depending on which index you use, LlamaIndex may make LLM calls in order to build the index.
+
+### Reusing Nodes across Index Structures
+
+If you have multiple Node objects defined, and wish to share these Node
+objects across multiple index structures, you can do that. Simply 
+define a DocumentStore object, add the Node objects to the DocumentStore,
+and pass the DocumentStore around.
+
+```python
+from gpt_index.docstore import DocumentStore
+
+docstore = DocumentStore()
+docstore.add_documents(nodes)
+
+index1 = GPTSimpleVectorIndex(nodes, docstore=docstore)
+index2 = GPTListIndex(nodes, docstore=docstore)
+```
+
+**NOTE**: If the `docstore` argument isn't specified, then it is implicitly
+created for each index during index construction. You can access the docstore
+associated with a given index through `index.docstore`.
+
 
 ### Inserting Documents
 
@@ -141,7 +162,7 @@ index = GPTSimpleVectorIndex.from_documents(
 See the [Custom LLM's How-To](/how_to/customization/custom_llms.md) for more details.
 
 
-#### Customizing Prompts
+### Customizing Prompts
 
 Depending on the index used, we used default prompt templates for constructing the index (and also insertion/querying).
 See [Custom Prompts How-To](/how_to/customization/custom_prompts.md) for more details on how to customize your prompt.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -98,6 +98,7 @@ That's where the **LlamaIndex** comes in. LlamaIndex is a simple, flexible inter
    reference/indices.rst
    reference/query.rst
    reference/node.rst
+   reference/docstore.rst
    reference/composability.rst
    reference/readers.rst
    reference/prompts.rst

--- a/docs/reference/docstore.rst
+++ b/docs/reference/docstore.rst
@@ -1,0 +1,8 @@
+.. _Ref-Docstore:
+
+Docstore
+=================
+
+.. automodule:: gpt_index.docstore
+   :members:
+   :inherited-members:

--- a/examples/docstore/DocstoreDemo.ipynb
+++ b/examples/docstore/DocstoreDemo.ipynb
@@ -41,8 +41,6 @@
     "# from gpt_index.composability.joint_qa_summary import QASummaryGraphBuilder\n",
     "from gpt_index import SimpleDirectoryReader, ServiceContext, LLMPredictor\n",
     "from gpt_index import GPTSimpleVectorIndex, GPTListIndex, GPTSimpleKeywordTableIndex\n",
-    "from gpt_index.node_parser import SimpleNodeParser\n",
-    "from gpt_index.docstore import DocumentStore\n",
     "from gpt_index.composability import ComposableGraph\n",
     "from langchain.chat_models import ChatOpenAI"
    ]
@@ -85,6 +83,7 @@
    },
    "outputs": [],
    "source": [
+    "from gpt_index.node_parser import SimpleNodeParser\n",
     "nodes = SimpleNodeParser().get_nodes_from_documents(documents)"
    ]
   },
@@ -105,6 +104,7 @@
    },
    "outputs": [],
    "source": [
+    "from gpt_index.docstore import DocumentStore\n",
     "docstore = DocumentStore()\n",
     "docstore.add_documents(nodes)"
    ]
@@ -121,78 +121,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "316fb6ac-2031-4d17-9999-ffdb827f46d1",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
-      "> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
-      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total embedding token usage: 0 tokens\n",
-      "> [build_index_from_nodes] Total embedding token usage: 0 tokens\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "list_index = GPTListIndex(nodes, docstore=docstore)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "9440f405-fa75-4788-bc7c-11d021a0a17b",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
-      "> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
-      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total embedding token usage: 17617 tokens\n",
-      "> [build_index_from_nodes] Total embedding token usage: 17617 tokens\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "vector_index = GPTSimpleVectorIndex(nodes, docstore=docstore) "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "364ef89f-4ba2-4b1a-b5e5-619e0e8420ef",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
-      "> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
-      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total embedding token usage: 0 tokens\n",
-      "> [build_index_from_nodes] Total embedding token usage: 0 tokens\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[nltk_data] Downloading package stopwords to\n",
-      "[nltk_data]     /Users/jerryliu/nltk_data...\n",
-      "[nltk_data]   Package stopwords is already up-to-date!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "keyword_table_index = GPTSimpleKeywordTableIndex(nodes, docstore=docstore) "
    ]

--- a/examples/docstore/DocstoreDemo.ipynb
+++ b/examples/docstore/DocstoreDemo.ipynb
@@ -1,0 +1,338 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a54d1c43-4b7f-4917-939f-a964f6f3dafc",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import nest_asyncio\n",
+    "nest_asyncio.apply()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "fa67fa07-1395-4aab-a356-72bdb302f6b2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "import sys\n",
+    "\n",
+    "logging.basicConfig(stream=sys.stdout, level=logging.INFO)\n",
+    "logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "1d12d766-3ca8-4012-9da2-248be80bb6ab",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# from gpt_index.composability.joint_qa_summary import QASummaryGraphBuilder\n",
+    "from gpt_index import SimpleDirectoryReader, ServiceContext, LLMPredictor\n",
+    "from gpt_index import GPTSimpleVectorIndex, GPTListIndex, GPTSimpleKeywordTableIndex\n",
+    "from gpt_index.node_parser import SimpleNodeParser\n",
+    "from gpt_index.docstore import DocumentStore\n",
+    "from gpt_index.composability import ComposableGraph\n",
+    "from langchain.chat_models import ChatOpenAI"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6dd9d5f-a601-4097-894e-fe98a0c35a5b",
+   "metadata": {},
+   "source": [
+    "#### Load Documents"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "e7cdaf9d-cfbd-4ced-8d4e-6eef8508224d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "reader = SimpleDirectoryReader('../paul_graham_essay/data')\n",
+    "documents = reader.load_data()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bae82b55-5c9f-432a-9e06-1fccb6f9fc7f",
+   "metadata": {},
+   "source": [
+    "#### Parse into Nodes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "f97e558a-c29f-44ec-ab33-1f481da1a6ef",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "nodes = SimpleNodeParser().get_nodes_from_documents(documents)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aff4c8e1-b2ba-4ea6-a8df-978c2788fedc",
+   "metadata": {},
+   "source": [
+    "#### Add to Docstore"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "1ba8b0da-67a8-4653-8cdb-09e39583a2d8",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "docstore = DocumentStore()\n",
+    "docstore.add_documents(nodes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "528149c1-5bde-4eba-b75a-e8fa1da17d7c",
+   "metadata": {},
+   "source": [
+    "#### Define Multiple Indexes\n",
+    "\n",
+    "Each index uses the same underlying Node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "316fb6ac-2031-4d17-9999-ffdb827f46d1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
+      "> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
+      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total embedding token usage: 0 tokens\n",
+      "> [build_index_from_nodes] Total embedding token usage: 0 tokens\n"
+     ]
+    }
+   ],
+   "source": [
+    "list_index = GPTListIndex(nodes, docstore=docstore)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "9440f405-fa75-4788-bc7c-11d021a0a17b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
+      "> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
+      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total embedding token usage: 17617 tokens\n",
+      "> [build_index_from_nodes] Total embedding token usage: 17617 tokens\n"
+     ]
+    }
+   ],
+   "source": [
+    "vector_index = GPTSimpleVectorIndex(nodes, docstore=docstore) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "364ef89f-4ba2-4b1a-b5e5-619e0e8420ef",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
+      "> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
+      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total embedding token usage: 0 tokens\n",
+      "> [build_index_from_nodes] Total embedding token usage: 0 tokens\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[nltk_data] Downloading package stopwords to\n",
+      "[nltk_data]     /Users/jerryliu/nltk_data...\n",
+      "[nltk_data]   Package stopwords is already up-to-date!\n"
+     ]
+    }
+   ],
+   "source": [
+    "keyword_table_index = GPTSimpleKeywordTableIndex(nodes, docstore=docstore) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "5c6b2141-fc77-4dec-891b-d4dad0633b35",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "6"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# NOTE: the docstore sitll has the same nodes\n",
+    "len(docstore.docs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d3bf6aaf-3375-4212-8323-777969a918f7",
+   "metadata": {},
+   "source": [
+    "#### Test out some Queries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "9bba68f3-2743-437e-93b6-ce9ba92e40c3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:gpt_index.llm_predictor.base:Unknown max input size for gpt-3.5-turbo, using defaults.\n",
+      "Unknown max input size for gpt-3.5-turbo, using defaults.\n"
+     ]
+    }
+   ],
+   "source": [
+    "llm_predictor_chatgpt = LLMPredictor(llm=ChatOpenAI(temperature=0, model_name=\"gpt-3.5-turbo\"))\n",
+    "service_context_chatgpt = ServiceContext.from_defaults(llm_predictor=llm_predictor_chatgpt, chunk_size_limit=1024)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "544c0565-72a0-434b-98e5-83138ebdaa2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = list_index.query(\"What is a summary of this document?\") "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "036077b7-108e-4026-9628-44c694343460",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = vector_index.query(\"What did the author do growing up?\") "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ecd7719c-f663-4edb-a239-d2a8f0a5c091",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = keyword_table_index.query(\"What did the author do after his time at YC?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "37524641-2632-4a76-8ae6-00f1285256d9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "After his time at YC, the author decided to take a break and focus on painting. He spent most of 2014 painting and then, in November, he ran out of steam and stopped. He then moved to Florence, Italy to attend the Accademia di Belle Arti di Firenze, where he studied painting and drawing. He also started painting still lives in his bedroom at night. In March 2015, he started working on Lisp again and wrote a new Lisp, called Bel, in itself in Arc. He wrote essays through 2020, but also started to think about other things he could work on. He wrote an essay for himself to answer the question of how he should choose what to do next and then wrote a more detailed version for others to read. He also created the Y Combinator logo, which was an inside joke referencing the Viaweb logo, a white V on a red circle, so he made the YC logo a white Y on an orange square. He also created a fund for YC for a couple of years, but after Heroku got bought, he had enough money to go back to being self-funded. He also disliked the term \"deal flow\" because it implies that the number of new startups at any given time\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ff58018c-3117-4d50-abff-16a1873eda9c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "llama_index",
+   "language": "python",
+   "name": "llama_index"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gpt_index/indices/base.py
+++ b/gpt_index/indices/base.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Generic, List, Optional, Sequence, Type, TypeVar, 
 from gpt_index.constants import DOCSTORE_KEY, INDEX_STRUCT_KEY
 from gpt_index.data_structs.data_structs_v2 import V2IndexStruct
 from gpt_index.data_structs.node_v2 import Node
-from gpt_index.docstore_v2 import DocumentStore
+from gpt_index.docstore import DocumentStore
 from gpt_index.indices.query.base import BaseGPTIndexQuery
 from gpt_index.indices.query.query_runner import QueryRunner
 from gpt_index.indices.query.query_transform.base import BaseQueryTransform
@@ -125,7 +125,7 @@ class BaseGPTIndex(Generic[IS], ABC):
     @llm_token_counter("build_index_from_nodes")
     def build_index_from_nodes(self, nodes: Sequence[Node]) -> IS:
         """Build the index from nodes."""
-        self._docstore.add_documents(nodes)
+        self._docstore.add_documents(nodes, allow_update=True)
         return self._build_index_from_nodes(nodes)
 
     @abstractmethod
@@ -135,7 +135,7 @@ class BaseGPTIndex(Generic[IS], ABC):
     @llm_token_counter("insert")
     def insert_nodes(self, nodes: Sequence[Node], **insert_kwargs: Any) -> None:
         """Insert nodes."""
-        self.docstore.add_documents(nodes)
+        self.docstore.add_documents(nodes, allow_update=True)
         self._insert(nodes, **insert_kwargs)
 
     def insert(self, document: Document, **insert_kwargs: Any) -> None:

--- a/gpt_index/indices/common_tree/base.py
+++ b/gpt_index/indices/common_tree/base.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional, Sequence, Tuple
 from gpt_index.async_utils import run_async_tasks
 from gpt_index.data_structs.data_structs_v2 import IndexGraph
 from gpt_index.data_structs.node_v2 import Node
-from gpt_index.docstore_v2 import DocumentStore
+from gpt_index.docstore import DocumentStore
 from gpt_index.indices.service_context import ServiceContext
 from gpt_index.indices.utils import get_sorted_node_list, truncate_text
 from gpt_index.prompts.prompts import SummaryPrompt
@@ -117,7 +117,7 @@ class GPTTreeIndexBuilder:
             index_graph.insert(new_node, children_nodes=cur_nodes_chunk)
             index = index_graph.get_index(new_node)
             new_node_dict[index] = new_node.get_doc_id()
-            self._docstore.add_documents([new_node])
+            self._docstore.add_documents([new_node], allow_update=False)
         return new_node_dict
 
     def build_index_from_nodes(

--- a/gpt_index/indices/composability/graph.py
+++ b/gpt_index/indices/composability/graph.py
@@ -8,7 +8,7 @@ from gpt_index.data_structs.data_structs_v2 import CompositeIndex
 from gpt_index.data_structs.data_structs_v2 import V2IndexStruct
 from gpt_index.data_structs.data_structs_v2 import V2IndexStruct as IndexStruct
 from gpt_index.data_structs.node_v2 import IndexNode, DocumentRelationship
-from gpt_index.docstore_v2 import DocumentStore
+from gpt_index.docstore import DocumentStore
 from gpt_index.indices.base import BaseGPTIndex
 from gpt_index.indices.query.query_runner import QueryRunner
 from gpt_index.indices.query.query_transform.base import BaseQueryTransform

--- a/gpt_index/indices/knowledge_graph/base.py
+++ b/gpt_index/indices/knowledge_graph/base.py
@@ -167,7 +167,7 @@ class GPTKnowledgeGraphIndex(BaseGPTIndex[KG]):
 
         """
         self._index_struct.add_node(keywords, node)
-        self._docstore.add_documents([node])
+        self._docstore.add_documents([node], allow_update=True)
 
     def upsert_triplet_and_node(
         self, triplet: Tuple[str, str, str], node: Node

--- a/gpt_index/indices/query/base.py
+++ b/gpt_index/indices/query/base.py
@@ -17,7 +17,7 @@ from langchain.input import print_text
 
 from gpt_index.data_structs.data_structs_v2 import V2IndexStruct
 from gpt_index.data_structs.node_v2 import Node, NodeWithScore
-from gpt_index.docstore_v2 import DocumentStore
+from gpt_index.docstore import DocumentStore
 from gpt_index.indices.postprocessor.node import (
     BaseNodePostprocessor,
     KeywordNodePostprocessor,

--- a/gpt_index/indices/query/query_runner.py
+++ b/gpt_index/indices/query/query_runner.py
@@ -10,7 +10,7 @@ from gpt_index.data_structs.data_structs_v2 import V2IndexStruct
 from gpt_index.data_structs.data_structs_v2 import V2IndexStruct as IndexStruct
 from gpt_index.data_structs.node_v2 import IndexNode, Node, NodeWithScore
 from gpt_index.data_structs.struct_type import IndexStructType
-from gpt_index.docstore_v2 import DocumentStore
+from gpt_index.docstore import DocumentStore
 from gpt_index.indices.query.base import BaseGPTIndexQuery
 from gpt_index.indices.query.query_combiner.base import (
     BaseQueryCombiner,

--- a/gpt_index/indices/response/builder.py
+++ b/gpt_index/indices/response/builder.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, Generator, List, Optional, Tuple, cast
 
 from gpt_index.data_structs.data_structs_v2 import IndexGraph
 from gpt_index.data_structs.node_v2 import Node, NodeWithScore
-from gpt_index.docstore_v2 import DocumentStore
+from gpt_index.docstore import DocumentStore
 from gpt_index.indices.common_tree.base import GPTTreeIndexBuilder
 from gpt_index.indices.service_context import ServiceContext
 from gpt_index.indices.utils import get_sorted_node_list, truncate_text
@@ -278,7 +278,7 @@ class ResponseBuilder:
         nodes = [Node(text=t) for t in text_chunks]
 
         docstore = DocumentStore()
-        docstore.add_documents(nodes)
+        docstore.add_documents(nodes, allow_update=False)
         index_builder = GPTTreeIndexBuilder(
             num_children,
             summary_template,

--- a/gpt_index/indices/tree/inserter.py
+++ b/gpt_index/indices/tree/inserter.py
@@ -4,7 +4,7 @@ from typing import Optional, Sequence
 
 from gpt_index.data_structs.data_structs_v2 import IndexGraph
 from gpt_index.data_structs.node_v2 import Node
-from gpt_index.docstore_v2 import DocumentStore
+from gpt_index.docstore import DocumentStore
 from gpt_index.indices.service_context import ServiceContext
 from gpt_index.indices.utils import extract_numbers_given_response, get_sorted_node_list
 from gpt_index.prompts.base import Prompt
@@ -95,11 +95,11 @@ class GPTTreeIndexInserter:
             self.index_graph.insert_under_parent(
                 node1, parent_node, new_index=self.index_graph.get_index(node1)
             )
-            self._docstore.add_documents([node1])
+            self._docstore.add_documents([node1], allow_update=False)
             self.index_graph.insert_under_parent(
                 node2, parent_node, new_index=self.index_graph.get_index(node2)
             )
-            self._docstore.add_documents([node2])
+            self._docstore.add_documents([node2], allow_update=False)
 
     def _insert_node(self, node: Node, parent_node: Optional[Node] = None) -> None:
         """Insert node."""

--- a/gpt_index/indices/vector_store/base.py
+++ b/gpt_index/indices/vector_store/base.py
@@ -171,7 +171,7 @@ class GPTVectorStoreIndex(BaseGPTIndex[IndexDict]):
         if not self._vector_store.stores_text:
             for result, new_id in zip(embedding_results, new_ids):
                 index_struct.add_node(result.node, text_id=new_id)
-                self._docstore.add_documents([result.node])
+                self._docstore.add_documents([result.node], allow_update=True)
 
     def _add_nodes_to_index(
         self,
@@ -191,7 +191,7 @@ class GPTVectorStoreIndex(BaseGPTIndex[IndexDict]):
         if not self._vector_store.stores_text:
             for result, new_id in zip(embedding_results, new_ids):
                 index_struct.add_node(result.node, text_id=new_id)
-                self._docstore.add_documents([result.node])
+                self._docstore.add_documents([result.node], allow_update=True)
 
     def _build_index_from_nodes(self, nodes: Sequence[Node]) -> IndexDict:
         """Build index from nodes."""

--- a/gpt_index/old_docstore.py
+++ b/gpt_index/old_docstore.py
@@ -46,7 +46,7 @@ class V1DocumentStore(DataClassJsonMixin):
         cls,
         docs_dict: Dict[str, Any],
         type_to_struct: Optional[Dict[str, Type[IndexStruct]]] = None,
-    ) -> "DocumentStore":
+    ) -> "V1DocumentStore":
         """Load from dict."""
         docs_obj_dict = {}
         for doc_id, doc_dict in docs_dict["docs"].items():
@@ -73,13 +73,13 @@ class V1DocumentStore(DataClassJsonMixin):
         )
 
     @classmethod
-    def from_documents(cls, docs: List[DOC_TYPE]) -> "DocumentStore":
+    def from_documents(cls, docs: List[DOC_TYPE]) -> "V1DocumentStore":
         """Create from documents."""
         obj = cls()
         obj.add_documents(docs)
         return obj
 
-    def update_docstore(self, other: "DocumentStore") -> None:
+    def update_docstore(self, other: "V1DocumentStore") -> None:
         """Update docstore."""
         self.docs.update(other.docs)
 

--- a/gpt_index/old_docstore.py
+++ b/gpt_index/old_docstore.py
@@ -2,21 +2,24 @@
 
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Type, Union
 
 from dataclasses_json import DataClassJsonMixin
 
-from gpt_index.constants import TYPE_KEY
-from gpt_index.data_structs.node_v2 import ImageNode, IndexNode, Node
+from gpt_index.data_structs.data_structs import IndexStruct
 from gpt_index.readers.schema.base import Document
-from gpt_index.schema import BaseDocument
+
+DOC_TYPE = Union[IndexStruct, Document]
+
+# type key: used to store type of document
+TYPE_KEY = "__type__"
 
 
 @dataclass
-class DocumentStore(DataClassJsonMixin):
+class V1DocumentStore(DataClassJsonMixin):
     """Document store."""
 
-    docs: Dict[str, BaseDocument] = field(default_factory=dict)
+    docs: Dict[str, DOC_TYPE] = field(default_factory=dict)
     ref_doc_info: Dict[str, Dict[str, Any]] = field(
         default_factory=lambda: defaultdict(dict)
     )
@@ -30,27 +33,39 @@ class DocumentStore(DataClassJsonMixin):
             docs_dict[doc_id] = doc_dict
         return {"docs": docs_dict, "ref_doc_info": self.ref_doc_info}
 
+    def contains_index_struct(self, exclude_ids: Optional[List[str]] = None) -> bool:
+        """Check if contains index struct."""
+        exclude_ids = exclude_ids or []
+        for doc in self.docs.values():
+            if isinstance(doc, IndexStruct) and doc.get_doc_id() not in exclude_ids:
+                return True
+        return False
+
     @classmethod
     def load_from_dict(
         cls,
         docs_dict: Dict[str, Any],
+        type_to_struct: Optional[Dict[str, Type[IndexStruct]]] = None,
     ) -> "DocumentStore":
         """Load from dict."""
         docs_obj_dict = {}
         for doc_id, doc_dict in docs_dict["docs"].items():
             doc_type = doc_dict.pop(TYPE_KEY, None)
-            doc: BaseDocument
             if doc_type == "Document" or doc_type is None:
-                doc = Document.from_dict(doc_dict)
-            elif doc_type == Node.get_type():
-                doc = Node.from_dict(doc_dict)
-            elif doc_type == ImageNode.get_type():
-                doc = ImageNode.from_dict(doc_dict)
-            elif doc_type == IndexNode.get_type():
-                doc = IndexNode.from_dict(doc_dict)
+                doc: DOC_TYPE = Document.from_dict(doc_dict)
             else:
-                raise ValueError(f"Unknown doc type: {doc_type}")
-
+                if type_to_struct is None:
+                    raise ValueError(
+                        "type_to_struct must be provided if type is index struct."
+                    )
+                # try using IndexStructType to retrieve documents
+                if doc_type not in type_to_struct:
+                    raise ValueError(
+                        f"doc_type {doc_type} not found in type_to_struct. "
+                        "Make sure that it was registered in the index registry."
+                    )
+                doc = type_to_struct[doc_type].from_dict(doc_dict)
+                # doc = index_struct_cls.from_dict(doc_dict)
             docs_obj_dict[doc_id] = doc
         return cls(
             docs=docs_obj_dict,
@@ -58,26 +73,17 @@ class DocumentStore(DataClassJsonMixin):
         )
 
     @classmethod
-    def from_documents(cls, docs: Sequence[BaseDocument]) -> "DocumentStore":
+    def from_documents(cls, docs: List[DOC_TYPE]) -> "DocumentStore":
         """Create from documents."""
         obj = cls()
         obj.add_documents(docs)
         return obj
 
-    @classmethod
-    def merge(cls, docstores: Sequence["DocumentStore"]) -> "DocumentStore":
-        merged_docstore = cls()
-        for docstore in docstores:
-            merged_docstore.update_docstore(docstore)
-        return merged_docstore
-
     def update_docstore(self, other: "DocumentStore") -> None:
         """Update docstore."""
         self.docs.update(other.docs)
 
-    def add_documents(
-        self, docs: Sequence[BaseDocument], allow_update: bool = False
-    ) -> None:
+    def add_documents(self, docs: List[DOC_TYPE], allow_update: bool = False) -> None:
         """Add a document to the store."""
         for doc in docs:
             if doc.is_doc_id_none:
@@ -92,9 +98,7 @@ class DocumentStore(DataClassJsonMixin):
             self.docs[doc.get_doc_id()] = doc
             self.ref_doc_info[doc.get_doc_id()]["doc_hash"] = doc.get_doc_hash()
 
-    def get_document(
-        self, doc_id: str, raise_error: bool = True
-    ) -> Optional[BaseDocument]:
+    def get_document(self, doc_id: str, raise_error: bool = True) -> Optional[DOC_TYPE]:
         """Get a document from the store."""
         doc = self.docs.get(doc_id, None)
         if doc is None and raise_error:
@@ -115,7 +119,7 @@ class DocumentStore(DataClassJsonMixin):
 
     def delete_document(
         self, doc_id: str, raise_error: bool = True
-    ) -> Optional[BaseDocument]:
+    ) -> Optional[DOC_TYPE]:
         """Delete a document from the store."""
         doc = self.docs.pop(doc_id, None)
         self.ref_doc_info.pop(doc_id, None)
@@ -123,19 +127,6 @@ class DocumentStore(DataClassJsonMixin):
             raise ValueError(f"doc_id {doc_id} not found.")
         return doc
 
-    def get_nodes(self, node_ids: List[str], raise_error: bool = True) -> List[Node]:
-        """Get nodes from docstore."""
-        return [self.get_node(node_id, raise_error=raise_error) for node_id in node_ids]
-
-    def get_node(self, node_id: str, raise_error: bool = True) -> Node:
-        """Get node from docstore."""
-        doc = self.get_document(node_id, raise_error=raise_error)
-        if not isinstance(doc, Node):
-            raise ValueError(f"Document {node_id} is not a Node.")
-        return doc
-
-    def get_node_dict(self, node_id_dict: Dict[int, str]) -> Dict[int, Node]:
-        """Get node dict from docstore given a mapping of index to node ids."""
-        return {
-            index: self.get_node(node_id) for index, node_id in node_id_dict.items()
-        }
+    def __len__(self) -> int:
+        """Get length."""
+        return len(self.docs.keys())

--- a/gpt_index/tools/migrate_v1_to_v2.py
+++ b/gpt_index/tools/migrate_v1_to_v2.py
@@ -51,8 +51,8 @@ from gpt_index.data_structs.node_v2 import DocumentRelationship
 from gpt_index.data_structs.node_v2 import ImageNode as V2ImageNode
 from gpt_index.data_structs.node_v2 import Node as V2Node
 from gpt_index.data_structs.struct_type import IndexStructType
-from gpt_index.docstore import DocumentStore
-from gpt_index.docstore_v2 import DocumentStore as V2DocumentStore
+from gpt_index.old_docstore import V1DocumentStore
+from gpt_index.docstore import DocumentStore as V2DocumentStore
 from gpt_index.tools.file_utils import add_prefix_suffix_to_file_path
 
 INDEX_STRUCT_TYPE_TO_V1_INDEX_STRUCT_CLASS: Dict[IndexStructType, Type[IndexStruct]] = {
@@ -202,7 +202,7 @@ def kg_to_v2(struct: KG) -> Tuple[V2KG, List[V2Node]]:
 
 
 def convert_to_v2_index_struct_and_docstore(
-    index_struct: IndexStruct, docstore: DocumentStore
+    index_struct: IndexStruct, docstore: V1DocumentStore
 ) -> Tuple[V2IndexStruct, V2DocumentStore]:
     struct_v2: V2IndexStruct
     if isinstance(index_struct, IndexGraph):
@@ -217,15 +217,15 @@ def convert_to_v2_index_struct_and_docstore(
         raise NotImplementedError(f"Cannot migrate {type(index_struct)} yet.")
 
     docstore_v2 = V2DocumentStore()
-    docstore_v2.add_documents(nodes_v2)
+    docstore_v2.add_documents(nodes_v2, allow_update=False)
     return struct_v2, docstore_v2
 
 
 def load_v1_index_struct_in_docstore(
     file_dict: dict,
-) -> Tuple[IndexStruct, DocumentStore]:
+) -> Tuple[IndexStruct, V1DocumentStore]:
     index_struct_id = file_dict[V1_INDEX_STRUCT_ID_KEY]
-    docstore = DocumentStore.load_from_dict(
+    docstore = V1DocumentStore.load_from_dict(
         file_dict[V1_DOC_STORE_KEY],
         type_to_struct=INDEX_STRUCT_TYPE_TO_V1_INDEX_STRUCT_CLASS,  # type: ignore
     )
@@ -236,10 +236,10 @@ def load_v1_index_struct_in_docstore(
 
 def load_v1_index_struct_separate(
     file_dict: dict, index_struct_type: IndexStructType
-) -> Tuple[IndexStruct, DocumentStore]:
+) -> Tuple[IndexStruct, V1DocumentStore]:
     index_struct_cls = INDEX_STRUCT_TYPE_TO_V1_INDEX_STRUCT_CLASS[index_struct_type]
     index_struct = index_struct_cls.from_dict(file_dict[V1_INDEX_STRUCT_KEY])
-    docstore = DocumentStore.load_from_dict(
+    docstore = V1DocumentStore.load_from_dict(
         file_dict[V1_DOC_STORE_KEY],
         type_to_struct=INDEX_STRUCT_TYPE_TO_V1_INDEX_STRUCT_CLASS,  # type: ignore
     )
@@ -248,7 +248,7 @@ def load_v1_index_struct_separate(
 
 def load_v1(
     file_dict: dict, index_struct_type: Optional[IndexStructType] = None
-) -> Tuple[IndexStruct, DocumentStore]:
+) -> Tuple[IndexStruct, V1DocumentStore]:
     if V1_INDEX_STRUCT_KEY in file_dict:
         assert index_struct_type is not None, "Must specify index_struct_type to load."
         index_struct, docstore = load_v1_index_struct_separate(

--- a/tests/indices/tree/test_base.py
+++ b/tests/indices/tree/test_base.py
@@ -7,7 +7,7 @@ import pytest
 
 from gpt_index.data_structs.data_structs_v2 import IndexGraph
 from gpt_index.data_structs.node_v2 import Node
-from gpt_index.docstore_v2 import DocumentStore
+from gpt_index.docstore import DocumentStore
 from gpt_index.indices.tree.base import GPTTreeIndex
 from gpt_index.langchain_helpers.chain_wrapper import (
     LLMChain,

--- a/tests/test_docstore.py
+++ b/tests/test_docstore.py
@@ -3,7 +3,7 @@
 
 from gpt_index.constants import TYPE_KEY
 from gpt_index.data_structs.node_v2 import Node, NodeType
-from gpt_index.docstore_v2 import DocumentStore
+from gpt_index.docstore import DocumentStore
 from gpt_index.readers.schema.base import Document
 
 

--- a/tests/tools/test_migrate_v1_to_v2.py
+++ b/tests/tools/test_migrate_v1_to_v2.py
@@ -14,8 +14,8 @@ from gpt_index.data_structs.data_structs_v2 import SimpleIndexDict as V2SimpleIn
 from gpt_index.data_structs.data_structs_v2 import V2IndexStruct
 from gpt_index.data_structs.node_v2 import ImageNode as V2ImageNode
 from gpt_index.data_structs.struct_type import IndexStructType
-from gpt_index.docstore import DocumentStore
-from gpt_index.docstore_v2 import DocumentStore as V2DocumentStore
+from gpt_index.old_docstore import V1DocumentStore
+from gpt_index.docstore import DocumentStore as V2DocumentStore
 from gpt_index.tools.migrate_v1_to_v2 import (
     convert_to_v2_dict,
     convert_to_v2_index_struct_and_docstore,
@@ -191,7 +191,7 @@ def test_convert_to_v2_index_struct_and_docstore() -> None:
     )
     nodes = [node_1, node_2]
     struct_v1 = IndexList(nodes=nodes)
-    docstore_v1 = DocumentStore()
+    docstore_v1 = V1DocumentStore()
     docstore_v1.add_documents([struct_v1])
 
     struct_v2, docstore_v2 = convert_to_v2_index_struct_and_docstore(
@@ -212,7 +212,7 @@ def test_convert_to_v2_dict() -> None:
     )
     nodes = [node_1, node_2]
     struct_v1 = IndexList(nodes=nodes)
-    docstore_v1 = DocumentStore()
+    docstore_v1 = V1DocumentStore()
     docstore_v1.add_documents([struct_v1])
 
     v1_dict = {


### PR DESCRIPTION
1) Changed allow_update to True by default in `add_documents`. This allows users to add nodes to docstore, and pass same docstore to different index structures.
2) Renamed old docstore to old_docstore.py, and new docstore from docstore_v2.py --> docstore.py. The git diff is messing up detecting the renaming (it thinks we renamed docstore_v2.py to old_docstore.py).
3) Expose docstore in docs (in reference section)
4) Added example notebook 