### PR TITLE
Fix index delete - again!

### DIFF
--- a/gpt_index/data_structs/data_structs_v2.py
+++ b/gpt_index/data_structs/data_structs_v2.py
@@ -183,7 +183,6 @@ class IndexDict(V2IndexStruct):
     def add_node(
         self,
         node: Node,
-        # NOTE: unused
         text_id: Optional[str] = None,
     ) -> str:
         """Add text to table, return current position in list."""
@@ -204,6 +203,7 @@ class IndexDict(V2IndexStruct):
             raise ValueError("doc_id not found in doc_id_dict")
         for vector_id in self.doc_id_dict[doc_id]:
             del self.nodes_dict[vector_id]
+        del self.doc_id_dict[doc_id]
 
     @classmethod
     def get_type(cls) -> IndexStructType:

--- a/gpt_index/data_structs/data_structs_v2.py
+++ b/gpt_index/data_structs/data_structs_v2.py
@@ -200,7 +200,7 @@ class IndexDict(V2IndexStruct):
     def delete(self, doc_id: str) -> None:
         """Delete a Node."""
         if doc_id not in self.doc_id_dict:
-            raise ValueError("doc_id not found in doc_id_dict")
+            return
         for vector_id in self.doc_id_dict[doc_id]:
             del self.nodes_dict[vector_id]
         del self.doc_id_dict[doc_id]

--- a/tests/indices/vector_store/test_base.py
+++ b/tests/indices/vector_store/test_base.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
-from gpt_index.data_structs.node_v2 import Node
+from gpt_index.data_structs.node_v2 import DocumentRelationship, Node
 from gpt_index.embeddings.openai import OpenAIEmbedding
 from gpt_index.indices.vector_store.vector_indices import (
     GPTFaissIndex,
@@ -17,7 +17,6 @@ from gpt_index.readers.schema.base import Document
 from gpt_index.vector_stores.simple import SimpleVectorStore
 from tests.mock_utils.mock_decorator import patch_common
 from tests.mock_utils.mock_prompts import MOCK_REFINE_PROMPT, MOCK_TEXT_QA_PROMPT
-from gpt_index.data_structs.node_v2 import DocumentRelationship
 
 
 @pytest.fixture
@@ -397,6 +396,7 @@ def test_simple_delete(
     # test delete
     index.delete("test_id_0")
     assert len(index.index_struct.nodes_dict) == 3
+    assert len(index.index_struct.doc_id_dict) == 3
     actual_node_tups = [
         ("This is a test.", [0, 1, 0, 0, 0], "test_id_1"),
         ("This is another test.", [0, 0, 1, 0, 0], "test_id_2"),


### PR DESCRIPTION
One more delete bug!

If you construct a vector index using the documents from the client, calling delete will never work if we raise a ValueError

```python
index = GPTQdrantIndex([], client=qdrant_client_instance, collection_name=self._collection_name)
index.delete("some_remote_id")
```