### PR TITLE
Select more rules for ruff

### DIFF
--- a/benchmarks/struct_indices/spider/evaluate.py
+++ b/benchmarks/struct_indices/spider/evaluate.py
@@ -8,11 +8,11 @@ from typing import Dict, List, Optional
 
 from langchain.chat_models import ChatOpenAI
 from langchain.schema import HumanMessage
-from gpt_index.response.schema import Response
 from spider_utils import create_indexes, load_examples
 from tqdm import tqdm
 
 from gpt_index.indices.struct_store.sql import GPTSQLStructStoreIndex
+from gpt_index.response.schema import Response
 
 logging.getLogger("root").setLevel(logging.WARNING)
 

--- a/gpt_index/composability/joint_qa_summary.py
+++ b/gpt_index/composability/joint_qa_summary.py
@@ -1,15 +1,15 @@
 """Joint QA Summary graph."""
 
 
-from typing import Sequence, Optional
+from typing import Optional, Sequence
 
-from gpt_index.indices.service_context import ServiceContext
 from gpt_index.composability import ComposableGraph
+from gpt_index.docstore import DocumentStore
 from gpt_index.indices.list.base import GPTListIndex
+from gpt_index.indices.service_context import ServiceContext
 from gpt_index.indices.tree.base import GPTTreeIndex
 from gpt_index.indices.vector_store.vector_indices import GPTSimpleVectorIndex
 from gpt_index.readers.schema.base import Document
