### PR TITLE
Fix link to Cost Analysis page

### DIFF
--- a/docs/reference/service_context/llm_predictor.rst
+++ b/docs/reference/service_context/llm_predictor.rst
@@ -10,7 +10,7 @@ Our LLMPredictor is a wrapper around Langchain's `LLMChain` that allows easy int
    :inherited-members:
 
 
-Our MockLLMPredictor is used for token prediction. See `Cost Analysis How-To <../how_to/cost_analysis.html>`_ for more information.
+Our MockLLMPredictor is used for token prediction. See `Cost Analysis How-To <../../how_to/analysis/cost_analysis.html>`_ for more information.
 
 .. automodule:: gpt_index.token_counter.mock_chain_wrapper
    :members:


### PR DESCRIPTION
Update link from
`https://gpt-index.readthedocs.io/en/latest/reference/how_to/cost_analysis.html` to
`https://gpt-index.readthedocs.io/en/latest/how_to/analysis/cost_analysis.html`