### PR TITLE
Qdrant local mode

### DIFF
--- a/gpt_index/readers/qdrant.py
+++ b/gpt_index/readers/qdrant.py
@@ -16,7 +16,9 @@ class QdrantReader(BaseReader):
             If `:memory:` - use in-memory Qdrant instance.
             If `str` - use it as a `url` parameter.
             If `None` - use default values for `host` and `port`.
-        url: either host or str of "Optional[scheme], host, Optional[port], Optional[prefix]".
+        url:
+            either host or str of
+            "Optional[scheme], host, Optional[port], Optional[prefix]".
             Default: `None`
         port: Port of the REST API interface. Default: 6333
         grpc_port: Port of the gRPC interface. Default: 6334

--- a/gpt_index/readers/qdrant.py
+++ b/gpt_index/readers/qdrant.py
@@ -12,7 +12,12 @@ class QdrantReader(BaseReader):
     Retrieve documents from existing Qdrant collections.
 
     Args:
-        host: Host name of Qdrant service.
+        location:
+            If `:memory:` - use in-memory Qdrant instance.
+            If `str` - use it as a `url` parameter.
+            If `None` - use default values for `host` and `port`.
+        url: either host or str of "Optional[scheme], host, Optional[port], Optional[prefix]".
+            Default: `None`
         port: Port of the REST API interface. Default: 6333
         grpc_port: Port of the gRPC interface. Default: 6334
         prefer_grpc: If `true` - use gPRC interface whenever possible in custom methods.
@@ -26,18 +31,23 @@ class QdrantReader(BaseReader):
         timeout:
             Timeout for REST and gRPC API requests.
             Default: 5.0 seconds for REST and unlimited for gRPC
+        host: Host name of Qdrant service. If url and host are None, set to 'localhost'.
+            Default: `None`
     """
 
     def __init__(
         self,
-        host: str,
-        port: int = 6333,
+        location: Optional[str] = None,
+        url: Optional[str] = None,
+        port: Optional[int] = 6333,
         grpc_port: int = 6334,
         prefer_grpc: bool = False,
         https: Optional[bool] = None,
         api_key: Optional[str] = None,
         prefix: Optional[str] = None,
         timeout: Optional[float] = None,
+        host: Optional[str] = None,
+        path: Optional[str] = None,
     ):
         """Initialize with parameters."""
         import_err_msg = (
@@ -49,7 +59,8 @@ class QdrantReader(BaseReader):
             raise ImportError(import_err_msg)
 
         self._client = qdrant_client.QdrantClient(
-            url=host,
+            location=location,
+            url=url,
             port=port,
             grpc_port=grpc_port,
             prefer_grpc=prefer_grpc,
@@ -57,6 +68,8 @@ class QdrantReader(BaseReader):
             api_key=api_key,
             prefix=prefix,
             timeout=timeout,
+            host=host,
+            path=path,
         )
 
     def load_data(

--- a/gpt_index/vector_stores/qdrant.py
+++ b/gpt_index/vector_stores/qdrant.py
@@ -102,7 +102,7 @@ class QdrantVectorStore(VectorStore):
 
             self._client.upsert(
                 collection_name=self._collection_name,
-                points=rest.Batch(
+                points=rest.Batch.construct(
                     ids=new_ids,
                     vectors=vectors,
                     payloads=payloads,

--- a/gpt_index/vector_stores/qdrant.py
+++ b/gpt_index/vector_stores/qdrant.py
@@ -156,7 +156,7 @@ class QdrantVectorStore(VectorStore):
 
         try:
             self._client.get_collection(collection_name)
-        except (RpcError, UnexpectedResponse):
+        except (RpcError, UnexpectedResponse, ValueError):
             return False
         return True
 
@@ -167,17 +167,9 @@ class QdrantVectorStore(VectorStore):
         """Query index for top k most similar nodes.
 
         Args:
-            query_embedding (List[float]): query embedding
-            similarity_top_k (int): top k most similar nodes
-            doc_ids (Optional[List[str]]): list of doc_ids to filter by
-
+            query (VectorStoreQuery): query
         """
-        from qdrant_client.http.models import (
-            FieldCondition,
-            Filter,
-            MatchValue,
-            Payload,
-        )
+        from qdrant_client.http.models import Payload
 
         query_embedding = cast(List[float], query.query_embedding)
 
@@ -185,18 +177,7 @@ class QdrantVectorStore(VectorStore):
             collection_name=self._collection_name,
             query_vector=query_embedding,
             limit=cast(int, query.similarity_top_k),
-            query_filter=None
-            if not query.doc_ids
-            else Filter(
-                must=[
-                    Filter(
-                        should=[
-                            FieldCondition(key="doc_id", match=MatchValue(value=doc_id))
-                            for doc_id in query.doc_ids
-                        ],
-                    )
-                ]
-            ),
+            query_filter=self._build_query_filter(query),
         )
 
         logger.debug(f"> Top {len(response)} nodes:")
@@ -219,3 +200,34 @@ class QdrantVectorStore(VectorStore):
             ids.append(str(point.id))
 
         return VectorStoreQueryResult(nodes=nodes, similarities=similarities, ids=ids)
+
+    def _build_query_filter(self, query: VectorStoreQuery) -> Optional["Filter"]:
+        if not query.doc_ids and not query.query_str:
+            return None
+
+        from qdrant_client.http.models import (
+            FieldCondition,
+            Filter,
+            MatchAny,
+            MatchText,
+        )
+
+        must_conditions = []
+
+        if query.doc_ids:
+            must_conditions.append(
+                FieldCondition(
+                    key="doc_id",
+                    match=MatchAny(any=[doc_id for doc_id in query.doc_ids]),
+                )
+            )
+
+        if query.query_str:
+            must_conditions.append(
+                FieldCondition(
+                    key="text",
+                    match=MatchText(text=query.query_str),
+                )
+            )
+
+        return Filter(must=must_conditions)

--- a/gpt_index/vector_stores/qdrant.py
+++ b/gpt_index/vector_stores/qdrant.py
@@ -169,7 +169,7 @@ class QdrantVectorStore(VectorStore):
         Args:
             query (VectorStoreQuery): query
         """
