### PR TITLE
[WIP] change vector store query interface / support initial hybrid search (for pinecone) 

### DIFF
--- a/examples/vector_indices/PineconeIndexDemo-Hybrid.ipynb
+++ b/examples/vector_indices/PineconeIndexDemo-Hybrid.ipynb
@@ -1,0 +1,267 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "307804a3-c02b-4a57-ac0d-172c30ddc851",
+   "metadata": {},
+   "source": [
+    "# Pinecone Index Demo"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7010b1d-d1bb-4f08-9309-a328bb4ea396",
+   "metadata": {},
+   "source": [
+    "#### Creating a Pinecone Index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d48af8e1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "import sys\n",
+    "\n",
+    "logging.basicConfig(stream=sys.stdout, level=logging.INFO)\n",
+    "logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "0ce3143d-198c-4dd2-8e5a-c5cdf94f017a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/jerryliu/Programming/gpt_index/.venv/lib/python3.10/site-packages/pinecone/index.py:4: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from tqdm.autonotebook import tqdm\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pinecone"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "4ad14111-0bbb-4c62-906d-6d6253e0cdee",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "api_key = \"\"\n",
+    "pinecone.init(api_key=api_key, environment=\"us-west1-gcp\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "9755c30e-0f7b-4f0b-bba9-890a6da6b967",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "IndexDescription(name='quickstart', metric='dotproduct', replicas=1, dimension=1536.0, shards=1, pods=1, pod_type='p1.x1', status={'ready': True, 'state': 'Ready'}, metadata_config=None, source_collection='')"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pinecone.describe_index(\"quickstart\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "c2c90087-bdd9-4ca4-b06b-2af883559f88",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# dimensions are for text-embedding-ada-002\n",
+    "# NOTE: needs dotproduct for hybrid search\n",
+    "pinecone.create_index(\"quickstart\", dimension=1536, metric=\"dotproduct\", pod_type=\"p1\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "667f3cb3-ce18-48d5-b9aa-bfc1a1f0f0f6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "pinecone_index = pinecone.Index(\"quickstart\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ee4473a-094f-4d0a-a825-e1213db07240",
+   "metadata": {},
+   "source": [
+    "#### Load documents, build the GPTPineconeIndex"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "0a2bcc07",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from gpt_index import GPTPineconeIndex, SimpleDirectoryReader\n",
+    "from IPython.display import Markdown, display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "68cbd239-880e-41a3-98d8-dbb3fab55431",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# load documents\n",
+    "documents = SimpleDirectoryReader('../paul_graham_essay/data').load_data()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "ba1558b3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:gpt_index.vector_stores.pinecone:If directly passing in client, cannot automatically reconstruct connetion after save_to_disk/load_from_disk.For automatic reload, store PINECONE_API_KEY in env variable and pass in index_name and environment instead.\n",
+      "If directly passing in client, cannot automatically reconstruct connetion after save_to_disk/load_from_disk.For automatic reload, store PINECONE_API_KEY in env variable and pass in index_name and environment instead.\n",
+      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
+      "> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
+      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total embedding token usage: 17617 tokens\n",
+      "> [build_index_from_nodes] Total embedding token usage: 17617 tokens\n"
+     ]
+    }
+   ],
+   "source": [
+    "# set add_sparse_vector=True to compute sparse vectors during upsert\n",
+    "index = GPTPineconeIndex.from_documents(documents, pinecone_index=pinecone_index, add_sparse_vector=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04304299-fc3e-40a0-8600-f50c3292767e",
+   "metadata": {},
+   "source": [
+    "#### Query Index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "35369eda",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:gpt_index.token_counter.token_counter:> [query] Total LLM token usage: 4061 tokens\n",
+      "> [query] Total LLM token usage: 4061 tokens\n",
+      "INFO:gpt_index.token_counter.token_counter:> [query] Total embedding token usage: 8 tokens\n",
+      "> [query] Total embedding token usage: 8 tokens\n"
+     ]
+    }
+   ],
+   "source": [
+    "# set Logging to DEBUG for more detailed outputs\n",
+    "response = index.query(\"What did the author do growing up?\", vector_store_search_mode=\"hybrid\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "bedbb693-725f-478f-be26-fa7180ea38b2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<b>\n",
+       "\n",
+       "The author grew up writing short stories, programming on an IBM 1401, and working on microcomputers. He wrote simple games, a program to predict how high his model rockets would fly, and a word processor. He studied philosophy in college, but switched to AI. He reverse-engineered SHRDLU for his undergraduate thesis and wrote a book about Lisp hacking. He visited the Carnegie Institute and realized he could make art that would last. He took art classes at Harvard and applied to RISD and the Accademia di Belli Arti in Florence, where he arrived at an arrangement whereby the students wouldn't require the faculty to teach anything, and in return the faculty wouldn't require the students to learn anything. He also started painting still lives in his bedroom at night, using leftover scraps of canvas.</b>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(Markdown(f\"<b>{response}</b>\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc4c41d3-cbaf-4989-bfbd-b8a26e52d3e8",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "llama_index",
+   "language": "python",
+   "name": "llama_index"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gpt_index/indices/vector_store/base_query.py
+++ b/gpt_index/indices/vector_store/base_query.py
@@ -5,14 +5,17 @@ from typing import Any, List, Optional
 
 from gpt_index.data_structs.data_structs_v2 import IndexDict
 
-# from gpt_index.data_structs.data_structs import IndexDict, Node
 from gpt_index.data_structs.node_v2 import Node
 from gpt_index.indices.query.base import BaseGPTIndexQuery
 from gpt_index.indices.query.embedding_utils import SimilarityTracker
 from gpt_index.indices.query.schema import QueryBundle
 from gpt_index.indices.service_context import ServiceContext
 from gpt_index.indices.utils import log_vector_store_query_result
-from gpt_index.vector_stores.types import VectorStore
+from gpt_index.vector_stores.types import (
+    VectorStore,
+    VectorStoreQuery,
+    VectorStoreQueryMode,
+)
 
 
 class GPTVectorStoreIndexQuery(BaseGPTIndexQuery[IndexDict]):
@@ -31,6 +34,7 @@ class GPTVectorStoreIndexQuery(BaseGPTIndexQuery[IndexDict]):
         service_context: ServiceContext,
         vector_store: Optional[VectorStore] = None,
         similarity_top_k: int = 1,
+        vector_store_search_mode: str = VectorStoreQueryMode.DEFAULT,
         **kwargs: Any,
     ) -> None:
         """Initialize params."""
