### PR TITLE
Remove mutual exclusion re: persist_directory boolean in forming ChromaDB client

### DIFF
--- a/gpt_index/readers/chroma.py
+++ b/gpt_index/readers/chroma.py
@@ -37,7 +37,6 @@ class ChromaReader(BaseReader):
             raise ValueError("Please provide a collection name.")
         from chromadb.config import Settings
 
-        
         self._client = chromadb.Client(
             Settings(
                 chroma_api_impl="rest",
@@ -46,6 +45,7 @@ class ChromaReader(BaseReader):
                 persist_directory=persist_directory if persist_directory else './chroma'
             )
         )
+
         self._collection = self._client.get_collection(collection_name)
 
     def create_documents(self, results: Any) -> List[Document]:

--- a/gpt_index/readers/chroma.py
+++ b/gpt_index/readers/chroma.py
@@ -37,20 +37,15 @@ class ChromaReader(BaseReader):
             raise ValueError("Please provide a collection name.")
         from chromadb.config import Settings
 
-        if persist_directory:
-            self._client = chromadb.Client(
-                Settings(
-                    chroma_db_impl="duckdb+parquet", persist_directory=persist_directory
-                )
+        
+        self._client = chromadb.Client(
+            Settings(
+                chroma_api_impl="rest",
+                chroma_server_host=host,
+                chroma_server_http_port=port,
+                persist_directory=persist_directory if persist_directory else './chroma'
             )
-        else:
-            self._client = chromadb.Client(
-                Settings(
-                    chroma_api_impl="rest",
-                    chroma_server_host=host,
-                    chroma_server_http_port=port,
-                )
-            )
+        )
         self._collection = self._client.get_collection(collection_name)
 
     def create_documents(self, results: Any) -> List[Document]:

--- a/gpt_index/vector_stores/registry.py
+++ b/gpt_index/vector_stores/registry.py
@@ -1,17 +1,17 @@
 from enum import Enum
 from typing import Any, Dict, Optional, Type
 
-from gpt_index.constants import DATA_KEY, TYPE_KEY
-from gpt_index.vector_stores.chatgpt_plugin import ChatGPTRetrievalPluginClient
-from gpt_index.vector_stores.chroma import ChromaVectorStore
-from gpt_index.vector_stores.faiss import FaissVectorStore
-from gpt_index.vector_stores.milvus import MilvusVectorStore
-from gpt_index.vector_stores.opensearch import OpensearchVectorStore
-from gpt_index.vector_stores.pinecone import PineconeVectorStore
-from gpt_index.vector_stores.qdrant import QdrantVectorStore
-from gpt_index.vector_stores.simple import SimpleVectorStore
-from gpt_index.vector_stores.types import VectorStore
-from gpt_index.vector_stores.weaviate import WeaviateVectorStore
+from llama_index.constants import DATA_KEY, TYPE_KEY
+from llama_index.vector_stores.chatgpt_plugin import ChatGPTRetrievalPluginClient
+from llama_index.vector_stores.chroma import ChromaVectorStore
+from llama_index.vector_stores.faiss import FaissVectorStore
+from llama_index.vector_stores.milvus import MilvusVectorStore
+from llama_index.vector_stores.opensearch import OpensearchVectorStore
+from llama_index.vector_stores.pinecone import PineconeVectorStore
+from llama_index.vector_stores.qdrant import QdrantVectorStore
+from llama_index.vector_stores.simple import SimpleVectorStore
+from llama_index.vector_stores.types import VectorStore
+from llama_index.vector_stores.weaviate import WeaviateVectorStore
 
 
 class VectorStoreType(str, Enum):
@@ -48,6 +48,7 @@ def load_vector_store_from_dict(
     type_to_cls: Optional[Dict[VectorStoreType, Type[VectorStore]]] = None,
     **kwargs: Any,
 ) -> VectorStore:
+    print(vector_store_dict)
     type_to_cls = type_to_cls or VECTOR_STORE_TYPE_TO_VECTOR_STORE_CLASS
     type = vector_store_dict[TYPE_KEY]
     config_dict: Dict[str, Any] = vector_store_dict[DATA_KEY]


### PR DESCRIPTION
this fixes the broken remote host implementation (_when persistent dir is used_) in ChromaDB

**before** 🚫

``` python
if persist_directory:
          self._client = chromadb.Client(
               Settings(
                    chroma_db_impl="duckdb+parquet", persist_directory=persist_directory
               )
          )
else:
          self._client = chromadb.Client(
               Settings(
                    chroma_api_impl="rest",
                    chroma_server_host=host,
                    chroma_server_http_port=port,
               )
          )
```

**after** ✅

``` python
self._client = chromadb.Client(
     Settings(
          chroma_api_impl="rest",
          chroma_server_host=host,
          chroma_server_http_port=port,
          persist_directory=persist_directory if persist_directory else './chroma'
     )
)
```

as you can imagine, the previous version creates confusing situations for people using remote host + persistent_db + just created a collection

