### PR TITLE
QdrantVectorStore new index creation fix

### DIFF
--- a/gpt_index/vector_stores/qdrant.py
+++ b/gpt_index/vector_stores/qdrant.py
@@ -14,6 +14,7 @@ from gpt_index.vector_stores.types import (
     VectorStoreQueryResult,
     VectorStoreQuery,
 )
+from qdrant_client.http.exceptions import UnexpectedResponse
 
 logger = logging.getLogger(__name__)
 
@@ -154,6 +155,8 @@ class QdrantVectorStore(VectorStore):
         try:
             self._client.get_collection(collection_name)
         except ValueError:
+            return False
+        except UnexpectedResponse:
             return False
         return True
 

--- a/gpt_index/vector_stores/qdrant.py
+++ b/gpt_index/vector_stores/qdrant.py
@@ -14,7 +14,6 @@ from gpt_index.vector_stores.types import (
     VectorStoreQueryResult,
     VectorStoreQuery,
 )
-from qdrant_client.http.exceptions import UnexpectedResponse
 
 logger = logging.getLogger(__name__)
 
@@ -152,11 +151,12 @@ class QdrantVectorStore(VectorStore):
 
     def _collection_exists(self, collection_name: str) -> bool:
         """Check if a collection exists."""
+        from grpc import RpcError
+        from qdrant_client.http.exceptions import UnexpectedResponse
+
         try:
             self._client.get_collection(collection_name)
-        except ValueError:
-            return False
-        except UnexpectedResponse:
+        except (RpcError, UnexpectedResponse):
             return False
         return True
 


### PR DESCRIPTION
QdrantVectorStore was failing to create new collections with the HTTP client. Reason was that the check for already existing collections did not catch the correct exception from the failing `get_collection` call.

If a collection is not found, Qdrant Client throws an UnexceptedResponse. Added this to checking if collection exists.

@kacperlukawski what do you think of the solution?