@@ -41,6 +45,7 @@ class GPTVectorStoreIndexQuery(BaseGPTIndexQuery[IndexDict]):
         if vector_store is None:
             raise ValueError("Vector store is required for vector store query.")
         self._vector_store = vector_store
+        self._vector_store_query_mode = VectorStoreQueryMode(vector_store_search_mode)
 
     def _retrieve(
         self,
@@ -54,19 +59,15 @@ class GPTVectorStoreIndexQuery(BaseGPTIndexQuery[IndexDict]):
                         query_bundle.embedding_strs
                     )
                 )
-            query_result = self._vector_store.query(
-                query_bundle.embedding,
-                self._similarity_top_k,
-                self._doc_ids,
-            )
-        else:
-            # TODO: fix function signature of query
-            query_result = self._vector_store.query(
-                [],
-                self._similarity_top_k,
-                self._doc_ids,
-                query_str=query_bundle.query_str,
-            )
+
+        query = VectorStoreQuery(
+            query_embedding=query_bundle.embedding,
+            similarity_top_k=self._similarity_top_k,
+            doc_ids=self._doc_ids,
+            query_str=query_bundle.query_str,
+            mode=self._vector_store_query_mode,
+        )
+        query_result = self._vector_store.query(query)
 
         if query_result.nodes is None:
             # NOTE: vector store does not keep text and returns node indices.

--- a/gpt_index/indices/vector_store/base_query.py
+++ b/gpt_index/indices/vector_store/base_query.py
@@ -34,7 +34,7 @@ class GPTVectorStoreIndexQuery(BaseGPTIndexQuery[IndexDict]):
         service_context: ServiceContext,
         vector_store: Optional[VectorStore] = None,
         similarity_top_k: int = 1,