-        from qdrant_client.http.models import Payload
+        from qdrant_client.http.models import Payload, Filter
 
         query_embedding = cast(List[float], query.query_embedding)
 
@@ -177,7 +177,7 @@ class QdrantVectorStore(VectorStore):
             collection_name=self._collection_name,
             query_vector=query_embedding,
             limit=cast(int, query.similarity_top_k),
-            query_filter=self._build_query_filter(query),
+            query_filter=cast(Filter, self._build_query_filter(query)),
         )
 
         logger.debug(f"> Top {len(response)} nodes:")
@@ -201,7 +201,7 @@ class QdrantVectorStore(VectorStore):
 
         return VectorStoreQueryResult(nodes=nodes, similarities=similarities, ids=ids)
 
-    def _build_query_filter(self, query: VectorStoreQuery) -> Optional["Filter"]:
+    def _build_query_filter(self, query: VectorStoreQuery) -> Optional[Any]:
         if not query.doc_ids and not query.query_str:
             return None
 

--- a/tests/indices/vector_store/test_qdrant.py
+++ b/tests/indices/vector_store/test_qdrant.py
@@ -1,0 +1,108 @@
+from typing import List, cast
+
+import pytest
+import qdrant_client
+
+from gpt_index.data_structs import Node
+from gpt_index.vector_stores import QdrantVectorStore
+from gpt_index.vector_stores.types import NodeEmbeddingResult, VectorStoreQuery
+
+
+@pytest.fixture
+def node() -> Node:
+    return Node(text="lorem ipsum")
+
+
+@pytest.fixture
+def node_embeddings(node: Node) -> List[NodeEmbeddingResult]:
+    return [
+        NodeEmbeddingResult(
+            id="c330d77f-90bd-4c51-9ed2-57d8d693b3b0",
+            embedding=[1.0, 0.0],
+            doc_id="test-0",
+            node=node,
+        ),
+        NodeEmbeddingResult(
+            id="c3d1e1dd-8fb4-4b8f-b7ea-7fa96038d39d",
+            embedding=[0.0, 1.0],
+            doc_id="test-1",
+            node=node,
+        ),
+    ]
+
+
+def test_add_stores_data(node_embeddings: List[NodeEmbeddingResult]) -> None:
+    client = qdrant_client.QdrantClient(":memory:")
+    qdrant_vector_store = QdrantVectorStore(collection_name="test", client=client)
+
+    with pytest.raises(ValueError):
+        client.count("test")  # That indicates the collection does not exist
+
+    qdrant_vector_store.add(node_embeddings)
+
+    assert client.count("test").count == 2
+
+
+def test_build_query_filter_returns_none() -> None:
+    client = qdrant_client.QdrantClient(":memory:")
+    qdrant_vector_store = QdrantVectorStore(collection_name="test", client=client)
+
+    query = VectorStoreQuery()
+    query_filter = qdrant_vector_store._build_query_filter(query)
+
+    assert query_filter is None
+
+
+def test_build_query_filter_returns_match_any() -> None:
+    from qdrant_client.http.models import Filter, FieldCondition, MatchAny
+
+    client = qdrant_client.QdrantClient(":memory:")
+    qdrant_vector_store = QdrantVectorStore(collection_name="test", client=client)
+
+    query = VectorStoreQuery(doc_ids=["1", "2", "3"])
+    query_filter = cast(Filter, qdrant_vector_store._build_query_filter(query))
+
+    assert query_filter is not None
+    assert len(query_filter.must) == 1  # type: ignore[index, arg-type]
+    assert isinstance(query_filter.must[0], FieldCondition)  # type: ignore[index]
+    assert query_filter.must[0].key == "doc_id"  # type: ignore[index]
+    assert isinstance(query_filter.must[0].match, MatchAny)  # type: ignore[index]
+    assert query_filter.must[0].match.any == ["1", "2", "3"]  # type: ignore[index]
+
+
+def test_build_query_filter_returns_text_filter() -> None:
+    from qdrant_client.http.models import Filter, FieldCondition, MatchText
+
+    client = qdrant_client.QdrantClient(":memory:")
+    qdrant_vector_store = QdrantVectorStore(collection_name="test", client=client)
+
+    query = VectorStoreQuery(query_str="lorem")
+    query_filter = cast(Filter, qdrant_vector_store._build_query_filter(query))
+
+    assert query_filter is not None
+    assert len(query_filter.must) == 1  # type: ignore[index, arg-type]
+    assert isinstance(query_filter.must[0], FieldCondition)  # type: ignore[index]
+    assert query_filter.must[0].key == "text"  # type: ignore[index]
+    assert isinstance(query_filter.must[0].match, MatchText)  # type: ignore[index]
+    assert query_filter.must[0].match.text == "lorem"  # type: ignore[index]
+
+
+def test_build_query_filter_returns_combined_filter() -> None:
+    from qdrant_client.http.models import Filter, FieldCondition, MatchText, MatchAny
+
+    client = qdrant_client.QdrantClient(":memory:")
+    qdrant_vector_store = QdrantVectorStore(collection_name="test", client=client)
+
+    query = VectorStoreQuery(query_str="lorem", doc_ids=["1", "2", "3"])
+    query_filter = cast(Filter, qdrant_vector_store._build_query_filter(query))
+
+    assert query_filter is not None
+    assert len(query_filter.must) == 2  # type: ignore[index, arg-type]
+    assert isinstance(query_filter.must[0], FieldCondition)  # type: ignore[index]
+    assert query_filter.must[0].key == "doc_id"  # type: ignore[index]
+    assert isinstance(query_filter.must[0].match, MatchAny)  # type: ignore[index]
+    assert query_filter.must[0].match.any == ["1", "2", "3"]  # type: ignore[index]
+    assert isinstance(query_filter.must[1], FieldCondition)  # type: ignore[index]
+    assert query_filter.must[1].key == "text"  # type: ignore[index]
+    assert isinstance(query_filter.must[1].match, MatchText)  # type: ignore[index]
+    assert query_filter.must[1].match.text == "lorem"  # type: ignore[index]

