### PR TITLE
Weaviate serialize Node relationships

### DIFF
--- a/gpt_index/response/schema.py
+++ b/gpt_index/response/schema.py
@@ -30,8 +30,8 @@ class Response:
         """Get formatted sources text."""
         texts = []
         for source_node in self.source_nodes:
-            fmt_text_chunk = truncate_text(source_node.source_text, length)
-            doc_id = source_node.doc_id or "None"
+            fmt_text_chunk = truncate_text(source_node.node.get_text(), length)
+            doc_id = source_node.node.doc_id or "None"
             source_text = f"> Source (Doc id: {doc_id}): {fmt_text_chunk}"
             texts.append(source_text)
         return "\n\n".join(texts)


### PR DESCRIPTION
On this PR:
- Create doc_hash and relationships as properties on the weaviate schema
- Serialize and deserialize relationships when writing to / reading from weaviate
- Serialize ref_doc_id when writing to weaviate because the delete_document method uses a where filter on this property. This is not needed when reading from weaviate because on the python side, ref_doc_id is read from the relationships.
- Make the Response. get_formatted_sources method compatible with the new version of Node

This should fix issue #970.