-        vector_store_search_mode: str = VectorStoreQueryMode.DEFAULT,
+        vector_store_query_mode: str = VectorStoreQueryMode.DEFAULT,
         **kwargs: Any,
     ) -> None:
         """Initialize params."""
@@ -45,7 +45,7 @@ class GPTVectorStoreIndexQuery(BaseGPTIndexQuery[IndexDict]):
         if vector_store is None:
             raise ValueError("Vector store is required for vector store query.")
         self._vector_store = vector_store
-        self._vector_store_query_mode = VectorStoreQueryMode(vector_store_search_mode)
+        self._vector_store_query_mode = VectorStoreQueryMode(vector_store_query_mode)
 
     def _retrieve(
         self,

--- a/gpt_index/indices/vector_store/vector_indices.py
+++ b/gpt_index/indices/vector_store/vector_indices.py
@@ -1,6 +1,6 @@
 """Deprecated vector store indices."""
 
-from typing import Any, Dict, Optional, Sequence, Type
+from typing import Any, Dict, Optional, Sequence, Type, Callable
 
 from requests.adapters import Retry
 
@@ -214,6 +214,8 @@ class GPTPineconeIndex(GPTVectorStoreIndex):
         index_struct: Optional[IndexDict] = None,
         service_context: Optional[ServiceContext] = None,
         vector_store: Optional[PineconeVectorStore] = None,
+        add_sparse_vector: bool = False,
+        tokenizer: Optional[Callable] = None,
         **kwargs: Any,
     ) -> None:
         """Init params."""
@@ -229,6 +231,8 @@ class GPTPineconeIndex(GPTVectorStoreIndex):
                 insert_kwargs=insert_kwargs,
                 query_kwargs=query_kwargs,
                 delete_kwargs=delete_kwargs,
+                add_sparse_vector=add_sparse_vector,
+                tokenizer=tokenizer,
             )
         assert vector_store is not None
 

--- a/gpt_index/vector_stores/chatgpt_plugin.py
+++ b/gpt_index/vector_stores/chatgpt_plugin.py
@@ -12,6 +12,7 @@ from gpt_index.vector_stores.types import (
     NodeEmbeddingResult,
     VectorStore,
     VectorStoreQueryResult,
+    VectorStoreQuery,
 )
 
 
@@ -128,17 +129,14 @@ class ChatGPTRetrievalPluginClient(VectorStore):
 
     def query(
         self,
-        query_embedding: List[float],
-        similarity_top_k: int,
-        doc_ids: Optional[List[str]] = None,
-        query_str: Optional[str] = None,
+        query: VectorStoreQuery,
     ) -> VectorStoreQueryResult:
         """Get nodes for response."""
-        if query_str is None:
+        if query.query_str is None:
             raise ValueError("query_str must be provided")
         headers = {"Authorization": f"Bearer {self._bearer_token}"}
         # TODO: add metadata filter
-        queries = [{"query": query_str, "top_k": similarity_top_k}]
+        queries = [{"query": query.query_str, "top_k": query.similarity_top_k}]
         res = requests.post(
             f"{self._endpoint_url}/query", headers=headers, json={"queries": queries}
         )

--- a/gpt_index/vector_stores/chroma.py
+++ b/gpt_index/vector_stores/chroma.py
@@ -1,7 +1,7 @@
 """Chroma vector store."""
 import logging
 import math
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, cast
 
 from gpt_index.data_structs.node_v2 import DocumentRelationship, Node
 from gpt_index.utils import truncate_text

--- a/gpt_index/vector_stores/chroma.py
+++ b/gpt_index/vector_stores/chroma.py
@@ -8,6 +8,7 @@ from gpt_index.utils import truncate_text
 from gpt_index.vector_stores.types import (
     NodeEmbeddingResult,
     VectorStore,
+    VectorStoreQuery,
     VectorStoreQueryResult,
 )
 
@@ -97,13 +98,7 @@ class ChromaVectorStore(VectorStore):
         """Return client."""
         return self._collection
 
