### PR TITLE
fix node id's assigned to vector store + pinecone ref doc id 

### DIFF
--- a/gpt_index/data_structs/node_v2.py
+++ b/gpt_index/data_structs/node_v2.py
@@ -94,8 +94,9 @@ class Node(BaseDocument):
     def get_text(self) -> str:
         """Get text."""
         text = super().get_text()
+        extra_info_exists = self.extra_info is not None and len(self.extra_info) > 0
         result_text = (
-            text if self.extra_info_str is None else f"{self.extra_info_str}\n\n{text}"
+            text if not extra_info_exists else f"{self.extra_info_str}\n\n{text}"
         )
         return result_text
 

--- a/gpt_index/indices/vector_store/base.py
+++ b/gpt_index/indices/vector_store/base.py
@@ -17,7 +17,6 @@ from gpt_index.indices.vector_store.base_query import GPTVectorStoreIndexQuery
 from gpt_index.prompts.default_prompts import DEFAULT_TEXT_QA_PROMPT
 from gpt_index.prompts.prompts import QuestionAnswerPrompt
 from gpt_index.token_counter.token_counter import llm_token_counter
-from gpt_index.utils import get_new_id
 from gpt_index.vector_stores.simple import SimpleVectorStore
 from gpt_index.vector_stores.types import NodeEmbeddingResult, VectorStore
 
@@ -83,7 +82,7 @@ class GPTVectorStoreIndex(BaseGPTIndex[IndexDict]):
         id_to_embed_map: Dict[str, List[float]] = {}
 
         for n in nodes:
-            new_id = get_new_id(existing_node_ids.union(id_to_node_map.keys()))
+            new_id = n.get_doc_id()
             if n.embedding is None:
                 self._service_context.embed_model.queue_text_for_embeddding(
                     new_id, n.get_text()
@@ -127,7 +126,7 @@ class GPTVectorStoreIndex(BaseGPTIndex[IndexDict]):
 
         text_queue: List[Tuple[str, str]] = []
         for n in nodes:
-            new_id = get_new_id(existing_node_ids.union(id_to_node_map.keys()))
+            new_id = n.get_doc_id()
             if n.embedding is None:
                 text_queue.append((new_id, n.get_text()))
             else:

--- a/gpt_index/vector_stores/chatgpt_plugin.py
+++ b/gpt_index/vector_stores/chatgpt_plugin.py
@@ -7,7 +7,7 @@ import requests
 from requests.adapters import HTTPAdapter, Retry
 from tqdm.auto import tqdm
 
-from gpt_index.data_structs.data_structs_v2 import Node
+from gpt_index.data_structs.node_v2 import Node, DocumentRelationship
 from gpt_index.vector_stores.types import (
     NodeEmbeddingResult,
     VectorStore,
@@ -26,7 +26,8 @@ def convert_docs_to_json(embedding_results: List[NodeEmbeddingResult]) -> List[D
             "id": embedding_result.id,
             "text": embedding_result.node.get_text(),
             # "source": embedding_result.node.source,
-            # "source_id": ...,
+            # NOTE: this is the doc_id to reference document
+            "source_id": embedding_result.doc_id,
             # "url": "...",
             # "created_at": ...,
             # "author": "..."",
@@ -142,9 +143,11 @@ class ChatGPTRetrievalPluginClient(VectorStore):
                 result_id = result["id"]
                 result_txt = result["text"]
                 result_score = result["score"]
+                result_ref_doc_id = result["source_id"]
                 node = Node(
                     doc_id=result_id,
                     text=result_txt,
+                    relationships={DocumentRelationship.SOURCE: result_ref_doc_id},
                 )
                 nodes.append(node)
                 similarities.append(result_score)

--- a/gpt_index/vector_stores/pinecone.py
+++ b/gpt_index/vector_stores/pinecone.py
@@ -6,7 +6,7 @@ An index that that is built on top of an existing vector store.
 
 from typing import Any, Dict, List, Optional, cast
 
-from gpt_index.data_structs.node_v2 import Node
+from gpt_index.data_structs.node_v2 import Node, DocumentRelationship
 from gpt_index.vector_stores.types import (
     NodeEmbeddingResult,
     VectorStore,
@@ -120,7 +120,9 @@ class PineconeVectorStore(VectorStore):
 
             metadata = {
                 "text": node.get_text(),
+                # NOTE: this is the reference to source doc
                 "doc_id": result.doc_id,
+                "id": new_id,
             }
             if node.extra_info:
                 # TODO: check if overlap with default metadata keys
@@ -197,9 +199,14 @@ class PineconeVectorStore(VectorStore):
             extra_info = get_node_info_from_metadata(match.metadata, "extra_info")
             node_info = get_node_info_from_metadata(match.metadata, "node_info")
             doc_id = match.metadata["doc_id"]
+            id = match.metadata["id"]
 
             node = Node(
-                text=text, extra_info=extra_info, node_info=node_info, doc_id=doc_id
+                text=text,
+                extra_info=extra_info,
+                node_info=node_info,
+                doc_id=id,
+                relationships={DocumentRelationship.SOURCE: doc_id},
             )
             top_k_ids.append(match.id)
             top_k_nodes.append(node)

--- a/gpt_index/vector_stores/qdrant.py
+++ b/gpt_index/vector_stores/qdrant.py
@@ -207,6 +207,7 @@ class QdrantVectorStore(VectorStore):
         for point in response:
             payload = cast(Payload, point.payload)
             node = Node(
+                doc_id=str(point.id),
                 text=payload.get("text"),
                 extra_info=payload.get("extra_info"),
                 relationships={

--- a/gpt_index/vector_stores/types.py
+++ b/gpt_index/vector_stores/types.py
@@ -15,6 +15,7 @@ class NodeEmbeddingResult:
         id (str): Node id
         node (Node): Node
         embedding (List[float]): Embedding
+        doc_id (str): Document id
 
     """
 


### PR DESCRIPTION
1) fix `new_id` generated in indices/vector_store/base.py. Not sure why we didn't just use `node.get_doc_id()` before
2) fix pinecone to use the actual node id as the returned doc_id, and return "doc_id" as the source doc relationship id instead (this is pretty confusing tbh) 

Tests:
- added two tests for simple vector and faiss to check id's
- manually ran pinecone nb 