### PR TITLE
[Hacky] Fix streaming

### DIFF
--- a/examples/vector_indices/SimpleIndexDemo-streaming-ChatGPT.ipynb
+++ b/examples/vector_indices/SimpleIndexDemo-streaming-ChatGPT.ipynb
@@ -1,0 +1,228 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8d3a8ef8-f387-4b90-9b1c-97d8ca707a02",
+   "metadata": {},
+   "source": [
+    "### Integrating Streaming into LlamaIndex via Callback Manager"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a02cc0b-d9f6-4efd-bc6a-3f8fc534d85b",
+   "metadata": {},
+   "source": [
+    "This demo shows how you can integrate streaming capabilities into a LlamaIndex app through LangChain's callback manager.\n",
+    "\n",
+    "LangChain's callback manager provides an `on_llm_new_token` method that's called for each token returned in a streaming setting.\n",
+    "\n",
+    "The challenge with integrating with LlamaIndex is that we only want `on_llm_new_token` to be called for the *final* response,\n",
+    "rather than for every intermediate response. This notebook below shows you how to set that up.\n",
+    "\n",
+    "Key components:\n",
+    "- `ChatOpenAI` LLM class with `streaming=True`\n",
+    "- `ChatGPTLLMPredictor` with LLM and `CallbackManager` specified\n",
+    "- call `index.query` with `streaming=True`\n",
+    "\n",
+    "A few notes:\n",
+    "- We've provided a demo `StreamStdoutCallbackHandler` that outputs tokens to stdout, but would highly encourage you to develop your own CallbackHandler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "e5ec7f3f-5a90-494c-b035-336063453210",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "import sys\n",
+    "\n",
+    "logging.basicConfig(stream=sys.stdout, level=logging.CRITICAL)\n",
+    "logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))\n",
+    "\n",
+    "# Uncomment if you want to temporarily disable logger\n",
+    "# logger = logging.getLogger()\n",
+    "# logger.disabled = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "ae41886b-ffe7-40f4-a76c-676872b1aa8f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from langchain.chat_models import ChatOpenAI\n",
+    "from langchain.callbacks import CallbackManager\n",
+    "from gpt_index.llm_predictor.chatgpt import ChatGPTLLMPredictor\n",
+    "from gpt_index.langchain_helpers.callbacks import StreamStdoutCallbackHandler\n",
+    "\n",
+    "from gpt_index import GPTSimpleVectorIndex, SimpleDirectoryReader, ServiceContext, LLMPredictor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "7b82d496-3969-47e9-b444-8554533caa5d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# load documents\n",
+    "documents = SimpleDirectoryReader('../paul_graham_essay/data').load_data()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "11a53cc3-44ec-41ca-a0b7-3224682ef8a0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# NOTE: please define your own callback handler/manager\n",
+    "# the StreamCallbackHandler is primarily used for demo purposes\n",
+    "callback_manager = CallbackManager(handlers=[StreamStdoutCallbackHandler()])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "3fe4d81d-353a-4281-b0c3-7c898b5bb58d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# define LLM + LLMPredictor\n",
+    "llm = ChatOpenAI(temperature=0, model_name=\"gpt-3.5-turbo\", streaming=True)\n",
+    "llm_predictor = ChatGPTLLMPredictor(llm=llm, callback_manager=callback_manager)\n",
+    "service_context = ServiceContext.from_defaults(llm_predictor=llm_predictor, chunk_size_limit=1024)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "fa28f579-913f-4014-b4e1-1f352bdf365e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "index = GPTSimpleVectorIndex.from_documents(documents, service_context=service_context)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "a2cf5b35-93e3-4ff2-85f3-d0b9e431c756",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The author worked on writing and programming outside of school growing up. They wrote short stories and tried programming on an IBM 1401 in 9th grade, using an early version of Fortran. With microcomputers, they started programming more and wrote simple games, a rocket prediction program, and a word processor. Despite enjoying programming, they initially planned to study philosophy in college."
+     ]
+    }
+   ],
+   "source": [
+    "response = index.query(\n",
+    "    \"What did the author do growing up?\", \n",
+    "    service_context=service_context,\n",
+    "    streaming=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a09dffb6-a393-437a-814d-7fc87ed5de9e",
+   "metadata": {},
+   "source": [
+    "### Note: What if you just use the callback manager as part of the LLM class directly?\n",
+    "\n",
+    "This means that intermediate LLM calls will also be logged, which may or may not be what you'd want.\n",
+    "\n",
+    "We show an example where we just attach the callback manager to the LLM class, and make 0 modifications on the LlamaIndex side."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "439353be-3680-47c0-aff1-cb1b8b2bd9c5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# define \n",
+    "llm = ChatOpenAI(temperature=0, model_name=\"gpt-3.5-turbo\", streaming=True, callback_manager=callback_manager)\n",
+    "llm_predictor = LLMPredictor(llm=llm)\n",
+    "service_context = ServiceContext.from_defaults(llm_predictor=llm_predictor, chunk_size_limit=1024)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "903ba919-6ced-4d46-86d9-468064fc56ae",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The author worked on writing and programming outside of school when growing up. They wrote short stories and started programming on an IBM 1401 using an early version of Fortran. They later got a TRS-80 microcomputer and started programming simple games, a rocket prediction program, and a word processor.The author worked on writing and programming outside of school when growing up. They wrote short stories and started programming on an IBM 1401 using an early version of Fortran. They later got a TRS-80 microcomputer and started programming simple games, a rocket prediction program, and a word processor. While in a PhD program in computer science at Harvard, the author took art classes and decided to become an artist. They applied to RISD and the Accademia di Belli Arti in Florence and ended up studying at RISD. After finishing the BFA program at RISD, the author received an invitation to take the entrance exam at the Accademia, and despite being a foreigner and having to write an essay in Italian, managed to pass the exam.The context provided is not useful for refining the original answer, which correctly states that the author worked on writing and programming outside of school when growing up and later became an artist after studying at RISD."
+     ]
+    }
+   ],
+   "source": [
+    "response = index.query(\n",
+    "    \"What did the author do growing up?\", \n",
+    "    service_context=service_context,\n",
+    "    similarity_top_k=3\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f40f09b-d19a-4e6b-a615-78e356e190ff",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "llama_index",
+   "language": "python",
+   "name": "llama_index"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/vector_indices/SimpleIndexDemo-streaming.ipynb
+++ b/examples/vector_indices/SimpleIndexDemo-streaming.ipynb
@@ -1,140 +1,140 @@
 {
-    "cells": [
-        {
-            "cell_type": "markdown",
-            "id": "9c48213d-6e6a-4c10-838a-2a7c710c3a05",
-            "metadata": {},
-            "source": [
-                "# Simple Index Demo"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "50d3b817-b70e-4667-be4f-d3a0fe4bd119",
-            "metadata": {},
-            "source": [
-                "#### Load documents, build the GPTSimpleVectorIndex"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 3,
-            "id": "690a6918-7c75-4f95-9ccc-d2c4a1fe00d7",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "import logging\n",
-                "import sys\n",
-                "\n",
-                "logging.basicConfig(stream=sys.stdout, level=logging.INFO)\n",
-                "logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))\n",
-                "\n",
-                "from gpt_index import GPTSimpleVectorIndex, SimpleDirectoryReader\n",
-                "from IPython.display import Markdown, display"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 4,
-            "id": "03d1691e-544b-454f-825b-5ee12f7faa8a",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# load documents\n",
-                "documents = SimpleDirectoryReader('../paul_graham_essay/data').load_data()"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 12,
-            "id": "ad144ee7-96da-4dd6-be00-fd6cf0c78e58",
-            "metadata": {
-                "scrolled": true
-            },
-            "outputs": [
-                {
-                    "name": "stdout",
-                    "output_type": "stream",
-                    "text": [
-                        "INFO:root:> [build_index_from_documents] Total LLM token usage: 0 tokens\n",
-                        "> [build_index_from_documents] Total LLM token usage: 0 tokens\n",
-                        "> [build_index_from_documents] Total LLM token usage: 0 tokens\n",
-                        "INFO:root:> [build_index_from_documents] Total embedding token usage: 18509 tokens\n",
-                        "> [build_index_from_documents] Total embedding token usage: 18509 tokens\n",
-                        "> [build_index_from_documents] Total embedding token usage: 18509 tokens\n"
-                    ]
-                }
-            ],
-            "source": [
-                "index = GPTSimpleVectorIndex.from_documents(documents, chunk_size_limit=1024)"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "b6caf93b-6345-4c65-a346-a95b0f1746c4",
-            "metadata": {},
-            "source": [
-                "#### Query Index"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "85466fdf-93f3-4cb1-a5f9-0056a8245a6f",
-            "metadata": {
-                "scrolled": true
-            },
-            "outputs": [],
-            "source": [
-                "# set Logging to DEBUG for more detailed outputs\n",
-                "response_stream = index.query(\n",
-                "    \"What did the author do growing up?\", \n",
-                "    streaming=True,\n",
-                "    similarity_top_k=1\n",
-                ")"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "16c15a25-15ed-4aed-813a-5c4c9182d7eb",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "response_stream.print_response_stream()"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "bdda1b2c-ae46-47cf-91d7-3153e8d0473b",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# can also get a normal response object\n",
-                "response = response_stream.get_response()"
-            ]
-        }
-    ],
-    "metadata": {
-        "kernelspec": {
-            "display_name": "gpt_retrieve_venv",
-            "language": "python",
-            "name": "gpt_retrieve_venv"
-        },
-        "language_info": {
-            "codemirror_mode": {
-                "name": "ipython",
-                "version": 3
-            },
-            "file_extension": ".py",
-            "mimetype": "text/x-python",
-            "name": "python",
-            "nbconvert_exporter": "python",
-            "pygments_lexer": "ipython3",
-            "version": "3.9.16"
-        }
-    },
-    "nbformat": 4,
-    "nbformat_minor": 5
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9c48213d-6e6a-4c10-838a-2a7c710c3a05",
+   "metadata": {},
+   "source": [
+    "# Simple Index Demo"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50d3b817-b70e-4667-be4f-d3a0fe4bd119",
+   "metadata": {},
+   "source": [
+    "#### Load documents, build the GPTSimpleVectorIndex"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "690a6918-7c75-4f95-9ccc-d2c4a1fe00d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "import sys\n",
+    "\n",
+    "logging.basicConfig(stream=sys.stdout, level=logging.INFO)\n",
+    "logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))\n",
+    "\n",
+    "from gpt_index import GPTSimpleVectorIndex, SimpleDirectoryReader\n",
+    "from IPython.display import Markdown, display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "03d1691e-544b-454f-825b-5ee12f7faa8a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load documents\n",
+    "documents = SimpleDirectoryReader('../paul_graham_essay/data').load_data()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "ad144ee7-96da-4dd6-be00-fd6cf0c78e58",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:> [build_index_from_documents] Total LLM token usage: 0 tokens\n",
+      "> [build_index_from_documents] Total LLM token usage: 0 tokens\n",
+      "> [build_index_from_documents] Total LLM token usage: 0 tokens\n",
+      "INFO:root:> [build_index_from_documents] Total embedding token usage: 18509 tokens\n",
+      "> [build_index_from_documents] Total embedding token usage: 18509 tokens\n",
+      "> [build_index_from_documents] Total embedding token usage: 18509 tokens\n"
+     ]
+    }
+   ],
+   "source": [
+    "index = GPTSimpleVectorIndex.from_documents(documents, chunk_size_limit=1024)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6caf93b-6345-4c65-a346-a95b0f1746c4",
+   "metadata": {},
+   "source": [
+    "#### Query Index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85466fdf-93f3-4cb1-a5f9-0056a8245a6f",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# set Logging to DEBUG for more detailed outputs\n",
+    "response_stream = index.query(\n",
+    "    \"What did the author do growing up?\", \n",
+    "    streaming=True,\n",
+    "    similarity_top_k=1\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16c15a25-15ed-4aed-813a-5c4c9182d7eb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response_stream.print_response_stream()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bdda1b2c-ae46-47cf-91d7-3153e8d0473b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# can also get a normal response object\n",
+    "response = response_stream.get_response()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "llama_index",
+   "language": "python",
+   "name": "llama_index"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/gpt_index/indices/empty/query.py
+++ b/gpt_index/indices/empty/query.py
@@ -59,8 +59,10 @@ class GPTEmptyIndexQuery(BaseGPTIndexQuery[EmptyIndex]):
             )
             return Response(response)
         else:
-            stream_response, _ = self._service_context.llm_predictor.stream(
+            llm_predictor = self._service_context.llm_predictor
+            response, _ = llm_predictor.predict_with_stream(
                 self._input_prompt,
+                is_last=True,
                 query_str=query_bundle.query_str,
             )
-            return StreamingResponse(stream_response)
+            return Response(response)

--- a/gpt_index/indices/response/builder.py
+++ b/gpt_index/indices/response/builder.py
@@ -134,7 +134,7 @@ class ResponseBuilder:
             )
         )
         text_chunks = refine_text_splitter.split_text(text_chunk)
-        for cur_text_chunk in text_chunks:
+        for idx, cur_text_chunk in enumerate(text_chunks):
             if not self._streaming:
                 (
                     response,
@@ -144,8 +144,11 @@ class ResponseBuilder:
                     context_msg=cur_text_chunk,
                 )
             else:
-                response, formatted_prompt = self._service_context.llm_predictor.stream(
+                is_last = idx == len(text_chunks) - 1
+                llm_predictor = self._service_context.llm_predictor
+                response, formatted_prompt = llm_predictor.predict_with_stream(
                     refine_template,
+                    is_last=is_last,
                     context_msg=cur_text_chunk,
                 )
             self._log_prompt_and_response(

--- a/gpt_index/indices/response/builder.py
+++ b/gpt_index/indices/response/builder.py
@@ -171,7 +171,7 @@ class ResponseBuilder:
         text_chunks = qa_text_splitter.split_text(text_chunk)
         response: Optional[RESPONSE_TEXT_TYPE] = None
         # TODO: consolidate with loop in get_response_default
-        for cur_text_chunk in text_chunks:
+        for idx, cur_text_chunk in enumerate(text_chunks):
             if response is None and not self._streaming:
                 (
                     response,
@@ -184,8 +184,11 @@ class ResponseBuilder:
                     formatted_prompt, response, log_prefix="Initial"
                 )
             elif response is None and self._streaming:
-                response, formatted_prompt = self._service_context.llm_predictor.stream(
+                is_last = idx == len(text_chunks) - 1
+                llm_predictor = self._service_context.llm_predictor
+                response, formatted_prompt = llm_predictor.predict_with_stream(
                     text_qa_template,
+                    is_last=is_last,
                     context_str=cur_text_chunk,
                 )
                 self._log_prompt_and_response(

--- a/gpt_index/langchain_helpers/callbacks.py
+++ b/gpt_index/langchain_helpers/callbacks.py
@@ -1,0 +1,97 @@
+from abc import ABC, abstractmethod
+from langchain.callbacks.base import BaseCallbackHandler
+from typing import Dict, Any, List, Union
+from langchain.schema import AgentAction, AgentFinish, LLMResult
+
+
+class StreamStdoutCallbackHandler(BaseCallbackHandler):
+    """Streaming stdout callback handler.
+
+    NOTE: this is used for demo purposes, would highly encourage you to develop your own
+    callback handler.
+
+    """
+
+    @property
+    def always_verbose(self) -> bool:
+        """Whether to call verbose callbacks even if verbose is False."""
+        return True
+
+    @property
+    def ignore_llm(self) -> bool:
+        """Whether to ignore LLM callbacks."""
+        return False
+
+    @property
+    def ignore_chain(self) -> bool:
+        """Whether to ignore chain callbacks."""
+        return False
+
+    @property
+    def ignore_agent(self) -> bool:
+        """Whether to ignore agent callbacks."""
+        return False
+
+    def on_llm_start(
+        self, serialized: Dict[str, Any], prompts: List[str], **kwargs: Any
+    ) -> Any:
+        """Run when LLM starts running."""
+        pass
+
+    def on_llm_new_token(self, token: str, **kwargs: Any) -> Any:
+        """Run on new LLM token. Only available when streaming is enabled."""
+        print(token, end="")
+
+    def on_llm_end(self, response: LLMResult, **kwargs: Any) -> Any:
+        """Run when LLM ends running."""
+        pass
+
+    def on_llm_error(
+        self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
+    ) -> Any:
+        """Run when LLM errors."""
+        pass
+
+    def on_chain_start(
+        self, serialized: Dict[str, Any], inputs: Dict[str, Any], **kwargs: Any
+    ) -> Any:
+        """Run when chain starts running."""
+        pass
+
+    def on_chain_end(self, outputs: Dict[str, Any], **kwargs: Any) -> Any:
+        """Run when chain ends running."""
+        pass
+
+    def on_chain_error(
+        self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
+    ) -> Any:
+        """Run when chain errors."""
+        pass
+
+    def on_tool_start(
+        self, serialized: Dict[str, Any], input_str: str, **kwargs: Any
+    ) -> Any:
+        """Run when tool starts running."""
+        pass
+
+    def on_tool_end(self, output: str, **kwargs: Any) -> Any:
+        """Run when tool ends running."""
+        pass
+
+    def on_tool_error(
+        self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
+    ) -> Any:
+        """Run when tool errors."""
+        pass
+
+    def on_text(self, text: str, **kwargs: Any) -> Any:
+        """Run on arbitrary text."""
+        pass
+
+    def on_agent_action(self, action: AgentAction, **kwargs: Any) -> Any:
+        """Run on agent action."""
+        pass
+
+    def on_agent_finish(self, finish: AgentFinish, **kwargs: Any) -> Any:
+        """Run on agent end."""
+        pass

--- a/gpt_index/llm_predictor/base.py
+++ b/gpt_index/llm_predictor/base.py
@@ -104,7 +104,7 @@ class BaseLLMPredictor(Protocol):
         prompt: Prompt,
         is_last: bool = False,
         **prompt_args: Any,
-    ) -> Tuple[Generator, str]:
+    ) -> Tuple[str, str]:
         """Stream the answer to a query.
 
         NOTE: this is a beta feature. Will try to build or use
@@ -241,7 +241,7 @@ class LLMPredictor(BaseLLMPredictor):
         return llm_prediction, formatted_prompt
 
     def predict_with_stream(
-        self, prompt: Prompt, **prompt_args: Any
+        self, prompt: Prompt, is_last: bool = False, **prompt_args: Any
     ) -> Tuple[str, str]:
         """Predict the answer to a query.
 

--- a/gpt_index/llm_predictor/chatgpt.py
+++ b/gpt_index/llm_predictor/chatgpt.py
@@ -130,7 +130,7 @@ class ChatGPTLLMPredictor(LLMPredictor):
         """
         # try casting to validate
         try:
-            cast(BaseChatModel, self._llm)
+            llm = cast(BaseChatModel, self._llm)
         except Exception:
             raise ValueError("LLM must be a BaseChatModel to use predict_with_stream")
 
@@ -141,8 +141,8 @@ class ChatGPTLLMPredictor(LLMPredictor):
 
         # only set callback manager if it's the last response generated from the LLM
         if not is_last:
-            self._llm.callback_manager = None
+            llm.callback_manager = None
         else:
-            self._llm.callback_manager = self._callback_manager
+            llm.callback_manager = self._callback_manager
 
         return self.predict(prompt, **prompt_args)

--- a/gpt_index/llm_predictor/chatgpt.py
+++ b/gpt_index/llm_predictor/chatgpt.py
@@ -15,7 +15,7 @@ from langchain.prompts.chat import (
 )
 from langchain.prompts.prompt import PromptTemplate
 from langchain.schema import BaseLanguageModel, BaseMessage
-from langchain.callbacks.base import BaseCallbackHandler
+from langchain.callbacks.base import BaseCallbackManager
 
 from gpt_index.llm_predictor.base import LLMPredictor
 from gpt_index.prompts.base import Prompt
@@ -47,7 +47,7 @@ class ChatGPTLLMPredictor(LLMPredictor):
         prepend_messages: Optional[
             List[Union[BaseMessagePromptTemplate, BaseMessage]]
         ] = None,
-        callback_handler: Optional[BaseCallbackHandler] = None,
+        callback_manager: Optional[BaseCallbackManager] = None,
         **kwargs: Any
     ) -> None:
         """Initialize params."""
@@ -55,7 +55,7 @@ class ChatGPTLLMPredictor(LLMPredictor):
             llm=llm or ChatOpenAI(temperature=0, model_name="gpt-3.5-turbo"), **kwargs
         )
         self.prepend_messages = prepend_messages
-        self._callback_manager = callback_handler
+        self._callback_manager = callback_manager
 
     def _get_langchain_prompt(
         self, prompt: Prompt
@@ -141,8 +141,8 @@ class ChatGPTLLMPredictor(LLMPredictor):
 
         # only set callback manager if it's the last response generated from the LLM
         if not is_last:
-            self._llm.callback_manager(None)
+            self._llm.callback_manager = None
         else:
-            self._llm.callback_manager(self._callback_manager)
+            self._llm.callback_manager = self._callback_manager
 
         return self.predict(prompt, **prompt_args)

--- a/gpt_index/llm_predictor/structured.py
+++ b/gpt_index/llm_predictor/structured.py
@@ -18,6 +18,13 @@ class StructuredLLMPredictor(LLMPredictor):
 
     """
 
+    def predict_with_stream(
+        self, prompt: Prompt, is_last: bool = False, **prompt_args: Any
+    ) -> Tuple[str, str]:
+        raise NotImplementedError(
+            "Streaming is not supported for structured LLM predictor."
+        )
+
     def predict(self, prompt: Prompt, **prompt_args: Any) -> Tuple[str, str]:
         """Predict the answer to a query.
 

--- a/gpt_index/readers/slack.py
+++ b/gpt_index/readers/slack.py
@@ -4,7 +4,7 @@ import os
 import time
 from datetime import datetime
 from ssl import SSLContext
-from typing import List, Optional
+from typing import List, Optional, cast
 
 from gpt_index.readers.base import BaseReader
 from gpt_index.readers.schema.base import Document


### PR DESCRIPTION
LangChain's callback manager provides an `on_llm_new_token` method that's called for each token returned in a streaming setting.

The challenge with integrating with LlamaIndex is that we only want `on_llm_new_token` to be called for the *final* response,
rather than for every intermediate response. This notebook below shows you how to set that up.

Key components:
- `ChatOpenAI` LLM class with `streaming=True`
- `ChatGPTLLMPredictor` with LLM and `CallbackManager` specified
- call `index.query` with `streaming=True`

A few notes:
- We've provided a demo `StreamStdoutCallbackHandler` that outputs tokens to stdout, but would highly encourage you to develop your own CallbackHandler

Tbh this solution is pretty hacky - for composed graphs it will still stream "multiple" intermediate responses. 
This API will probably change in the near future