-    def query(
-        self,
-        query_embedding: List[float],
-        similarity_top_k: int,
-        doc_ids: Optional[List[str]] = None,
-        query_str: Optional[str] = None,
-    ) -> VectorStoreQueryResult:
+    def query(self, query: VectorStoreQuery) -> VectorStoreQueryResult:
         """Query index for top k most similar nodes.
 
         Args:
@@ -112,7 +107,7 @@ class ChromaVectorStore(VectorStore):
 
         """
         results = self._collection.query(
-            query_embeddings=query_embedding, n_results=similarity_top_k
+            query_embeddings=query.query_embedding, n_results=query.similarity_top_k
         )
 
         logger.debug(f"> Top {len(results['documents'])} nodes:")

--- a/gpt_index/vector_stores/faiss.py
+++ b/gpt_index/vector_stores/faiss.py
@@ -12,6 +12,7 @@ from gpt_index.vector_stores.types import (
     NodeEmbeddingResult,
     VectorStore,
     VectorStoreQueryResult,
+    VectorStoreQuery,
 )
 
 
@@ -131,10 +132,7 @@ class FaissVectorStore(VectorStore):
 
     def query(
         self,
-        query_embedding: List[float],
-        similarity_top_k: int,
-        doc_ids: Optional[List[str]] = None,
-        query_str: Optional[str] = None,
+        query: VectorStoreQuery,
     ) -> VectorStoreQueryResult:
         """Query index for top k most similar nodes.
 
@@ -143,8 +141,11 @@ class FaissVectorStore(VectorStore):
             similarity_top_k (int): top k most similar nodes
 
         """
+        query_embedding = cast(List[float], query.query_embedding)
         query_embedding_np = np.array(query_embedding, dtype="float32")[np.newaxis, :]
-        dists, indices = self._faiss_index.search(query_embedding_np, similarity_top_k)
+        dists, indices = self._faiss_index.search(
+            query_embedding_np, query.similarity_top_k
+        )
         dists = [d for d in dists[0]]
         # if empty, then return an empty response
         if len(indices) == 0:

--- a/gpt_index/vector_stores/opensearch.py
+++ b/gpt_index/vector_stores/opensearch.py
@@ -1,12 +1,13 @@
 """Elasticsearch/Opensearch vector store."""
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 from gpt_index.data_structs import Node
 from gpt_index.vector_stores.types import (
     NodeEmbeddingResult,
     VectorStore,
     VectorStoreQueryResult,
+    VectorStoreQuery,
 )
 
 
@@ -194,13 +195,7 @@ class OpensearchVectorStore(VectorStore):
         """
         self._client.delete_doc_id(doc_id)
 
-    def query(
-        self,
-        query_embedding: List[float],
-        similarity_top_k: int,
-        doc_ids: Optional[List[str]] = None,
-        query_str: Optional[str] = None,
-    ) -> VectorStoreQueryResult:
+    def query(self, query: VectorStoreQuery) -> VectorStoreQueryResult:
         """Query index for top k most similar nodes.
 
         Args:
@@ -208,4 +203,5 @@ class OpensearchVectorStore(VectorStore):
             similarity_top_k (int): top k most similar nodes
 
         """
-        return self._client.do_approx_knn(query_embedding, similarity_top_k)
+        query_embedding = cast(List[float], query.query_embedding)
+        return self._client.do_approx_knn(query_embedding, query.similarity_top_k)

--- a/gpt_index/vector_stores/pinecone.py
+++ b/gpt_index/vector_stores/pinecone.py
@@ -5,14 +5,18 @@ An index that that is built on top of an existing vector store.
 """
 
 import os
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Optional, cast, Callable
+from functools import partial
 
 from gpt_index.data_structs.node_v2 import Node, DocumentRelationship
 from gpt_index.vector_stores.types import (
     NodeEmbeddingResult,
     VectorStore,
     VectorStoreQueryResult,
+    VectorStoreQuery,
+    VectorStoreQueryMode,
 )
+from collections import Counter
 import logging
 
 _logger = logging.getLogger(__name__)
