### PR TITLE
update environment setup to include windows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,6 +180,12 @@ python -m venv .venv
 source .venv/bin/activate
 ```
 
+if you are in windows, use the following to activate your virtual environment:
+
+```bash
+.venv\scripts\activate
+```
+
 Install the required dependencies (this will also install gpt-index through `pip install -e .` 
 so that you can start developing on it):
 


### PR DESCRIPTION
when I was setting up my dev environment, I found the instructions for Windows were missing in the environment setup section. I've updated the docs to include the activation instruction for Windows