### PR TITLE
Fix bug with delete

### DIFF
--- a/gpt_index/data_structs/data_structs_v2.py
+++ b/gpt_index/data_structs/data_structs_v2.py
@@ -183,7 +183,6 @@ class IndexDict(V2IndexStruct):
     def add_node(
         self,
         node: Node,
-        # NOTE: unused
         text_id: Optional[str] = None,
     ) -> str:
         """Add text to table, return current position in list."""
@@ -204,6 +203,7 @@ class IndexDict(V2IndexStruct):
             raise ValueError("doc_id not found in doc_id_dict")
         for vector_id in self.doc_id_dict[doc_id]:
             del self.nodes_dict[vector_id]
+        del self.doc_id_dict[doc_id]
 
     @classmethod
     def get_type(cls) -> IndexStructType:

--- a/tests/indices/vector_store/test_base.py
+++ b/tests/indices/vector_store/test_base.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
-from gpt_index.data_structs.node_v2 import Node
+from gpt_index.data_structs.node_v2 import DocumentRelationship, Node
 from gpt_index.embeddings.openai import OpenAIEmbedding
 from gpt_index.indices.vector_store.vector_indices import (
     GPTFaissIndex,
@@ -17,7 +17,6 @@ from gpt_index.readers.schema.base import Document
 from gpt_index.vector_stores.simple import SimpleVectorStore
 from tests.mock_utils.mock_decorator import patch_common
 from tests.mock_utils.mock_prompts import MOCK_REFINE_PROMPT, MOCK_TEXT_QA_PROMPT
-from gpt_index.data_structs.node_v2 import DocumentRelationship
 
 
 @pytest.fixture
@@ -397,6 +396,7 @@ def test_simple_delete(
     # test delete
     index.delete("test_id_0")
     assert len(index.index_struct.nodes_dict) == 3
+    assert len(index.index_struct.doc_id_dict) == 3
     actual_node_tups = [
         ("This is a test.", [0, 1, 0, 0, 0], "test_id_1"),
         ("This is another test.", [0, 0, 1, 0, 0], "test_id_2"),


### PR DESCRIPTION
There was a small bug with delete.

A few users have noticed some odd behaviour whenever delete is called (including refresh, update, etc.) I think this should fix it!

The specific bug I was testing went like this:

```
doc1 = Document("test1", doc_id="test1")
doc2 = Document("test2", doc_id="test2")

index = GPTSimpleVectorIndex.from_documents([doc1, doc2])

doc1.text = "new_test1"
index.update(doc1)
doc1.text = "new_new_test1"
index.update(doc1)   # <-- this causes a key error in current version
print('done!')
```