### PR TITLE
Wire up the keyword table v1 to v2 migration

### DIFF
--- a/gpt_index/tools/migrate_v1_to_v2.py
+++ b/gpt_index/tools/migrate_v1_to_v2.py
@@ -213,6 +213,8 @@ def convert_to_v2_index_struct_and_docstore(
         struct_v2, nodes_v2 = index_dict_to_v2(index_struct)
     elif isinstance(index_struct, KG):
         struct_v2, nodes_v2 = kg_to_v2(index_struct)
+    elif isinstance(index_struct, KeywordTable):
+        struct_v2, nodes_v2 = keyword_table_to_v2(index_struct)
     else:
         raise NotImplementedError(f"Cannot migrate {type(index_struct)} yet.")
 


### PR DESCRIPTION
The function always existed in the migration script but wasn't wired into the actual migration process.

This wires it up. Have tested it by migrating a 1.5GiB index and queries against said index appear to be working fine.

Fixes #1026