### PR TITLE
add prev/next node postprocessor

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -98,6 +98,7 @@ That's where the **LlamaIndex** comes in. LlamaIndex is a simple, flexible inter
    reference/indices.rst
    reference/query.rst
    reference/node.rst
+   reference/node_postprocessor.rst
    reference/docstore.rst
    reference/composability.rst
    reference/readers.rst

--- a/docs/reference/node_postprocessor.rst
+++ b/docs/reference/node_postprocessor.rst
@@ -1,0 +1,8 @@
+.. _Ref-Node-Postprocessor:
+
+Node Postprocessor
+=================
+
+.. automodule:: gpt_index.indices.postprocessor
+   :members:
+   :inherited-members:

--- a/examples/node_postprocessor/NodePostprocessorDemo.ipynb
+++ b/examples/node_postprocessor/NodePostprocessorDemo.ipynb
@@ -28,8 +28,8 @@
    "source": [
     "from gpt_index import GPTSimpleVectorIndex, SimpleDirectoryReader, ServiceContext\n",
     "from gpt_index.indices.postprocessor.node import (\n",
-    "    PrevNextNodePostProcessor, \n",
-    "    AutoPrevNextNodePostProcessor\n",
+    "    PrevNextNodePostprocessor, \n",
+    "    AutoPrevNextNodePostprocessor\n",
     ")\n",
     "from gpt_index.node_parser import SimpleNodeParser\n",
     "from gpt_index.docstore import DocumentStore"
@@ -76,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "5f7f68d6-2389-4f6c-bc4e-8612a1a53fb8",
    "metadata": {
     "tags": []
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "23706146-d277-4036-9c84-24b9cd44396e",
    "metadata": {
     "tags": []
@@ -111,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "c5dabcf2-a027-4864-955b-971213927ab5",
    "metadata": {
     "tags": []
@@ -132,14 +132,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "a1d34f87-2997-452a-bad4-65380775e534",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "node_postprocessor = PrevNextNodePostProcessor(docstore=docstore, num_nodes=4)"
+    "node_postprocessor = PrevNextNodePostprocessor(docstore=docstore, num_nodes=4)"
    ]
   },
   {
@@ -154,7 +154,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:gpt_index.token_counter.token_counter:> [query] Total LLM token usage: 2491 tokens\n",
+      "INFO:gpt_index.token_counter.token_counter:> [query] Total LLM token usage: 2522 tokens\n",
       "INFO:gpt_index.token_counter.token_counter:> [query] Total embedding token usage: 17 tokens\n"
      ]
     }
@@ -181,7 +181,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "After handing off Y Combinator to Sam Altman, the author decided to take up painting. He spent most of the rest of 2014 painting, but eventually ran out of steam and stopped. He then started writing essays again and wrote a bunch of new ones. In March 2015, he started working on Lisp again and wrote a new Lisp, called Bel, in Arc. He had to ban himself from writing essays during most of this time in order to finish the project, which took 4 years.\n"
+      "After handing off Y Combinator to Sam Altman, the author decided to take up painting. He spent most of the rest of 2014 painting and got to be better than he had been before. However, in November he ran out of steam and stopped working on a painting. He then started writing essays again and wrote a bunch of new ones over the next few months. In March 2015, he started working on Lisp again and wrote a new Lisp, called Bel, in Arc. He had to ban himself from writing essays during most of this time in order to finish the project, which took 4 years from March 26, 2015 to October 12, 2019.\n"
      ]
     }
    ],
@@ -191,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 9,
    "id": "0cafc75d-fd83-43ff-948b-b171da75c647",
    "metadata": {
     "tags": []
@@ -217,7 +217,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 10,
    "id": "f2aa1763-5557-4ad8-ac43-74d2661a0966",
    "metadata": {
     "tags": []
@@ -238,7 +238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 11,
    "id": "a1c3e599-5376-4706-9a83-d3a769df6e46",
    "metadata": {
     "tags": []
@@ -248,7 +248,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:gpt_index.token_counter.token_counter:> [query] Total LLM token usage: 1544 tokens\n",
+      "INFO:gpt_index.token_counter.token_counter:> [query] Total LLM token usage: 1547 tokens\n",
       "INFO:gpt_index.token_counter.token_counter:> [query] Total embedding token usage: 17 tokens\n"
      ]
     }
@@ -264,7 +264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 12,
    "id": "7cfda042-c88b-4ce1-a61d-65baafff4d1c",
    "metadata": {
     "tags": []
@@ -275,7 +275,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "After handing off Y Combinator to Sam Altman, the author decided to take a break and focus on painting. He spent most of the rest of 2014 painting and eventually ran out of steam in November. He then decided to take a break from painting and focus on other things.\n"
+      "After handing off Y Combinator to Sam Altman, the author decided to take up painting as his next activity. He spent most of the rest of 2014 painting and eventually ran out of steam in November. He then stopped working on the painting and began to think about what he should do next.\n"
      ]
     }
    ],
@@ -293,14 +293,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 13,
    "id": "82d510b0-5a90-45bb-ace1-de764bc7a068",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "node_postprocessor = AutoPrevNextNodePostProcessor(\n",
+    "node_postprocessor = AutoPrevNextNodePostprocessor(\n",
     "    docstore=docstore, \n",
     "    num_nodes=3,\n",
     "    service_context=service_context,\n",
@@ -310,7 +310,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 15,
    "id": "c6a8094f-c757-4dae-b81a-248d65166443",
    "metadata": {
     "tags": []
@@ -327,7 +327,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:gpt_index.token_counter.token_counter:> [query] Total LLM token usage: 1982 tokens\n",
+      "INFO:gpt_index.token_counter.token_counter:> [query] Total LLM token usage: 1987 tokens\n",
       "INFO:gpt_index.token_counter.token_counter:> [query] Total embedding token usage: 17 tokens\n"
      ]
     }
