### PR TITLE
Update CompsableIndices Weaviate example to use llama_index instead o…

### DIFF
--- a/examples/composable_indices/ComposableIndices-Weaviate.ipynb
+++ b/examples/composable_indices/ComposableIndices-Weaviate.ipynb
@@ -25,7 +25,7 @@
     "logging.basicConfig(stream=sys.stdout, level=logging.INFO)\n",
     "logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))\n",
     "\n",
-    "from gpt_index import (\n",
+    "from llama_index import (\n",
     "    GPTSimpleVectorIndex, \n",
     "    GPTSimpleKeywordTableIndex, \n",
     "    GPTListIndex, \n",
@@ -329,7 +329,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from gpt_index.indices.composability import ComposableGraph"
+    "from llama_index.indices.composability import ComposableGraph"
    ]
   },
   {


### PR DESCRIPTION
…f gpt_index

Problem:

When trying out the example, we encounter this error:

`ModuleNotFoundError: No module named 'gpt_index'`

Solution:

Replace gpt_index with llama_index (new module name).