@@ -39,6 +43,43 @@ def get_node_info_from_metadata(
     return node_extra_info
 
 
+def build_dict(input_batch: List[List[int]]) -> List[Dict[str, Any]]:
+    """Build a list of sparse dictionaries from a batch of input_ids.
+
+    NOTE: taken from https://www.pinecone.io/learn/hybrid-search-intro/.
+
+    """
+    # store a batch of sparse embeddings
+    sparse_emb = []
+    # iterate through input batch
+    for token_ids in input_batch:
+        indices = []
+        values = []
+        # convert the input_ids list to a dictionary of key to frequency values
+        d = dict(Counter(token_ids))
+        for idx in d:
+            indices.append(idx)
+            values.append(float(d[idx]))
+        sparse_emb.append({"indices": indices, "values": values})
+    # return sparse_emb list
+    return sparse_emb
+
+
+def generate_sparse_vectors(
+    context_batch: List[str], tokenizer: Callable
+) -> List[Dict[str, Any]]:
+    """Generate sparse vectors from a batch of contexts.
+
+    NOTE: taken from https://www.pinecone.io/learn/hybrid-search-intro/.
+
+    """
+    # create batch of input_ids
+    inputs = tokenizer(context_batch)["input_ids"]
+    # create sparse dictionaries
+    sparse_embeds = build_dict(inputs)
+    return sparse_embeds
+
+
 class PineconeVectorStore(VectorStore):
     """Pinecone Vector Store.
 
@@ -56,6 +97,8 @@ class PineconeVectorStore(VectorStore):
         insert_kwargs (Optional[Dict]): insert kwargs during `upsert` call.
         query_kwargs (Optional[Dict]): query kwargs during `query` call.
         delete_kwargs (Optional[Dict]): delete kwargs during `delete` call.
+        add_sparse_vector (bool): whether to add sparse vector to index.
+        tokenizer (Optional[Callable]): tokenizer to use to generate sparse
 
     """
 
@@ -71,6 +114,8 @@ class PineconeVectorStore(VectorStore):
         insert_kwargs: Optional[Dict] = None,
         query_kwargs: Optional[Dict] = None,
         delete_kwargs: Optional[Dict] = None,
+        add_sparse_vector: bool = False,
+        tokenizer: Optional[Callable] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize params."""
@@ -123,6 +168,22 @@ class PineconeVectorStore(VectorStore):
             self._query_kwargs = query_kwargs or {}
             self._delete_kwargs = delete_kwargs or {}
 
+        self._add_sparse_vector = add_sparse_vector
+        if tokenizer is None:
+            from transformers import BertTokenizerFast
+
+            orig_tokenizer = BertTokenizerFast.from_pretrained("bert-base-uncased")
+            # set some default arguments, so input is just a list of strings
+            tokenizer = partial(
+                orig_tokenizer,
+                padding=True,
+                truncation=True,
+                max_length=512,
+                # taking this out because causing errors
+                # special_tokens=False,
+            )
+        self._tokenizer = tokenizer
+
     @classmethod
     def from_dict(cls, config_dict: Dict[str, Any]) -> "VectorStore":
         return cls(**config_dict)
@@ -138,6 +199,7 @@ class PineconeVectorStore(VectorStore):
             "insert_kwargs": self._insert_kwargs,
             "query_kwargs": self._query_kwargs,
             "delete_kwargs": self._delete_kwargs,
+            "add_sparse_vector": self._add_sparse_vector,
         }
 
     def add(
@@ -183,9 +245,18 @@ class PineconeVectorStore(VectorStore):
                     f"metadata keys: {intersecting_keys}"
                 )
             metadata.update(self._metadata_filters)
-            self._pinecone_index.upsert(
-                [(new_id, text_embedding, metadata)], **self._pinecone_kwargs
-            )
+
+            entry = {
+                "id": new_id,
+                "values": text_embedding,
+                "metadata": metadata,
+            }
+            if self._add_sparse_vector:
+                sparse_vector = generate_sparse_vectors(
+                    [node.get_text()], self._tokenizer
+                )[0]
+                entry.update({"sparse_values": sparse_vector})
+            self._pinecone_index.upsert([entry], **self._pinecone_kwargs)
             ids.append(new_id)
         return ids
 
@@ -206,13 +277,7 @@ class PineconeVectorStore(VectorStore):
         """Return Pinecone client."""
         return self._pinecone_index
 
-    def query(
-        self,
-        query_embedding: List[float],
-        similarity_top_k: int,
-        doc_ids: Optional[List[str]] = None,
-        query_str: Optional[str] = None,
-    ) -> VectorStoreQueryResult:
+    def query(self, query: VectorStoreQuery) -> VectorStoreQueryResult:
         """Query index for top k most similar nodes.
 
         Args:
@@ -220,9 +285,19 @@ class PineconeVectorStore(VectorStore):
             similarity_top_k (int): top k most similar nodes
 
         """
+        sparse_vector = None
+        if query.mode in (VectorStoreQueryMode.SPARSE, VectorStoreQueryMode.HYBRID):
+            sparse_vector = generate_sparse_vectors([query.query_str], self._tokenizer)[
+                0
+            ]
+        query_embedding = None
+        if query.mode in (VectorStoreQueryMode.DEFAULT, VectorStoreQueryMode.HYBRID):
+            query_embedding = cast(List[float], query.query_embedding)
+
         response = self._pinecone_index.query(
-            query_embedding,
-            top_k=similarity_top_k,
+            vector=query_embedding,
+            sparse_vector=sparse_vector,
+            top_k=query.similarity_top_k,
             include_values=True,
             include_metadata=True,
             filter=self._metadata_filters,

--- a/gpt_index/vector_stores/qdrant.py
+++ b/gpt_index/vector_stores/qdrant.py
@@ -12,6 +12,7 @@ from gpt_index.vector_stores.types import (
     NodeEmbeddingResult,
     VectorStore,
     VectorStoreQueryResult,
+    VectorStoreQuery,
 )
 
 logger = logging.getLogger(__name__)
@@ -158,10 +159,7 @@ class QdrantVectorStore(VectorStore):
 
     def query(
         self,
-        query_embedding: List[float],
-        similarity_top_k: int,
-        doc_ids: Optional[List[str]] = None,
-        query_str: Optional[str] = None,
+        query: VectorStoreQuery,
     ) -> VectorStoreQueryResult:
         """Query index for top k most similar nodes.
 
@@ -178,18 +176,20 @@ class QdrantVectorStore(VectorStore):
             Payload,
         )
 