@@ -344,7 +344,83 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 16,
+   "id": "055f5663-b1f8-4f11-bfbf-b04bcf6ee53c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "After handing off Y Combinator to Sam Altman, the author decided to take up painting. He spent most of the rest of 2014 painting and got better at it, but eventually ran out of steam and stopped working on it. He then started writing essays again and wrote a few that weren't about startups. In March 2015, he started working on Lisp again.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "1fd4392f-8e71-4a07-b123-5af23d33744a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> Postprocessor Predicted mode: none\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:gpt_index.token_counter.token_counter:> [query] Total LLM token usage: 571 tokens\n",
+      "INFO:gpt_index.token_counter.token_counter:> [query] Total embedding token usage: 14 tokens\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Infer that we don't need to search previous or next\n",
+    "response = index.query(\n",
+    "    \"What did the author do during his time at Y Combinator?\", \n",
+    "    similarity_top_k=1,\n",
+    "    node_postprocessors=[node_postprocessor],\n",
+    "    response_mode=\"tree_summarize\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "dfa87d01-5349-452d-af5a-58c474e89d7a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "The author did a variety of things during his time at Y Combinator, including hacking, writing essays, investing in startups, creating a batch system for startup funding, building a tight alumni community, and working on a new version of Arc with Robert Morris. He also created Hacker News, an online news aggregator for startup founders.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
    "id": "33b92118-50fb-4b19-85a6-a94a11950fb6",
    "metadata": {
     "tags": []
@@ -361,7 +437,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:gpt_index.token_counter.token_counter:> [query] Total LLM token usage: 2071 tokens\n",
+      "INFO:gpt_index.token_counter.token_counter:> [query] Total LLM token usage: 2057 tokens\n",
       "INFO:gpt_index.token_counter.token_counter:> [query] Total embedding token usage: 17 tokens\n"
      ]
     }
@@ -378,7 +454,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 20,
    "id": "6de2caac-95cc-4d98-9c3d-d16916aaab11",
    "metadata": {
     "tags": []
@@ -389,7 +465,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Before handing off Y Combinator to Sam Altman, the author worked on a new version of Arc, wrote Hacker News in it, wrote all of YC's internal software in Arc, visited his mother in Oregon, and worked hard on YC even at the parts he didn't like. He also offered unsolicited advice to other founders and worked to learn as much as he could about startups in the shortest possible time.\n"
+      "Before handing off Y Combinator to Sam Altman, the author wrote essays, worked on Y Combinator, wrote Hacker News in Arc, wrote all of Y Combinator's internal software in Arc, and worked hard at the parts of the job he didn't like. He also flew up to Oregon to visit his mother regularly and had time to think on those flights.\n"
      ]
     }
    ],