-from gpt_index.docstore import DocumentStore
 
 DEFAULT_SUMMARY_TEXT = "Use this index for summarization queries"
 DEFAULT_QA_TEXT = (

--- a/gpt_index/data_structs/node_v2.py
+++ b/gpt_index/data_structs/node_v2.py
@@ -8,16 +8,15 @@ about its relationship to other `Node` objects (and `Document` objects).
 
 It is often used as an atomic unit of data in various indices.
 """
+import logging
+import warnings
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from typing import Any, Dict, Optional
-import warnings
 
 from dataclasses_json import DataClassJsonMixin
 
 from gpt_index.schema import BaseDocument
-
-import logging
 
 _logger = logging.getLogger(__name__)
 

--- a/gpt_index/evaluation/base.py
+++ b/gpt_index/evaluation/base.py
@@ -67,7 +67,7 @@ class ResponseEvaluator:
             1. context_response -> comparing context \
             information and response.
             2. others coming soon!
-    
+
     """
 
     def __init__(

--- a/gpt_index/indices/composability/graph.py
+++ b/gpt_index/indices/composability/graph.py
@@ -4,10 +4,9 @@ import json
 from typing import Any, Dict, List, Optional, Sequence, Type, Union, cast
 
 from gpt_index.constants import DOCSTORE_KEY, INDEX_STRUCT_KEY
-from gpt_index.data_structs.data_structs_v2 import CompositeIndex
-from gpt_index.data_structs.data_structs_v2 import V2IndexStruct
+from gpt_index.data_structs.data_structs_v2 import CompositeIndex, V2IndexStruct
 from gpt_index.data_structs.data_structs_v2 import V2IndexStruct as IndexStruct
-from gpt_index.data_structs.node_v2 import IndexNode, DocumentRelationship
+from gpt_index.data_structs.node_v2 import DocumentRelationship, IndexNode
 from gpt_index.docstore import DocumentStore
 from gpt_index.indices.base import BaseGPTIndex
 from gpt_index.indices.query.query_runner import QueryRunner

--- a/gpt_index/indices/empty/query.py
+++ b/gpt_index/indices/empty/query.py
@@ -2,8 +2,8 @@
 from typing import Any, List, Optional
 
 from gpt_index.data_structs.data_structs_v2 import EmptyIndex
-from gpt_index.indices.query.base import BaseGPTIndexQuery
 from gpt_index.data_structs.node_v2 import NodeWithScore
+from gpt_index.indices.query.base import BaseGPTIndexQuery
 from gpt_index.indices.query.schema import QueryBundle
 from gpt_index.prompts.default_prompts import DEFAULT_SIMPLE_INPUT_PROMPT
 from gpt_index.prompts.prompts import SimpleInputPrompt

--- a/gpt_index/indices/keyword_table/base.py
+++ b/gpt_index/indices/keyword_table/base.py
@@ -15,12 +15,12 @@ from gpt_index.async_utils import run_async_tasks
 from gpt_index.data_structs.data_structs_v2 import KeywordTable
 from gpt_index.data_structs.node_v2 import Node
 from gpt_index.indices.base import BaseGPTIndex, QueryMap
-from gpt_index.indices.keyword_table.utils import extract_keywords_given_response
 from gpt_index.indices.keyword_table.query import (
     GPTKeywordTableGPTQuery,
     GPTKeywordTableRAKEQuery,
     GPTKeywordTableSimpleQuery,
 )
+from gpt_index.indices.keyword_table.utils import extract_keywords_given_response
 from gpt_index.indices.query.schema import QueryMode
 from gpt_index.indices.service_context import ServiceContext
 from gpt_index.prompts.default_prompts import (

--- a/gpt_index/indices/postprocessor/__init__.py
+++ b/gpt_index/indices/postprocessor/__init__.py
@@ -3,10 +3,10 @@
 
 from gpt_index.indices.postprocessor.base import BasePostprocessor
 from gpt_index.indices.postprocessor.node import (
-    SimilarityPostprocessor,
+    AutoPrevNextNodePostprocessor,
     KeywordNodePostprocessor,
     PrevNextNodePostprocessor,
-    AutoPrevNextNodePostprocessor,
+    SimilarityPostprocessor,
 )
 
 __all__ = [

--- a/gpt_index/indices/postprocessor/node.py
+++ b/gpt_index/indices/postprocessor/node.py
@@ -1,20 +1,20 @@
 """Node postprocessor."""
 
+import logging
 import re
 from abc import abstractmethod
 from typing import Dict, List, Optional, cast
 
 from pydantic import BaseModel, Field, validator
 
-import logging
-from gpt_index.indices.query.schema import QueryBundle
-from gpt_index.indices.service_context import ServiceContext
-from gpt_index.prompts.prompts import QuestionAnswerPrompt, RefinePrompt
+from gpt_index.data_structs.node_v2 import DocumentRelationship, Node
 from gpt_index.docstore import DocumentStore
-from gpt_index.data_structs.node_v2 import Node, DocumentRelationship
 from gpt_index.indices.postprocessor.base import BasePostprocessor
 from gpt_index.indices.query.embedding_utils import SimilarityTracker
+from gpt_index.indices.query.schema import QueryBundle
 from gpt_index.indices.response.builder import ResponseBuilder, TextChunk
+from gpt_index.indices.service_context import ServiceContext
+from gpt_index.prompts.prompts import QuestionAnswerPrompt, RefinePrompt
 
 logger = logging.getLogger(__name__)
 

--- a/gpt_index/indices/query/query_runner.py
+++ b/gpt_index/indices/query/query_runner.py
@@ -5,8 +5,7 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
-from gpt_index.data_structs.data_structs_v2 import CompositeIndex
-from gpt_index.data_structs.data_structs_v2 import V2IndexStruct
+from gpt_index.data_structs.data_structs_v2 import CompositeIndex, V2IndexStruct
 from gpt_index.data_structs.data_structs_v2 import V2IndexStruct as IndexStruct
 from gpt_index.data_structs.node_v2 import IndexNode, Node, NodeWithScore
 from gpt_index.data_structs.struct_type import IndexStructType

--- a/gpt_index/indices/query/query_transform/__init__.py
+++ b/gpt_index/indices/query/query_transform/__init__.py
@@ -1,8 +1,8 @@
 """Query Transforms."""
 
 from gpt_index.indices.query.query_transform.base import (
-    HyDEQueryTransform,
     DecomposeQueryTransform,
+    HyDEQueryTransform,
     StepDecomposeQueryTransform,
 )
 

--- a/gpt_index/indices/registry.py
+++ b/gpt_index/indices/registry.py
@@ -5,8 +5,8 @@ from typing import Any, Dict, Type
 from gpt_index.constants import DATA_KEY, TYPE_KEY
 from gpt_index.data_structs.data_structs_v2 import (
     KG,
+    ChatGPTRetrievalPluginIndexDict,
     ChromaIndexDict,
-    OpensearchIndexDict,
     CompositeIndex,
     EmptyIndex,
     FaissIndexDict,
@@ -14,12 +14,12 @@ from gpt_index.data_structs.data_structs_v2 import (
     IndexGraph,
     IndexList,
     KeywordTable,
+    OpensearchIndexDict,
     PineconeIndexDict,
     QdrantIndexDict,
     SimpleIndexDict,
     V2IndexStruct,
     WeaviateIndexDict,
-    ChatGPTRetrievalPluginIndexDict,
 )
 from gpt_index.data_structs.struct_type import IndexStructType
 from gpt_index.data_structs.table_v2 import PandasStructTable, SQLStructTable
@@ -33,14 +33,14 @@ from gpt_index.indices.struct_store.sql import GPTSQLStructStoreIndex
 from gpt_index.indices.tree.base import GPTTreeIndex
 from gpt_index.indices.vector_store.base import GPTVectorStoreIndex
 from gpt_index.indices.vector_store.vector_indices import (
+    ChatGPTRetrievalPluginIndex,
     GPTChromaIndex,
     GPTFaissIndex,
+    GPTOpensearchIndex,
     GPTPineconeIndex,
     GPTQdrantIndex,
     GPTSimpleVectorIndex,
     GPTWeaviateIndex,
-    ChatGPTRetrievalPluginIndex,
-    GPTOpensearchIndex,
 )
 
 INDEX_STRUCT_TYPE_TO_INDEX_STRUCT_CLASS: Dict[IndexStructType, Type[V2IndexStruct]] = {

--- a/gpt_index/indices/struct_store/pandas.py
+++ b/gpt_index/indices/struct_store/pandas.py
@@ -2,14 +2,14 @@
 
 from typing import Any, Optional, Sequence
 
+import pandas as pd
+
 from gpt_index.data_structs.node_v2 import Node
 from gpt_index.data_structs.table_v2 import PandasStructTable
 from gpt_index.indices.base import QueryMap
 from gpt_index.indices.query.schema import QueryMode
 from gpt_index.indices.struct_store.base import BaseGPTStructStoreIndex
 from gpt_index.indices.struct_store.pandas_query import GPTNLPandasIndexQuery
-
-import pandas as pd
 
 
 class GPTPandasIndex(BaseGPTStructStoreIndex[PandasStructTable]):

--- a/gpt_index/indices/struct_store/sql.py
+++ b/gpt_index/indices/struct_store/sql.py
@@ -2,6 +2,8 @@
 import json
 from typing import Any, Dict, Optional, Sequence
 
+from sqlalchemy import Table
+
 from gpt_index.data_structs.node_v2 import Node
 from gpt_index.data_structs.table_v2 import SQLStructTable
 from gpt_index.indices.base import BaseGPTIndex, QueryMap
@@ -16,7 +18,6 @@ from gpt_index.indices.struct_store.sql_query import (
     GPTSQLStructStoreIndexQuery,
 )
 from gpt_index.langchain_helpers.sql_wrapper import SQLDatabase
-from sqlalchemy import Table
 
 
 class GPTSQLStructStoreIndex(BaseGPTStructStoreIndex[SQLStructTable]):

--- a/gpt_index/indices/tree/base.py
+++ b/gpt_index/indices/tree/base.py
@@ -8,12 +8,12 @@ from gpt_index.data_structs.node_v2 import Node
 from gpt_index.indices.base import BaseGPTIndex, QueryMap
 from gpt_index.indices.common_tree.base import GPTTreeIndexBuilder
 from gpt_index.indices.query.schema import QueryMode
+from gpt_index.indices.service_context import ServiceContext
 from gpt_index.indices.tree.embedding_query import GPTTreeIndexEmbeddingQuery
+from gpt_index.indices.tree.inserter import GPTTreeIndexInserter
 from gpt_index.indices.tree.leaf_query import GPTTreeIndexLeafQuery
 from gpt_index.indices.tree.retrieve_query import GPTTreeIndexRetQuery
 from gpt_index.indices.tree.summarize_query import GPTTreeIndexSummarizeQuery
-from gpt_index.indices.service_context import ServiceContext
-from gpt_index.indices.tree.inserter import GPTTreeIndexInserter
 from gpt_index.prompts.default_prompts import (
     DEFAULT_INSERT_PROMPT,
     DEFAULT_SUMMARY_PROMPT,

--- a/gpt_index/indices/vector_store/queries.py
+++ b/gpt_index/indices/vector_store/queries.py
@@ -3,6 +3,8 @@
 
 from typing import Any, Dict, Optional
 
+from requests.adapters import Retry
+
 from gpt_index.data_structs.data_structs_v2 import IndexDict
 from gpt_index.indices.vector_store.base_query import GPTVectorStoreIndexQuery
 from gpt_index.vector_stores import (
@@ -16,7 +18,6 @@ from gpt_index.vector_stores import (
     WeaviateVectorStore,
 )
 from gpt_index.vector_stores.opensearch import OpensearchVectorClient
-from requests.adapters import Retry
 
 
 class GPTSimpleVectorIndexQuery(GPTVectorStoreIndexQuery):

--- a/gpt_index/indices/vector_store/vector_indices.py
+++ b/gpt_index/indices/vector_store/vector_indices.py
@@ -18,6 +18,8 @@ from gpt_index.data_structs.data_structs_v2 import (
 from gpt_index.data_structs.node_v2 import Node
 from gpt_index.indices.base import BaseGPTIndex, QueryMap
 from gpt_index.indices.query.schema import QueryMode
+from gpt_index.indices.service_context import ServiceContext
+from gpt_index.indices.vector_store.base import GPTVectorStoreIndex
 from gpt_index.indices.vector_store.queries import (
     ChatGPTRetrievalPluginQuery,
     GPTChromaIndexQuery,
@@ -28,8 +30,6 @@ from gpt_index.indices.vector_store.queries import (
     GPTSimpleVectorIndexQuery,
     GPTWeaviateIndexQuery,
 )
-from gpt_index.indices.service_context import ServiceContext
-from gpt_index.indices.vector_store.base import GPTVectorStoreIndex
 from gpt_index.vector_stores import (
     ChatGPTRetrievalPluginClient,
     ChromaVectorStore,

--- a/gpt_index/langchain_helpers/agents/agents.py
+++ b/gpt_index/langchain_helpers/agents/agents.py
@@ -3,9 +3,9 @@
 from typing import Any, Optional
 
 from langchain.agents import AgentExecutor, initialize_agent
+from langchain.agents.agent_types import AgentType
 from langchain.callbacks import BaseCallbackManager
 from langchain.llms.base import BaseLLM
-from langchain.agents.agent_types import AgentType
 
 from gpt_index.langchain_helpers.agents.toolkits import LlamaToolkit
 

--- a/gpt_index/langchain_helpers/agents/tools.py
+++ b/gpt_index/langchain_helpers/agents/tools.py
@@ -5,8 +5,8 @@ from typing import Dict, List, cast
 from langchain.tools import BaseTool
 from pydantic import BaseModel, Field
 
-from gpt_index.indices.composability.graph import QUERY_CONFIG_TYPE, ComposableGraph
 from gpt_index.indices.base import BaseGPTIndex
+from gpt_index.indices.composability.graph import QUERY_CONFIG_TYPE, ComposableGraph
 
 
 class IndexToolConfig(BaseModel):

--- a/gpt_index/langchain_helpers/memory_wrapper.py
+++ b/gpt_index/langchain_helpers/memory_wrapper.py
@@ -3,9 +3,8 @@
 from typing import Any, Dict, List, Optional
 
 from langchain.memory.chat_memory import BaseChatMemory
-from langchain.schema import AIMessage
+from langchain.schema import AIMessage, BaseMessage, HumanMessage
 from langchain.schema import BaseMemory as Memory
-from langchain.schema import BaseMessage, HumanMessage
 from pydantic import Field
 
 from gpt_index.indices.base import BaseGPTIndex

--- a/gpt_index/langchain_helpers/sql_wrapper.py
+++ b/gpt_index/langchain_helpers/sql_wrapper.py
@@ -1,5 +1,5 @@
 """SQL wrapper around SQLDatabase in langchain."""
-from typing import Any, Dict, List, Tuple, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from langchain.sql_database import SQLDatabase as LangchainSQLDatabase
 from sqlalchemy import MetaData, create_engine, insert, text

--- a/gpt_index/node_parser/__init__.py
+++ b/gpt_index/node_parser/__init__.py
@@ -1,6 +1,6 @@
 """Node parsers."""
 
-from gpt_index.node_parser.simple import SimpleNodeParser
 from gpt_index.node_parser.interface import NodeParser
+from gpt_index.node_parser.simple import SimpleNodeParser
 
 __all__ = ["SimpleNodeParser", "NodeParser"]

--- a/gpt_index/node_parser/interface.py
+++ b/gpt_index/node_parser/interface.py
@@ -1,7 +1,6 @@
 """Node parser interface."""
-from typing import List, Sequence
-
 from abc import ABC, abstractmethod
+from typing import List, Sequence
 
 from gpt_index.data_structs.node_v2 import Node
 from gpt_index.readers.schema.base import Document

--- a/gpt_index/node_parser/simple.py
+++ b/gpt_index/node_parser/simple.py
@@ -3,9 +3,9 @@ from typing import List, Optional, Sequence
 
 from gpt_index.data_structs.node_v2 import Node
 from gpt_index.langchain_helpers.text_splitter import TextSplitter, TokenTextSplitter
+from gpt_index.node_parser.interface import NodeParser
 from gpt_index.node_parser.node_utils import get_nodes_from_document
 from gpt_index.readers.schema.base import Document
-from gpt_index.node_parser.interface import NodeParser
 
 
 class SimpleNodeParser(NodeParser):

--- a/gpt_index/readers/make_com/wrapper.py
+++ b/gpt_index/readers/make_com/wrapper.py
@@ -7,8 +7,8 @@ Currently cannot load documents.
 from typing import Any, List, Optional
 
 import requests
-from gpt_index.data_structs.node_v2 import Node, NodeWithScore
 
+from gpt_index.data_structs.node_v2 import Node, NodeWithScore
 from gpt_index.readers.base import BaseReader
 from gpt_index.readers.schema.base import Document
 from gpt_index.response.schema import Response

--- a/gpt_index/response/notebook_utils.py
+++ b/gpt_index/response/notebook_utils.py
@@ -2,8 +2,8 @@
 from typing import Any, Dict, Tuple
 
 from IPython.display import Markdown, display
-from gpt_index.data_structs.node_v2 import ImageNode, NodeWithScore
 
+from gpt_index.data_structs.node_v2 import ImageNode, NodeWithScore
 from gpt_index.img_utils import b64_2_img
 from gpt_index.response.schema import Response
 from gpt_index.utils import truncate_text

--- a/gpt_index/tools/migrate_v1_to_v2.py
+++ b/gpt_index/tools/migrate_v1_to_v2.py
@@ -43,7 +43,9 @@ from gpt_index.data_structs.data_structs_v2 import (
 )
 from gpt_index.data_structs.data_structs_v2 import QdrantIndexDict as V2QdrantIndexDict
 from gpt_index.data_structs.data_structs_v2 import SimpleIndexDict as V2SimpleIndexDict
-from gpt_index.data_structs.data_structs_v2 import V2IndexStruct
+from gpt_index.data_structs.data_structs_v2 import (
+    V2IndexStruct,
+)
 from gpt_index.data_structs.data_structs_v2 import (
     WeaviateIndexDict as V2WeaviateIndexDict,
 )
@@ -51,8 +53,8 @@ from gpt_index.data_structs.node_v2 import DocumentRelationship
 from gpt_index.data_structs.node_v2 import ImageNode as V2ImageNode
 from gpt_index.data_structs.node_v2 import Node as V2Node
 from gpt_index.data_structs.struct_type import IndexStructType
-from gpt_index.old_docstore import V1DocumentStore
 from gpt_index.docstore import DocumentStore as V2DocumentStore
+from gpt_index.old_docstore import V1DocumentStore
 from gpt_index.tools.file_utils import add_prefix_suffix_to_file_path
 
 INDEX_STRUCT_TYPE_TO_V1_INDEX_STRUCT_CLASS: Dict[IndexStructType, Type[IndexStruct]] = {

--- a/gpt_index/types.py
+++ b/gpt_index/types.py
@@ -1,4 +1,3 @@
 from typing import Generator, Union
 
-
 RESPONSE_TEXT_TYPE = Union[str, Generator]

--- a/gpt_index/vector_stores/chatgpt_plugin.py
+++ b/gpt_index/vector_stores/chatgpt_plugin.py
@@ -7,7 +7,7 @@ import requests
 from requests.adapters import HTTPAdapter, Retry
 from tqdm.auto import tqdm
 
-from gpt_index.data_structs.node_v2 import Node, DocumentRelationship
+from gpt_index.data_structs.node_v2 import DocumentRelationship, Node
 from gpt_index.vector_stores.types import (
     NodeEmbeddingResult,
     VectorStore,

--- a/gpt_index/vector_stores/pinecone.py
+++ b/gpt_index/vector_stores/pinecone.py
@@ -6,7 +6,7 @@ An index that that is built on top of an existing vector store.
 
 from typing import Any, Dict, List, Optional, cast
 
-from gpt_index.data_structs.node_v2 import Node, DocumentRelationship
+from gpt_index.data_structs.node_v2 import DocumentRelationship, Node
 from gpt_index.vector_stores.types import (
     NodeEmbeddingResult,
     VectorStore,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,4 +23,5 @@ select = [
     "F",
     # Pycodestyle
     "E",
+    "W",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,4 +19,6 @@ exclude = [
 select = [
     # isort
     "I",
+    # Pyflakes
+    "F",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,4 +21,6 @@ select = [
     "I",
     # Pyflakes
     "F",
+    # Pycodestyle
+    "E",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,8 @@ disallow_untyped_defs = "True"
 exclude = ["notebooks", "build", "examples"]
 
 [tool.ruff]
+fix = true
+
 exclude = [
     ".venv",
     "__pycache__",
@@ -12,4 +14,9 @@ exclude = [
     ".ruff_cache",
     "examples",
     "notebooks",
+]
+
+select = [
+    # isort
+    "I",
 ]

--- a/tests/indices/embedding/test_base.py
+++ b/tests/indices/embedding/test_base.py
@@ -9,8 +9,8 @@ import pytest
 from gpt_index.data_structs.node_v2 import Node
 from gpt_index.embeddings.base import mean_agg
 from gpt_index.embeddings.openai import OpenAIEmbedding
-from gpt_index.indices.tree.embedding_query import GPTTreeIndexEmbeddingQuery
 from gpt_index.indices.tree.base import GPTTreeIndex
+from gpt_index.indices.tree.embedding_query import GPTTreeIndexEmbeddingQuery
 from gpt_index.langchain_helpers.chain_wrapper import (
     LLMChain,
     LLMMetadata,

--- a/tests/indices/knowledge_graph/test_base.py
+++ b/tests/indices/knowledge_graph/test_base.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Tuple
 from unittest.mock import patch
 
 import pytest
+
 from gpt_index.data_structs.node_v2 import Node
 from gpt_index.embeddings.openai import OpenAIEmbedding
 from gpt_index.indices.knowledge_graph.base import GPTKnowledgeGraphIndex

--- a/tests/indices/list/test_base.py
+++ b/tests/indices/list/test_base.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Tuple, cast
 from unittest.mock import patch
 
 import pytest
+
 from gpt_index.data_structs.node_v2 import Node
 from gpt_index.indices.list.base import GPTListIndex
 from gpt_index.indices.list.embedding_query import GPTListIndexEmbeddingQuery

--- a/tests/indices/postprocessor/test_base.py
+++ b/tests/indices/postprocessor/test_base.py
@@ -2,9 +2,9 @@
 
 import pytest
 
-from gpt_index.data_structs.node_v2 import Node, DocumentRelationship
-from gpt_index.indices.postprocessor.node import PrevNextNodePostprocessor
+from gpt_index.data_structs.node_v2 import DocumentRelationship, Node
 from gpt_index.docstore import DocumentStore
+from gpt_index.indices.postprocessor.node import PrevNextNodePostprocessor
 
 
 def test_forward_back_processor() -> None:

--- a/tests/indices/struct_store/test_base.py
+++ b/tests/indices/struct_store/test_base.py
@@ -1,12 +1,11 @@
 """Test struct store indices."""
 
-import re
 import asyncio
+import re
 from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import patch
 
 import pytest
-
 from sqlalchemy import (
     Column,
     Integer,
@@ -25,8 +24,8 @@ from gpt_index.indices.struct_store.sql import (
     GPTSQLStructStoreIndex,
     SQLContextContainerBuilder,
 )
-from gpt_index.langchain_helpers.sql_wrapper import SQLDatabase
 from gpt_index.langchain_helpers.chain_wrapper import LLMPredictor
+from gpt_index.langchain_helpers.sql_wrapper import SQLDatabase
 from gpt_index.readers.schema.base import Document
 from gpt_index.schema import BaseDocument
 from tests.mock_utils.mock_decorator import patch_common

--- a/tests/indices/vector_store/test_pinecone.py
+++ b/tests/indices/vector_store/test_pinecone.py
@@ -1,7 +1,7 @@
 """Test pinecone indexes."""
 
 import sys
-from typing import Any, Dict, List, Tuple, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -9,7 +9,6 @@ import pytest
 
 from gpt_index.embeddings.openai import OpenAIEmbedding
 from gpt_index.indices.vector_store.vector_indices import GPTPineconeIndex
-
 from gpt_index.readers.schema.base import Document
 from tests.mock_utils.mock_decorator import patch_common
 from tests.mock_utils.mock_prompts import MOCK_REFINE_PROMPT, MOCK_TEXT_QA_PROMPT

--- a/tests/tools/test_migrate_v1_to_v2.py
+++ b/tests/tools/test_migrate_v1_to_v2.py
@@ -14,8 +14,8 @@ from gpt_index.data_structs.data_structs_v2 import SimpleIndexDict as V2SimpleIn
 from gpt_index.data_structs.data_structs_v2 import V2IndexStruct
 from gpt_index.data_structs.node_v2 import ImageNode as V2ImageNode
 from gpt_index.data_structs.struct_type import IndexStructType
-from gpt_index.old_docstore import V1DocumentStore
 from gpt_index.docstore import DocumentStore as V2DocumentStore
+from gpt_index.old_docstore import V1DocumentStore
 from gpt_index.tools.migrate_v1_to_v2 import (
     convert_to_v2_dict,
     convert_to_v2_index_struct_and_docstore,


### PR DESCRIPTION
- Selects `isort`, `Pycodestyle`, and `Pyflakes` rules in `ruff` configuration
- Leaving out `McCabe` complexity rules for now
- Also sets `fix` to `True` so `ruff` will automatically fix errors when it lints