+        query_embedding = cast(List[float], query.query_embedding)
+
         response = self._client.search(
             collection_name=self._collection_name,
             query_vector=query_embedding,
-            limit=cast(int, similarity_top_k),
+            limit=cast(int, query.similarity_top_k),
             query_filter=None
-            if not doc_ids
+            if not query.doc_ids
             else Filter(
                 must=[
                     Filter(
                         should=[
                             FieldCondition(key="doc_id", match=MatchValue(value=doc_id))
-                            for doc_id in doc_ids
+                            for doc_id in query.doc_ids
                         ],
                     )
                 ]

--- a/gpt_index/vector_stores/simple.py
+++ b/gpt_index/vector_stores/simple.py
@@ -1,7 +1,7 @@
 """Simple vector store index."""
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 from dataclasses_json import DataClassJsonMixin
 
@@ -10,6 +10,7 @@ from gpt_index.vector_stores.types import (
     NodeEmbeddingResult,
     VectorStore,
     VectorStoreQueryResult,
+    VectorStoreQuery,
 )
 
 
@@ -95,10 +96,7 @@ class SimpleVectorStore(VectorStore):
 
     def query(
         self,
-        query_embedding: List[float],
-        similarity_top_k: int,
-        doc_ids: Optional[List[str]] = None,
-        query_str: Optional[str] = None,
+        query: VectorStoreQuery,
     ) -> VectorStoreQueryResult:
         """Get nodes for response."""
         # TODO: consolidate with get_query_text_embedding_similarities
@@ -106,10 +104,12 @@ class SimpleVectorStore(VectorStore):
         node_ids = [t[0] for t in items]
         embeddings = [t[1] for t in items]
 
+        query_embedding = cast(List[float], query.query_embedding)
+
         top_similarities, top_ids = get_top_k_embeddings(
             query_embedding,
             embeddings,
-            similarity_top_k=similarity_top_k,
+            similarity_top_k=query.similarity_top_k,
             embedding_ids=node_ids,
         )
 

--- a/gpt_index/vector_stores/types.py
+++ b/gpt_index/vector_stores/types.py
@@ -4,6 +4,7 @@
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
 
+from enum import Enum
 from gpt_index.data_structs.node_v2 import Node
 
 
@@ -32,6 +33,28 @@ class VectorStoreQueryResult:
     nodes: Optional[List[Node]] = None
     similarities: Optional[List[float]] = None
     ids: Optional[List[str]] = None
+
+
+class VectorStoreQueryMode(str, Enum):
+    """Vector store query mode."""
+
+    DEFAULT = "default"
+    SPARSE = "sparse"
+    HYBRID = "hybrid"
+
+
+@dataclass
+class VectorStoreQuery:
+    """Vector store query."""
+
+    # dense embedding
+    query_embedding: Optional[List[float]] = None
+    similarity_top_k: int = 1
+    doc_ids: Optional[List[str]] = None
+    query_str: Optional[str] = None
+
+    # NOTE: current mode
+    mode: VectorStoreQueryMode = VectorStoreQueryMode.DEFAULT
 
 
 @runtime_checkable
@@ -68,10 +91,11 @@ class VectorStore(Protocol):
 
     def query(
         self,
-        query_embedding: List[float],
-        similarity_top_k: int,
-        doc_ids: Optional[List[str]] = None,
-        query_str: Optional[str] = None,
+        query: VectorStoreQuery,
+        # query_embedding: List[float],
+        # similarity_top_k: int,
+        # doc_ids: Optional[List[str]] = None,
+        # query_str: Optional[str] = None,
     ) -> VectorStoreQueryResult:
         """Query vector store."""
         ...

--- a/gpt_index/vector_stores/weaviate.py
+++ b/gpt_index/vector_stores/weaviate.py
@@ -12,6 +12,7 @@ from gpt_index.vector_stores.types import (
     NodeEmbeddingResult,
     VectorStore,
     VectorStoreQueryResult,
+    VectorStoreQuery,
 )
 
 
@@ -108,13 +109,7 @@ class WeaviateVectorStore(VectorStore):
         """
         WeaviateNode.delete_document(self._client, doc_id, self._class_prefix)
 
-    def query(
-        self,
-        query_embedding: List[float],
-        similarity_top_k: int,
-        doc_ids: Optional[List[str]] = None,
-        query_str: Optional[str] = None,
-    ) -> VectorStoreQueryResult:
+    def query(self, query: VectorStoreQuery) -> VectorStoreQueryResult:
         """Query index for top k most similar nodes.
 
         Args:
@@ -122,13 +117,14 @@ class WeaviateVectorStore(VectorStore):
             similarity_top_k (int): top k most similar nodes
 
         """
+        query_embedding = cast(List[float], query.query_embedding)
         nodes = WeaviateNode.to_gpt_index_list(
             self.client,
             self._class_prefix,
             vector=query_embedding,
-            object_limit=similarity_top_k,
+            object_limit=query.similarity_top_k,
         )
-        nodes = nodes[:similarity_top_k]
+        nodes = nodes[: query.similarity_top_k]
         node_idxs = [str(i) for i in range(len(nodes))]
 
         return VectorStoreQueryResult(nodes=nodes, ids=node_idxs)

--- a/tests/indices/composability/test_utils.py
+++ b/tests/indices/composability/test_utils.py
@@ -9,6 +9,7 @@ from gpt_index.vector_stores.types import (
     NodeEmbeddingResult,
     VectorStore,
     VectorStoreQueryResult,
+    VectorStoreQuery,
 )
 
 
@@ -45,13 +46,7 @@ class MockVectorStore(VectorStore):
         """Delete doc."""
         raise NotImplementedError()
 
-    def query(
-        self,
-        query_embedding: List[float],
-        similarity_top_k: int,
-        doc_ids: Optional[List[str]] = None,
-        query_str: Optional[str] = None,
-    ) -> VectorStoreQueryResult:
+    def query(self, query: VectorStoreQuery) -> VectorStoreQueryResult:
         """Query vector store."""
         raise NotImplementedError()
 

--- a/tests/indices/query/test_compose_vector.py
+++ b/tests/indices/query/test_compose_vector.py
@@ -536,6 +536,7 @@ def test_recursive_query_pinecone_pinecone(
         [pinecone1, pinecone2, pinecone3, pinecone4],
         index_summaries=summaries,
         pinecone_index=pinecone_index5,
+        tokenizer=mock_tokenizer,
         **pinecone_kwargs
     )
     query_str = "Foo?"
@@ -553,7 +554,12 @@ def test_recursive_query_pinecone_pinecone(
     with TemporaryDirectory() as tmpdir:
         graph.save_to_disk(str(Path(tmpdir) / "tmp.json"))
         query_context_kwargs = {
-            index_id: {"vector_store": {"pinecone_index": pinecone_index}}
+            index_id: {
+                "vector_store": {
+                    "pinecone_index": pinecone_index,
+                    "tokenizer": mock_tokenizer,
+                }
+            }
             for index_id, pinecone_index in zip(
                 [
                     pinecone1.index_struct.index_id,

--- a/tests/indices/query/test_compose_vector.py
+++ b/tests/indices/query/test_compose_vector.py
@@ -37,6 +37,7 @@ from tests.mock_utils.mock_prompts import (
     MOCK_TEXT_QA_PROMPT,
 )
 from tests.mock_utils.mock_text_splitter import mock_token_splitter_newline
+from tests.mock_utils.mock_utils import mock_tokenizer
 
 
 @pytest.fixture
@@ -500,16 +501,28 @@ def test_recursive_query_pinecone_pinecone(
     # use a diff set of documents
     # try building a list for every two, then a tree
     pinecone1 = GPTPineconeIndex.from_documents(
-        documents[0:2], pinecone_index=pinecone_index1, **pinecone_kwargs
+        documents[0:2],
+        pinecone_index=pinecone_index1,
+        tokenizer=mock_tokenizer,
+        **pinecone_kwargs
     )
     pinecone2 = GPTPineconeIndex.from_documents(
-        documents[2:4], pinecone_index=pinecone_index2, **pinecone_kwargs
+        documents[2:4],
+        pinecone_index=pinecone_index2,
+        tokenizer=mock_tokenizer,
+        **pinecone_kwargs
     )
     pinecone3 = GPTPineconeIndex.from_documents(
-        documents[4:6], pinecone_index=pinecone_index3, **pinecone_kwargs
+        documents[4:6],
+        pinecone_index=pinecone_index3,
+        tokenizer=mock_tokenizer,
+        **pinecone_kwargs
     )
     pinecone4 = GPTPineconeIndex.from_documents(
-        documents[6:8], pinecone_index=pinecone_index4, **pinecone_kwargs
+        documents[6:8],
+        pinecone_index=pinecone_index4,
+        tokenizer=mock_tokenizer,
+        **pinecone_kwargs
     )
 
     summary1 = "foo bar"

--- a/tests/indices/vector_store/test_pinecone.py
+++ b/tests/indices/vector_store/test_pinecone.py
@@ -14,6 +14,8 @@ from tests.indices.vector_store.utils import MockPineconeIndex
 from tests.mock_utils.mock_decorator import patch_common
 from tests.mock_utils.mock_prompts import MOCK_REFINE_PROMPT, MOCK_TEXT_QA_PROMPT
 
+from tests.mock_utils.mock_utils import mock_tokenizer
+
 
 @pytest.fixture
 def struct_kwargs() -> Tuple[Dict, Dict]:
@@ -103,7 +105,10 @@ def test_build_pinecone(
     index_kwargs, query_kwargs = struct_kwargs
 
     index = GPTPineconeIndex.from_documents(
-        documents=documents, pinecone_index=pinecone_index, **index_kwargs
+        documents=documents,
+        pinecone_index=pinecone_index,
+        tokenizer=mock_tokenizer,
+        **index_kwargs
     )
 
     response = index.query("What is?", **query_kwargs)


### PR DESCRIPTION
1) abstracted query args in vector store to VectorStoreQuery dataclass. Allows us to add more configurable arguments to each query call (including the search mode like dense/sparse/hybrid

2) implemented basic sparse vector encoding + querying for pinecone, following this guide. https://docs.pinecone.io/docs/hybrid-search. Helps to enable hybrid search.

Need to fix some tests but tested on pinecone nb and it seems to work 