### PR TITLE
Revert "Add namespace to pinecone index (#1146)"

### DIFF
--- a/gpt_index/vector_stores/pinecone.py
+++ b/gpt_index/vector_stores/pinecone.py
@@ -4,20 +4,20 @@ An index that that is built on top of an existing vector store.
 
 """
 
-import logging
 import os
-from collections import Counter
+from typing import Any, Dict, List, Optional, cast, Callable
 from functools import partial
-from typing import Any, Callable, Dict, List, Optional, cast
 
-from gpt_index.data_structs.node_v2 import DocumentRelationship, Node
+from gpt_index.data_structs.node_v2 import Node, DocumentRelationship
 from gpt_index.vector_stores.types import (
     NodeEmbeddingResult,
     VectorStore,
+    VectorStoreQueryResult,
     VectorStoreQuery,
     VectorStoreQueryMode,
-    VectorStoreQueryResult,
 )
+from collections import Counter
+import logging
 
 _logger = logging.getLogger(__name__)
 
@@ -128,7 +128,6 @@ class PineconeVectorStore(VectorStore):
         pinecone_index: Optional[Any] = None,
         index_name: Optional[str] = None,
         environment: Optional[str] = None,
-        namespace: Optional[str] = None,
         metadata_filters: Optional[Dict[str, Any]] = None,
         pinecone_kwargs: Optional[Dict] = None,
         insert_kwargs: Optional[Dict] = None,
@@ -149,7 +148,6 @@ class PineconeVectorStore(VectorStore):
 
         self._index_name = index_name
         self._environment = environment
-        self._namespace = namespace
         if pinecone_index is not None:
             self._pinecone_index = cast(pinecone.Index, pinecone_index)
             _logger.warn(
@@ -260,7 +258,6 @@ class PineconeVectorStore(VectorStore):
                 "id": new_id,
                 "values": text_embedding,
                 "metadata": metadata,
-                "namespace": self._namespace,
             }
             if self._add_sparse_vector:
                 sparse_vector = generate_sparse_vectors(
@@ -315,7 +312,6 @@ class PineconeVectorStore(VectorStore):
             top_k=query.similarity_top_k,
             include_values=True,
             include_metadata=True,
-            namespace=self._namespace,
             filter=self._metadata_filters,
             **self._pinecone_kwargs,
         )

--- a/tests/indices/vector_store/utils.py
+++ b/tests/indices/vector_store/utils.py
@@ -29,7 +29,6 @@ class MockPineconeIndex:
         include_values: bool = True,
         include_metadata: bool = True,
         filter: Optional[Dict[str, Any]] = None,
-        namespace: Optional[str] = None,
     ) -> Any:
         """Mock query."""
         # index_mat is n x k


### PR DESCRIPTION
This reverts commit 63b5dc374fdad8bcf7b391230f2e97bfbcfbdd3d.

There was some issues caused by adding namespace to the pinecone entries.

The namespace field doesn't seem to be allowed. I confirmed by checking the latest version of the [pinecone-client repo](https://github.com/pinecone-io/pinecone-python-client/blob/main/pinecone/index.py#L176)

```
ValueError: Found excess keys in the vector dictionary: ['namespace']. The allowed keys are: ['id', 'values', 'sparse_values', 'metadata']
/usr/local/lib/python3.9/dist-packages/pinecone/index.py in _dict_to_vector(item)
    176             excessive_keys = item_keys - (REQUIRED_VECTOR_FIELDS | OPTIONAL_VECTOR_FIELDS)
    177             if len(excessive_keys) > 0:
--> 178                 raise ValueError(f"Found excess keys in the vector dictionary: {list(excessive_keys)}. "
    179                                  f"The allowed keys are: {list(REQUIRED_VECTOR_FIELDS | OPTIONAL_VECTOR_FIELDS)}")
    180
```