--- a/tests/indices/vector_store/test_qdrant.py
+++ b/tests/indices/vector_store/test_qdrant.py
@@ -1,7 +1,11 @@
 from typing import List, cast
 
 import pytest
-import qdrant_client
+
+try:
+    import qdrant_client
+except ImportError:
+    qdrant_client = None
 
 from gpt_index.data_structs import Node
 from gpt_index.vector_stores import QdrantVectorStore
@@ -31,6 +35,7 @@ def node_embeddings(node: Node) -> List[NodeEmbeddingResult]:
     ]
 
 
+@pytest.mark.skipif(qdrant_client is None, reason="qdrant-client not installed")
 def test_add_stores_data(node_embeddings: List[NodeEmbeddingResult]) -> None:
     client = qdrant_client.QdrantClient(":memory:")
     qdrant_vector_store = QdrantVectorStore(collection_name="test", client=client)
@@ -43,6 +48,7 @@ def test_add_stores_data(node_embeddings: List[NodeEmbeddingResult]) -> None:
     assert client.count("test").count == 2
 
 
+@pytest.mark.skipif(qdrant_client is None, reason="qdrant-client not installed")
 def test_build_query_filter_returns_none() -> None:
     client = qdrant_client.QdrantClient(":memory:")
     qdrant_vector_store = QdrantVectorStore(collection_name="test", client=client)
@@ -53,6 +59,7 @@ def test_build_query_filter_returns_none() -> None:
     assert query_filter is None
 
 
+@pytest.mark.skipif(qdrant_client is None, reason="qdrant-client not installed")
 def test_build_query_filter_returns_match_any() -> None:
     from qdrant_client.http.models import Filter, FieldCondition, MatchAny
 
@@ -70,6 +77,7 @@ def test_build_query_filter_returns_match_any() -> None:
     assert query_filter.must[0].match.any == ["1", "2", "3"]  # type: ignore[index]
 
 
+@pytest.mark.skipif(qdrant_client is None, reason="qdrant-client not installed")
 def test_build_query_filter_returns_text_filter() -> None:
     from qdrant_client.http.models import Filter, FieldCondition, MatchText
 
@@ -87,6 +95,7 @@ def test_build_query_filter_returns_text_filter() -> None:
     assert query_filter.must[0].match.text == "lorem"  # type: ignore[index]
 
 
+@pytest.mark.skipif(qdrant_client is None, reason="qdrant-client not installed")
 def test_build_query_filter_returns_combined_filter() -> None:
     from qdrant_client.http.models import Filter, FieldCondition, MatchText, MatchAny
 


### PR DESCRIPTION
This PR makes sure Qdrant integration supports HTTP, gRPC and local modes at the same time. There were some previous issues reported in #1109 and #1072. It's all fixed now. In addition to that, text filters have been implemented in Qdrant.