### PR TITLE
Update QA Summary example to use llama_index instead of gpt_index

### DIFF
--- a/examples/composable_indices/QASummaryGraph.ipynb
+++ b/examples/composable_indices/QASummaryGraph.ipynb
@@ -41,15 +41,15 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/jerryliu/Programming/gpt_index/.venv/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "/Users/jerryliu/Programming/llama_index/.venv/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
       "  from .autonotebook import tqdm as notebook_tqdm\n"
      ]
     }
    ],
    "source": [
-    "from gpt_index.composability.joint_qa_summary import QASummaryGraphBuilder\n",
-    "from gpt_index import SimpleDirectoryReader, ServiceContext, LLMPredictor\n",
-    "from gpt_index.composability import ComposableGraph\n",
+    "from llama_index.composability.joint_qa_summary import QASummaryGraphBuilder\n",
+    "from llama_index import SimpleDirectoryReader, ServiceContext, LLMPredictor\n",
+    "from llama_index.composability import ComposableGraph\n",
     "from langchain.chat_models import ChatOpenAI"
    ]
   },
@@ -78,7 +78,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "WARNING:gpt_index.llm_predictor.base:Unknown max input size for gpt-3.5-turbo, using defaults.\n",
+      "WARNING:llama_index.llm_predictor.base:Unknown max input size for gpt-3.5-turbo, using defaults.\n",
       "Unknown max input size for gpt-3.5-turbo, using defaults.\n"
      ]
     }
@@ -103,17 +103,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
+      "INFO:llama_index.token_counter.token_counter:> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
       "> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
-      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total embedding token usage: 20729 tokens\n",
+      "INFO:llama_index.token_counter.token_counter:> [build_index_from_nodes] Total embedding token usage: 20729 tokens\n",
       "> [build_index_from_nodes] Total embedding token usage: 20729 tokens\n",
-      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
+      "INFO:llama_index.token_counter.token_counter:> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
       "> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
-      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total embedding token usage: 0 tokens\n",
+      "INFO:llama_index.token_counter.token_counter:> [build_index_from_nodes] Total embedding token usage: 0 tokens\n",
       "> [build_index_from_nodes] Total embedding token usage: 0 tokens\n",
-      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
+      "INFO:llama_index.token_counter.token_counter:> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
       "> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
-      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total embedding token usage: 0 tokens\n",
+      "INFO:llama_index.token_counter.token_counter:> [build_index_from_nodes] Total embedding token usage: 0 tokens\n",
       "> [build_index_from_nodes] Total embedding token usage: 0 tokens\n"
      ]
     }
@@ -201,7 +201,7 @@
       ">[Level 0] Current response: ANSWER: 2\n",
       "\n",
       "This summary was selected because the question asks for a summary of the author's life, which implies needing a summarized version rather than a specific context from the documents. Hence, choice 2 is more relevant for summarization queries.\n",
-      "INFO:gpt_index.indices.tree.leaf_query:>[Level 0] Selected node: [2]/[2]\n",
+      "INFO:llama_index.indices.tree.leaf_query:>[Level 0] Selected node: [2]/[2]\n",
       ">[Level 0] Selected node: [2]/[2]\n",
       ">[Level 0] Selected node: [2]/[2]\n",
       ">[Level 0] Node [2] Summary text: Use this index for summarization queries\n",
@@ -253,7 +253,7 @@
       "\u001b[0m\u001b[36;1m\u001b[1;3m> Got node text: up a deeply rooted tree.\n",
       "\n",
       "[19] One way to get more precise about the concept of invented vs discovered is to talk about space aliens. Any sufficiently advanced alien civilization would certainly kn...\n",
-      "\u001b[0mINFO:gpt_index.indices.common_tree.base:> Building index from nodes: 6 chunks\n",
+      "\u001b[0mINFO:llama_index.indices.common_tree.base:> Building index from nodes: 6 chunks\n",
       "> Building index from nodes: 6 chunks\n",
       "INFO:openai:message='OpenAI API response' path=https://api.openai.com/v1/chat/completions processing_ms=3833 request_id=5bd6aba916b8fc4e87f26cabd582d6f0 response_code=200\n",
       "message='OpenAI API response' path=https://api.openai.com/v1/chat/completions processing_ms=3833 request_id=5bd6aba916b8fc4e87f26cabd582d6f0 response_code=200\n",
@@ -317,7 +317,7 @@
       ">[Level 0] Current response: ANSWER: 1\n",
       "\n",
       "The question, \"What did the author do growing up?\" asks for specific context from documents about the author's experiences or activities during their childhood. Choice 1 mentions retrieval of specific context from documents, which is more in line with answering this type of question than summarization queries mentioned in Choice 2.\n",
-      "INFO:gpt_index.indices.tree.leaf_query:>[Level 0] Selected node: [1]/[1]\n",
+      "INFO:llama_index.indices.tree.leaf_query:>[Level 0] Selected node: [1]/[1]\n",
       ">[Level 0] Selected node: [1]/[1]\n",
       ">[Level 0] Selected node: [1]/[1]\n",
       ">[Level 0] Node [1] Summary text: Use this index for queries that require retrieval of specific context from documents.\n",
@@ -369,7 +369,7 @@
       ">[Level 0] Current response: ANSWER: 1\n",
       "\n",
       "This summary was selected in relation to the question because it involves retrieval of specific context from documents, which is necessary to know what the author did during his time in art school. Choice 2 is focused on summarization queries, which isn't related to the specific detail needed to answer the question.\n",
-      "INFO:gpt_index.indices.tree.leaf_query:>[Level 0] Selected node: [1]/[1]\n",
+      "INFO:llama_index.indices.tree.leaf_query:>[Level 0] Selected node: [1]/[1]\n",
       ">[Level 0] Selected node: [1]/[1]\n",
       ">[Level 0] Selected node: [1]/[1]\n",
       ">[Level 0] Node [1] Summary text: Use this index for queries that require retrieval of specific context from documents.\n",


### PR DESCRIPTION
**Problem:**

When trying out the example, we encounter this error:

`ModuleNotFoundError: No module named 'gpt_index'`

**Solution:**

Replace gpt_index with llama_index (new module name).