@@ -399,7 +475,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 21,
    "id": "14822e9b-fe96-44e9-a7fd-a441f6fe2ae4",
    "metadata": {
     "tags": []
@@ -424,7 +500,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 22,
    "id": "7dbdeafc-1829-4110-a6ca-ca81eac6e0c9",
    "metadata": {
     "tags": []

--- a/examples/node_postprocessor/NodePostprocessorDemo.ipynb
+++ b/examples/node_postprocessor/NodePostprocessorDemo.ipynb
@@ -1,0 +1,476 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b1c1ebaa-50de-4851-a720-acbb977551ea",
+   "metadata": {},
+   "source": [
+    "# Showcase Forward/Backward Node PostProcessor\n",
+    "\n",
+    "Showcase capabilities of leveraging Node relationships on top of PG's essay"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "92d06b38-2103-4a40-93c3-60e0708a1124",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/jerryliu/Programming/gpt_index/.venv/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
+   "source": [
+    "from gpt_index import GPTSimpleVectorIndex, SimpleDirectoryReader, ServiceContext\n",
+    "from gpt_index.indices.postprocessor.node import (\n",
+    "    PrevNextNodePostProcessor, \n",
+    "    AutoPrevNextNodePostProcessor\n",
+    ")\n",
+    "from gpt_index.node_parser import SimpleNodeParser\n",
+    "from gpt_index.docstore import DocumentStore"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67020156-2975-4bbb-8e98-afc55abb3d72",
+   "metadata": {},
+   "source": [
+    "### Parse Documents into Nodes, add to Docstore"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "caddd84e-9827-40a4-9520-dba6405fd1fd",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# load documents\n",
+    "documents = SimpleDirectoryReader('../paul_graham_essay/data').load_data()\n",
+    "\n",
+    "# define service context (wrapper container around current classes)\n",
+    "service_context = ServiceContext.from_defaults(chunk_size_limit=512)\n",
+    "\n",
+    "# use node parser in service context to parse into nodes\n",
+    "nodes = service_context.node_parser.get_nodes_from_documents(documents)\n",
+    "\n",
+    "# add to docstore\n",
+    "docstore = DocumentStore()\n",
+    "docstore.add_documents(nodes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5a25b95-de5e-4e56-a846-51e9c6eba181",
+   "metadata": {},
+   "source": [
+    "### Build Index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "5f7f68d6-2389-4f6c-bc4e-8612a1a53fb8",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
+      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total embedding token usage: 27212 tokens\n"
+     ]
+    }
+   ],
+   "source": [
+    "# build index \n",
+    "index = GPTSimpleVectorIndex(nodes, docstore=docstore)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "23706146-d277-4036-9c84-24b9cd44396e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# [optional] save index to disk\n",
+    "index.save_to_disk('index.json')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c5dabcf2-a027-4864-955b-971213927ab5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# [optional] load from disk\n",
+    "index = GPTSimpleVectorIndex.load_from_disk('index.json')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e493666e-ca76-47c0-bb9a-aa70c9eee3df",
+   "metadata": {},
+   "source": [
+    "### Add PrevNext Node Postprocessor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a1d34f87-2997-452a-bad4-65380775e534",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "node_postprocessor = PrevNextNodePostProcessor(docstore=docstore, num_nodes=4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "7675437d-d7be-436b-898c-dac0df5990b9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:gpt_index.token_counter.token_counter:> [query] Total LLM token usage: 2491 tokens\n",
+      "INFO:gpt_index.token_counter.token_counter:> [query] Total embedding token usage: 17 tokens\n"
+     ]
+    }
+   ],
+   "source": [
+    "response = index.query(\n",
+    "    \"What did the author do after handing off Y Combinator to Sam Altman?\", \n",
+    "    similarity_top_k=1,\n",
+    "    node_postprocessors=[node_postprocessor],\n",
+    "    response_mode=\"tree_summarize\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "3d2391ea-2bac-4ceb-bedb-57ba0c9cabca",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "After handing off Y Combinator to Sam Altman, the author decided to take up painting. He spent most of the rest of 2014 painting, but eventually ran out of steam and stopped. He then started writing essays again and wrote a bunch of new ones. In March 2015, he started working on Lisp again and wrote a new Lisp, called Bel, in Arc. He had to ban himself from writing essays during most of this time in order to finish the project, which took 4 years.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(response) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "0cafc75d-fd83-43ff-948b-b171da75c647",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:gpt_index.token_counter.token_counter:> [query] Total LLM token usage: 583 tokens\n",
+      "INFO:gpt_index.token_counter.token_counter:> [query] Total embedding token usage: 17 tokens\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Try querying index without node postprocessor\n",
+    "response = index.query(\n",
+    "    \"What did the author do after handing off Y Combinator to Sam Altman?\", \n",
+    "    similarity_top_k=1, \n",
+    "    response_mode=\"tree_summarize\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "f2aa1763-5557-4ad8-ac43-74d2661a0966",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "After handing off Y Combinator to Sam Altman, the author focused on helping his mother get out of the nursing home and back to her house. He flew up to Oregon to visit her regularly and used the time to think. He also spent time with his sister to help his mother.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "a1c3e599-5376-4706-9a83-d3a769df6e46",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:gpt_index.token_counter.token_counter:> [query] Total LLM token usage: 1544 tokens\n",
+      "INFO:gpt_index.token_counter.token_counter:> [query] Total embedding token usage: 17 tokens\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Try querying index without node postprocessor and higher top-k\n",
+    "response = index.query(\n",
+    "    \"What did the author do after handing off Y Combinator to Sam Altman?\", \n",
+    "    similarity_top_k=3, \n",
+    "    response_mode=\"tree_summarize\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "7cfda042-c88b-4ce1-a61d-65baafff4d1c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "After handing off Y Combinator to Sam Altman, the author decided to take a break and focus on painting. He spent most of the rest of 2014 painting and eventually ran out of steam in November. He then decided to take a break from painting and focus on other things.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6917ff5-be24-4b76-837a-ea5de7f492cb",
+   "metadata": {},
+   "source": [
+    "### Add Auto Prev/Next Node Postprocessor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "82d510b0-5a90-45bb-ace1-de764bc7a068",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "node_postprocessor = AutoPrevNextNodePostProcessor(\n",
+    "    docstore=docstore, \n",
+    "    num_nodes=3,\n",
+    "    service_context=service_context,\n",
+    "    verbose=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c6a8094f-c757-4dae-b81a-248d65166443",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> Postprocessor Predicted mode: next\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:gpt_index.token_counter.token_counter:> [query] Total LLM token usage: 1982 tokens\n",
+      "INFO:gpt_index.token_counter.token_counter:> [query] Total embedding token usage: 17 tokens\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Infer that we need to search nodes after current one\n",
+    "response = index.query(\n",
+    "    \"What did the author do after handing off Y Combinator to Sam Altman?\", \n",
+    "    similarity_top_k=1,\n",
+    "    node_postprocessors=[node_postprocessor],\n",
+    "    response_mode=\"tree_summarize\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "33b92118-50fb-4b19-85a6-a94a11950fb6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> Postprocessor Predicted mode: previous\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:gpt_index.token_counter.token_counter:> [query] Total LLM token usage: 2071 tokens\n",
+      "INFO:gpt_index.token_counter.token_counter:> [query] Total embedding token usage: 17 tokens\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Infer that we need to search nodes before current one\n",
+    "response = index.query(\n",
+    "    \"What did the author do before handing off Y Combinator to Sam Altman?\", \n",
+    "    similarity_top_k=1,\n",
+    "    node_postprocessors=[node_postprocessor],\n",
+    "    response_mode=\"tree_summarize\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "6de2caac-95cc-4d98-9c3d-d16916aaab11",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Before handing off Y Combinator to Sam Altman, the author worked on a new version of Arc, wrote Hacker News in it, wrote all of YC's internal software in Arc, visited his mother in Oregon, and worked hard on YC even at the parts he didn't like. He also offered unsolicited advice to other founders and worked to learn as much as he could about startups in the shortest possible time.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "14822e9b-fe96-44e9-a7fd-a441f6fe2ae4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:gpt_index.token_counter.token_counter:> [query] Total LLM token usage: 575 tokens\n",
+      "INFO:gpt_index.token_counter.token_counter:> [query] Total embedding token usage: 17 tokens\n"
+     ]
+    }
+   ],
+   "source": [
+    "response = index.query(\n",
+    "    \"What did the author do before handing off Y Combinator to Sam Altman?\", \n",
+    "    similarity_top_k=1,\n",
+    "    response_mode=\"tree_summarize\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "7dbdeafc-1829-4110-a6ca-ca81eac6e0c9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "The author spent the rest of 2013 gradually leaving the running of Y Combinator to Sam Altman, partly so he could learn the job and partly because the author was focused on visiting his mother in Oregon and helping her get out of a nursing home.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ee0e4646-def2-4ac6-b764-c7672420826a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "llama_index",
+   "language": "python",
+   "name": "llama_index"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gpt_index/indices/postprocessor/__init__.py
+++ b/gpt_index/indices/postprocessor/__init__.py
@@ -5,14 +5,14 @@ from gpt_index.indices.postprocessor.base import BasePostprocessor
 from gpt_index.indices.postprocessor.node import (
     SimilarityPostprocessor,
     KeywordNodePostprocessor,
-    PrevNextNodePostProcessor,
-    AutoPrevNextNodePostProcessor,
+    PrevNextNodePostprocessor,
+    AutoPrevNextNodePostprocessor,
 )
 
 __all__ = [
     "BasePostprocessor",
     "SimilarityPostprocessor",
     "KeywordNodePostprocessor",
-    "PrevNextNodePostProcessor",
-    "AutoPrevNextNodePostProcessor",
+    "PrevNextNodePostprocessor",
+    "AutoPrevNextNodePostprocessor",
 ]

--- a/gpt_index/indices/postprocessor/__init__.py
+++ b/gpt_index/indices/postprocessor/__init__.py
@@ -1,5 +1,18 @@
-"""Base postprocessor."""
+"""Node PostProcessor module."""
 
 
-class BasePostprocessor:
-    """Base Postprocessor."""
+from gpt_index.indices.postprocessor.base import BasePostprocessor
+from gpt_index.indices.postprocessor.node import (
+    SimilarityPostprocessor,
+    KeywordNodePostprocessor,
+    PrevNextNodePostProcessor,
+    AutoPrevNextNodePostProcessor,
+)
+
+__all__ = [
+    "BasePostprocessor",
+    "SimilarityPostprocessor",
+    "KeywordNodePostprocessor",
+    "PrevNextNodePostProcessor",
+    "AutoPrevNextNodePostProcessor",
+]

--- a/gpt_index/indices/postprocessor/base.py
+++ b/gpt_index/indices/postprocessor/base.py
@@ -1,0 +1,5 @@
+"""Base postprocessor."""
+
+
+class BasePostprocessor:
+    """Base Postprocessor."""

--- a/gpt_index/indices/postprocessor/node.py
+++ b/gpt_index/indices/postprocessor/node.py
@@ -10,12 +10,10 @@ import logging
 from gpt_index.indices.query.schema import QueryBundle
 from gpt_index.indices.service_context import ServiceContext
 from gpt_index.prompts.prompts import QuestionAnswerPrompt, RefinePrompt
-from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
 from gpt_index.docstore import DocumentStore
 from gpt_index.data_structs.node_v2 import Node, DocumentRelationship
 from gpt_index.indices.postprocessor.base import BasePostprocessor
 from gpt_index.indices.query.embedding_utils import SimilarityTracker
-from gpt_index.logger.base import LlamaLogger
 from gpt_index.indices.response.builder import ResponseBuilder, TextChunk
 
 logger = logging.getLogger(__name__)
@@ -302,6 +300,7 @@ class AutoPrevNextNodePostProcessor(BasePrevNextNodePostProcessor):
                 query_str=query_bundle.query_str,
                 response_mode="tree_summarize",
             )
+            raw_pred = cast(str, raw_pred)
             mode = self._parse_prediction(raw_pred)
 
             logger.debug(f"> Postprocessor Predicted mode: {mode}")

--- a/gpt_index/indices/postprocessor/node.py
+++ b/gpt_index/indices/postprocessor/node.py
@@ -4,11 +4,21 @@ import re
 from abc import abstractmethod
 from typing import Dict, List, Optional, cast
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 
-from gpt_index.data_structs.node_v2 import Node
-from gpt_index.indices.postprocessor import BasePostprocessor
+import logging
+from gpt_index.indices.query.schema import QueryBundle
+from gpt_index.indices.service_context import ServiceContext
+from gpt_index.prompts.prompts import QuestionAnswerPrompt, RefinePrompt
+from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
+from gpt_index.docstore import DocumentStore
+from gpt_index.data_structs.node_v2 import Node, DocumentRelationship
+from gpt_index.indices.postprocessor.base import BasePostprocessor
 from gpt_index.indices.query.embedding_utils import SimilarityTracker
+from gpt_index.logger.base import LlamaLogger
+from gpt_index.indices.response.builder import ResponseBuilder, TextChunk
+
+logger = logging.getLogger(__name__)
 
 
 class BaseNodePostprocessor(BasePostprocessor, BaseModel):
@@ -82,3 +92,228 @@ class SimilarityPostprocessor(BaseNodePostprocessor):
                 new_nodes.append(node)
 
         return new_nodes
+
+
+class BasePrevNextNodePostProcessor(BaseNodePostprocessor):
+    """Previous/Next Node post-processor.
+
+    Allows users to fetch additional nodes from the document store,
+    based on the relationships of the nodes.
+
+    NOTE: this is a beta feature.
+
+    Args:
+        docstore (DocumentStore): The document store.
+        num_nodes (int): The number of nodes to return (default: 1)
+        mode (str): The mode of the post-processor. Can be "forward" or "backward".
+
+    """
+
+    docstore: DocumentStore
+    num_nodes: int = Field(default=1)
+
+    def _get_forward_nodes(self, node: Node) -> Dict[str, Node]:
+        """Get forward nodes."""
+
+        nodes: Dict[str, Node] = {node.get_doc_id(): node}
+        cur_count = 0
+        # get forward nodes in an iterative manner
+        while cur_count < self.num_nodes:
+            if DocumentRelationship.NEXT not in node.relationships:
+                break
+            next_node_id = node.relationships[DocumentRelationship.NEXT]
+            next_node = self.docstore.get_node(next_node_id)
+            if next_node is None:
+                break
+            nodes[next_node.get_doc_id()] = next_node
+            node = next_node
+            cur_count += 1
+        return nodes
+
+    def _get_backward_nodes(self, node: Node) -> Dict[str, Node]:
+        """Get backward nodes."""
+        # get backward nodes in an iterative manner
+        nodes: Dict[str, Node] = {node.get_doc_id(): node}
+        cur_count = 0
+        while cur_count < self.num_nodes:
+            if DocumentRelationship.PREVIOUS not in node.relationships:
+                break
+            prev_node_id = node.relationships[DocumentRelationship.PREVIOUS]
+            prev_node = self.docstore.get_node(prev_node_id)
+            if prev_node is None:
+                break
+            nodes[prev_node.get_doc_id()] = prev_node
+            node = prev_node
+            cur_count += 1
+        return nodes
+
+
+class PrevNextNodePostProcessor(BasePrevNextNodePostProcessor):
+    """Previous/Next Node post-processor.
+
+    Allows users to fetch additional nodes from the document store,
+    based on the relationships of the nodes.
+
+    NOTE: this is a beta feature.
+
+    Args:
+        docstore (DocumentStore): The document store.
+        num_nodes (int): The number of nodes to return (default: 1)
+        mode (str): The mode of the post-processor.
+            Can be "previous", "next", or "both.
+
+    """
+
+    mode: str = Field(default="next")
+
+    @validator("mode")
+    def _validate_mode(cls, v: str) -> str:
+        """Validate mode."""
+        if v not in ["next", "previous", "both"]:
+            raise ValueError(f"Invalid mode: {v}")
+        return v
+
+    def postprocess_nodes(
+        self, nodes: List[Node], extra_info: Optional[Dict] = None
+    ) -> List[Node]:
+        """Postprocess nodes."""
+        all_nodes: Dict[str, Node] = {}
+        for node in nodes:
+            all_nodes[node.get_doc_id()] = node
+            if self.mode == "next":
+                all_nodes.update(self._get_forward_nodes(node))
+            elif self.mode == "previous":
+                all_nodes.update(self._get_backward_nodes(node))
+            elif self.mode == "both":
+                all_nodes.update(self._get_forward_nodes(node))
+                all_nodes.update(self._get_backward_nodes(node))
+            else:
+                raise ValueError(f"Invalid mode: {self.mode}")
+
+        sorted_nodes = sorted(all_nodes.values(), key=lambda x: x.get_doc_id())
+        return list(sorted_nodes)
+
+
+DEFAULT_INFER_PREV_NEXT_TMPL = (
+    "The current context information is provided. \n"
+    "A question is also provided. \n"
+    "You are a retrieval agent deciding whether to search the "
+    "document store for additional prior context or future context. \n"
+    "Given the context and question, return PREVIOUS or NEXT or NONE. \n"
+    "Examples: \n\n"
+    "Context: Describes the author's experience at Y Combinator."
+    "Question: What did the author do after his time at Y Combinator? \n"
+    "Answer: NEXT \n\n"
+    "Context: Describes the author's experience at Y Combinator."
+    "Question: What did the author do before his time at Y Combinator? \n"
+    "Answer: PREVIOUS \n\n"
+    "Context: Describe the author's experience at Y Combinator."
+    "Question: What did the author do at Y Combinator? \n"
+    "Answer: NONE \n\n"
+    "Context: {context_str}\n"
+    "Question: {query_str}\n"
+    "Answer: "
+)
+
+
+DEFAULT_REFINE_INFER_PREV_NEXT_TMPL = (
+    "The current context information is provided. \n"
+    "A question is also provided. \n"
+    "An existing answer is also provided.\n"
+    "You are a retrieval agent deciding whether to search the "
+    "document store for additional prior context or future context. \n"
+    "Given the context, question, and previous answer, "
+    "return PREVIOUS or NEXT or NONE.\n"
+    "Examples: \n\n"
+    "Context: {context_msg}\n"
+    "Question: {query_str}\n"
+    "Existing Answer: {existing_answer}\n"
+    "Answer: "
+)
+
+
+class AutoPrevNextNodePostProcessor(BasePrevNextNodePostProcessor):
+    """Previous/Next Node post-processor.
+
+    Allows users to fetch additional nodes from the document store,
+    based on the prev/next relationships of the nodes.
+
+    NOTE: difference with PrevNextPostProcessor is that
+    this infers forward/backwards direction.
+
+    NOTE: this is a beta feature.
+
+    Args:
+        docstore (DocumentStore): The document store.
+        llm_predictor (LLMPredictor): The LLM predictor.
+        num_nodes (int): The number of nodes to return (default: 1)
+        infer_prev_next_tmpl (str): The template to use for inference.
+            Required fields are {context_str} and {query_str}.
+
+    """
+
+    service_context: ServiceContext
+    infer_prev_next_tmpl: str = Field(default=DEFAULT_INFER_PREV_NEXT_TMPL)
+    refine_prev_next_tmpl: str = Field(default=DEFAULT_REFINE_INFER_PREV_NEXT_TMPL)
+    verbose: bool = Field(default=False)
+
+    class Config:
+        """Configuration for this pydantic object."""
+
+        arbitrary_types_allowed = True
+
+    def _parse_prediction(self, raw_pred: str) -> str:
+        """Parse prediction."""
+        pred = raw_pred.strip().lower()
+        if "previous" in pred:
+            return "previous"
+        elif "next" in pred:
+            return "next"
+        elif "none" in pred:
+            return "none"
+        raise ValueError(f"Invalid prediction: {raw_pred}")
+
+    def postprocess_nodes(
+        self, nodes: List[Node], extra_info: Optional[Dict] = None
+    ) -> List[Node]:
+        """Postprocess nodes."""
+        if extra_info is None or "query_bundle" not in extra_info:
+            raise ValueError("Missing query bundle in extra info.")
+
+        query_bundle = cast(QueryBundle, extra_info["query_bundle"])
+
+        infer_prev_next_prompt = QuestionAnswerPrompt(
+            self.infer_prev_next_tmpl,
+        )
+        refine_infer_prev_next_prompt = RefinePrompt(self.refine_prev_next_tmpl)
+
+        all_nodes: Dict[str, Node] = {}
+        for node in nodes:
+            all_nodes[node.get_doc_id()] = node
+            # use response builder instead of llm_predictor directly
+            # to be more robust to handling long context
+            response_builder = ResponseBuilder(
+                self.service_context,
+                infer_prev_next_prompt,
+                refine_infer_prev_next_prompt,
+            )
+            response_builder.add_text_chunks([TextChunk(node.get_text())])
+            raw_pred = response_builder.get_response(
+                query_str=query_bundle.query_str,
+                response_mode="tree_summarize",
+            )
+            mode = self._parse_prediction(raw_pred)
+
+            logger.debug(f"> Postprocessor Predicted mode: {mode}")
+            if self.verbose:
+                print(f"> Postprocessor Predicted mode: {mode}")
+
+            if mode == "next":
+                all_nodes.update(self._get_forward_nodes(node))
+            elif mode == "previous":
+                all_nodes.update(self._get_backward_nodes(node))
+            else:
+                raise ValueError(f"Invalid mode: {mode}")
+
+        sorted_nodes = sorted(all_nodes.values(), key=lambda x: x.get_doc_id())
+        return list(sorted_nodes)

--- a/gpt_index/indices/query/base.py
+++ b/gpt_index/indices/query/base.py
@@ -248,7 +248,10 @@ class BaseGPTIndexQuery(Generic[IS], ABC):
         similarity_tracker = SimilarityTracker()
         nodes = self._retrieve(query_bundle, similarity_tracker=similarity_tracker)
 
-        postprocess_info = {"similarity_tracker": similarity_tracker}
+        postprocess_info = {
+            "similarity_tracker": similarity_tracker,
+            "query_bundle": query_bundle,
+        }
         for node_processor in self.node_preprocessors:
             nodes = node_processor.postprocess_nodes(nodes, postprocess_info)
 

--- a/gpt_index/node_parser/interface.py
+++ b/gpt_index/node_parser/interface.py
@@ -1,5 +1,5 @@
 """Node parser interface."""
-from typing import List, Protocol, Sequence
+from typing import List, Sequence
 
 from abc import ABC, abstractmethod
 

--- a/gpt_index/node_parser/interface.py
+++ b/gpt_index/node_parser/interface.py
@@ -1,13 +1,16 @@
 """Node parser interface."""
 from typing import List, Protocol, Sequence
 
+from abc import ABC, abstractmethod
+
 from gpt_index.data_structs.node_v2 import Node
 from gpt_index.readers.schema.base import Document
 
 
-class NodeParser(Protocol):
+class NodeParser(ABC):
     """Base interface for node parser."""
 
+    @abstractmethod
     def get_nodes_from_documents(
         self,
         documents: Sequence[Document],
@@ -18,4 +21,3 @@ class NodeParser(Protocol):
             documents (Sequence[Document]): documents to parse
 
         """
-        ...

--- a/gpt_index/node_parser/node_utils.py
+++ b/gpt_index/node_parser/node_utils.py
@@ -44,8 +44,9 @@ def get_nodes_from_document(
     document: BaseDocument,
     text_splitter: TextSplitter,
     include_extra_info: bool = True,
+    include_prev_next_rel: bool = False,
 ) -> List[Node]:
-    """Add document to index."""
+    """Get nodes from document."""
     text_splits = get_text_splits_from_document(
         document=document,
         text_splitter=text_splitter,
@@ -85,4 +86,17 @@ def get_nodes_from_document(
                 relationships={DocumentRelationship.SOURCE: document.get_doc_id()},
             )
             nodes.append(node)
+
+    # if include_prev_next_rel, then add prev/next relationships
+    if include_prev_next_rel:
+        for i, node in enumerate(nodes):
+            if i > 0:
+                node.relationships[DocumentRelationship.PREVIOUS] = nodes[
+                    i - 1
+                ].get_doc_id()
+            if i < len(nodes) - 1:
+                node.relationships[DocumentRelationship.NEXT] = nodes[
+                    i + 1
+                ].get_doc_id()
+
     return nodes

--- a/gpt_index/node_parser/simple.py
+++ b/gpt_index/node_parser/simple.py
@@ -5,9 +5,10 @@ from gpt_index.data_structs.node_v2 import Node
 from gpt_index.langchain_helpers.text_splitter import TextSplitter, TokenTextSplitter
 from gpt_index.node_parser.node_utils import get_nodes_from_document
 from gpt_index.readers.schema.base import Document
+from gpt_index.node_parser.interface import NodeParser
 
 
-class SimpleNodeParser:
+class SimpleNodeParser(NodeParser):
     """Simple node parser.
 
     Splits a document into Nodes using a TextSplitter.
@@ -15,6 +16,7 @@ class SimpleNodeParser:
     Args:
         text_splitter (Optional[TextSplitter]): text splitter
         include_extra_info (bool): whether to include extra info in nodes
+        include_prev_next_rel (bool): whether to include prev/next relationships
 
     """
 
@@ -22,10 +24,12 @@ class SimpleNodeParser:
         self,
         text_splitter: Optional[TextSplitter] = None,
         include_extra_info: bool = True,
+        include_prev_next_rel: bool = True,
     ) -> None:
         """Init params."""
         self._text_splitter = text_splitter or TokenTextSplitter()
         self._include_extra_info = include_extra_info
+        self._include_prev_next_rel = include_prev_next_rel
 
     def get_nodes_from_documents(
         self,
@@ -42,7 +46,10 @@ class SimpleNodeParser:
         all_nodes: List[Node] = []
         for document in documents:
             nodes = get_nodes_from_document(
-                document, self._text_splitter, include_extra_info
+                document,
+                self._text_splitter,
+                include_extra_info,
+                include_prev_next_rel=self._include_prev_next_rel,
             )
             all_nodes.extend(nodes)
         return all_nodes

--- a/tests/indices/postprocessor/__init__.py
+++ b/tests/indices/postprocessor/__init__.py
@@ -1,0 +1,1 @@
+"""Init params."""

--- a/tests/indices/postprocessor/test_base.py
+++ b/tests/indices/postprocessor/test_base.py
@@ -3,7 +3,7 @@
 import pytest
 
 from gpt_index.data_structs.node_v2 import Node, DocumentRelationship
-from gpt_index.indices.postprocessor.node import PrevNextNodePostProcessor
+from gpt_index.indices.postprocessor.node import PrevNextNodePostprocessor
 from gpt_index.docstore import DocumentStore
 
 
@@ -30,7 +30,7 @@ def test_forward_back_processor() -> None:
     docstore.add_documents(nodes)
 
     # check for a single node
-    node_postprocessor = PrevNextNodePostProcessor(
+    node_postprocessor = PrevNextNodePostprocessor(
         docstore=docstore, num_nodes=2, mode="next"
     )
     processed_nodes = node_postprocessor.postprocess_nodes([nodes[0]])
@@ -40,7 +40,7 @@ def test_forward_back_processor() -> None:
     assert processed_nodes[2].get_doc_id() == "3"
 
     # check for multiple nodes (nodes should not be duped)
-    node_postprocessor = PrevNextNodePostProcessor(
+    node_postprocessor = PrevNextNodePostprocessor(
         docstore=docstore, num_nodes=1, mode="next"
     )
     processed_nodes = node_postprocessor.postprocess_nodes([nodes[1], nodes[2]])
@@ -50,7 +50,7 @@ def test_forward_back_processor() -> None:
     assert processed_nodes[2].get_doc_id() == "4"
 
     # check for previous
-    node_postprocessor = PrevNextNodePostProcessor(
+    node_postprocessor = PrevNextNodePostprocessor(
         docstore=docstore, num_nodes=1, mode="previous"
     )
     processed_nodes = node_postprocessor.postprocess_nodes([nodes[1], nodes[2]])
@@ -60,7 +60,7 @@ def test_forward_back_processor() -> None:
     assert processed_nodes[2].get_doc_id() == "3"
 
     # check that both works
-    node_postprocessor = PrevNextNodePostProcessor(
+    node_postprocessor = PrevNextNodePostprocessor(
         docstore=docstore, num_nodes=1, mode="both"
     )
     processed_nodes = node_postprocessor.postprocess_nodes([nodes[2]])
@@ -71,7 +71,7 @@ def test_forward_back_processor() -> None:
     assert processed_nodes[2].get_doc_id() == "4"
 
     # check that num_nodes too high still works
-    node_postprocessor = PrevNextNodePostProcessor(
+    node_postprocessor = PrevNextNodePostprocessor(
         docstore=docstore, num_nodes=4, mode="both"
     )
     processed_nodes = node_postprocessor.postprocess_nodes([nodes[2]])
@@ -84,4 +84,4 @@ def test_forward_back_processor() -> None:
 
     # check that raises value error for invalid mode
     with pytest.raises(ValueError):
-        PrevNextNodePostProcessor(docstore=docstore, num_nodes=4, mode="asdfasdf")
+        PrevNextNodePostprocessor(docstore=docstore, num_nodes=4, mode="asdfasdf")

--- a/tests/indices/postprocessor/test_base.py
+++ b/tests/indices/postprocessor/test_base.py
@@ -1,0 +1,95 @@
+"""Node postprocessor tests."""
+
+import sys
+from typing import Any, Dict, List, Tuple, cast
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from gpt_index.embeddings.openai import OpenAIEmbedding
+from gpt_index.data_structs.node_v2 import Node, DocumentRelationship
+from gpt_index.indices.postprocessor.node import PrevNextNodePostProcessor
+from gpt_index.readers.schema.base import Document
+from gpt_index.vector_stores.simple import SimpleVectorStore
+from tests.mock_utils.mock_decorator import patch_common
+from tests.mock_utils.mock_prompts import MOCK_REFINE_PROMPT, MOCK_TEXT_QA_PROMPT
+from gpt_index.docstore import DocumentStore
+
+
+def test_forward_back_processor():
+    """Test forward-back processor."""
+
+    nodes = [
+        Node("Hello world.", doc_id="1"),
+        Node("This is a test.", doc_id="2"),
+        Node("This is another test.", doc_id="3"),
+        Node("This is a test v2.", doc_id="4"),
+    ]
+    for i, node in enumerate(nodes):
+        if i > 0:
+            node.relationships.update(
+                {DocumentRelationship.PREVIOUS: nodes[i - 1].doc_id}
+            )
+        if i < len(nodes) - 1:
+            node.relationships.update({DocumentRelationship.NEXT: nodes[i + 1].doc_id})
+
+    docstore = DocumentStore()
+    docstore.add_documents(nodes)
+
+    # check for a single node
+    node_postprocessor = PrevNextNodePostProcessor(
+        docstore=docstore, num_nodes=2, mode="next"
+    )
+    processed_nodes = node_postprocessor.postprocess_nodes([nodes[0]])
+    assert len(processed_nodes) == 3
+    assert processed_nodes[0].get_doc_id() == "1"
+    assert processed_nodes[1].get_doc_id() == "2"
+    assert processed_nodes[2].get_doc_id() == "3"
+
+    # check for multiple nodes (nodes should not be duped)
+    node_postprocessor = PrevNextNodePostProcessor(
+        docstore=docstore, num_nodes=1, mode="next"
+    )
+    processed_nodes = node_postprocessor.postprocess_nodes([nodes[1], nodes[2]])
+    assert len(processed_nodes) == 3
+    assert processed_nodes[0].get_doc_id() == "2"
+    assert processed_nodes[1].get_doc_id() == "3"
+    assert processed_nodes[2].get_doc_id() == "4"
+
+    # check for previous
+    node_postprocessor = PrevNextNodePostProcessor(
+        docstore=docstore, num_nodes=1, mode="previous"
+    )
+    processed_nodes = node_postprocessor.postprocess_nodes([nodes[1], nodes[2]])
+    assert len(processed_nodes) == 3
+    assert processed_nodes[0].get_doc_id() == "1"
+    assert processed_nodes[1].get_doc_id() == "2"
+    assert processed_nodes[2].get_doc_id() == "3"
+
+    # check that both works
+    node_postprocessor = PrevNextNodePostProcessor(
+        docstore=docstore, num_nodes=1, mode="both"
+    )
+    processed_nodes = node_postprocessor.postprocess_nodes([nodes[2]])
+    assert len(processed_nodes) == 3
+    # nodes are sorted
+    assert processed_nodes[0].get_doc_id() == "2"
+    assert processed_nodes[1].get_doc_id() == "3"
+    assert processed_nodes[2].get_doc_id() == "4"
+
+    # check that num_nodes too high still works
+    node_postprocessor = PrevNextNodePostProcessor(
+        docstore=docstore, num_nodes=4, mode="both"
+    )
+    processed_nodes = node_postprocessor.postprocess_nodes([nodes[2]])
+    assert len(processed_nodes) == 4
+    # nodes are sorted
+    assert processed_nodes[0].get_doc_id() == "1"
+    assert processed_nodes[1].get_doc_id() == "2"
+    assert processed_nodes[2].get_doc_id() == "3"
+    assert processed_nodes[3].get_doc_id() == "4"
+
+    # check that raises value error for invalid mode
+    with pytest.raises(ValueError):
+        PrevNextNodePostProcessor(docstore=docstore, num_nodes=4, mode="asdfasdf")

--- a/tests/indices/postprocessor/test_base.py
+++ b/tests/indices/postprocessor/test_base.py
@@ -1,23 +1,13 @@
 """Node postprocessor tests."""
 
-import sys
-from typing import Any, Dict, List, Tuple, cast
-from unittest.mock import MagicMock, patch
-
-import numpy as np
 import pytest
 
-from gpt_index.embeddings.openai import OpenAIEmbedding
 from gpt_index.data_structs.node_v2 import Node, DocumentRelationship
 from gpt_index.indices.postprocessor.node import PrevNextNodePostProcessor
-from gpt_index.readers.schema.base import Document
-from gpt_index.vector_stores.simple import SimpleVectorStore
-from tests.mock_utils.mock_decorator import patch_common
-from tests.mock_utils.mock_prompts import MOCK_REFINE_PROMPT, MOCK_TEXT_QA_PROMPT
 from gpt_index.docstore import DocumentStore
 
 
-def test_forward_back_processor():
+def test_forward_back_processor() -> None:
     """Test forward-back processor."""
 
     nodes = [
@@ -29,10 +19,12 @@ def test_forward_back_processor():
     for i, node in enumerate(nodes):
         if i > 0:
             node.relationships.update(
-                {DocumentRelationship.PREVIOUS: nodes[i - 1].doc_id}
+                {DocumentRelationship.PREVIOUS: nodes[i - 1].get_doc_id()},
             )
         if i < len(nodes) - 1:
-            node.relationships.update({DocumentRelationship.NEXT: nodes[i + 1].doc_id})
+            node.relationships.update(
+                {DocumentRelationship.NEXT: nodes[i + 1].get_doc_id()},
+            )
 
     docstore = DocumentStore()
     docstore.add_documents(nodes)

--- a/tests/indices/vector_store/test_base.py
+++ b/tests/indices/vector_store/test_base.py
@@ -1,4 +1,4 @@
-"""Test Faiss index."""
+"""Test vector store indexes."""
 
 import sys
 from typing import Any, Dict, List, Tuple, cast


### PR DESCRIPTION
- add "manual" version: user has to specify whether to go forwards/backwards
- add "auto" version: we can infer whether to keep processing nodes ahead or before 

- changed nodeparser to ABC from Protocol, it was breaking pydantic validation 