### PR TITLE
[WIP] [EXPERIMENTAL] detecting irrelevent responses

### DIFF
--- a/gpt_index/indices/query/base.py
+++ b/gpt_index/indices/query/base.py
@@ -2,18 +2,7 @@
 
 import logging
 from abc import ABC
-from typing import (
-    Any,
-    Dict,
-    Generator,
-    Generic,
-    List,
-    Optional,
-    Sequence,
-    TypeVar,
-)
-
-from langchain.input import print_text
+from typing import Any, Dict, Generator, Generic, List, Optional, Sequence, TypeVar
 
 from gpt_index.data_structs.data_structs_v2 import V2IndexStruct
 from gpt_index.data_structs.node_v2 import Node, NodeWithScore
@@ -25,24 +14,17 @@ from gpt_index.indices.postprocessor.node import (
 )
 from gpt_index.indices.query.embedding_utils import SimilarityTracker
 from gpt_index.indices.query.schema import QueryBundle
-from gpt_index.indices.response.builder import (
-    ResponseBuilder,
-    ResponseMode,
-    TextChunk,
-)
+from gpt_index.indices.response.builder import ResponseBuilder, ResponseMode, TextChunk
 from gpt_index.indices.service_context import ServiceContext
 from gpt_index.optimization.optimizer import BaseTokenUsageOptimizer
 from gpt_index.prompts.default_prompt_selectors import DEFAULT_REFINE_PROMPT_SEL
 from gpt_index.prompts.default_prompts import DEFAULT_TEXT_QA_PROMPT
 from gpt_index.prompts.prompts import QuestionAnswerPrompt, RefinePrompt
-from gpt_index.response.schema import (
-    RESPONSE_TYPE,
-    Response,
-    StreamingResponse,
-)
+from gpt_index.response.schema import RESPONSE_TYPE, Response, StreamingResponse
 from gpt_index.token_counter.token_counter import llm_token_counter
 from gpt_index.types import RESPONSE_TEXT_TYPE
 from gpt_index.utils import truncate_text
+from langchain.input import print_text
 
 # to prevent us from having to remove all instances of v2 later
 IndexStruct = V2IndexStruct
@@ -129,6 +111,9 @@ class BaseGPTIndexQuery(Generic[IS], ABC):
         doc_ids: Optional[List[str]] = None,
         optimizer: Optional[BaseTokenUsageOptimizer] = None,
         node_postprocessors: Optional[List[BaseNodePostprocessor]] = None,
+        overlap_threshold: float = 0.4,
+        remove_outlier_responses: bool = False,
+        early_stopping: bool = False,
         verbose: bool = False,
     ) -> None:
         """Initialize with parameters."""
@@ -165,6 +150,9 @@ class BaseGPTIndexQuery(Generic[IS], ABC):
             self.refine_template,
             use_async=use_async,
             streaming=streaming,
+            overlap_threshold=overlap_threshold,
+            remove_outlier_responses=remove_outlier_responses,
+            early_stopping=early_stopping,
         )
 
         # TODO: deprecated

--- a/gpt_index/response/utils.py
+++ b/gpt_index/response/utils.py
@@ -2,6 +2,8 @@
 
 from typing import Generator
 
+from rouge_score import rouge_scorer
+
 
 def get_response_text(response_gen: Generator) -> str:
     """Get response text."""
@@ -9,3 +11,12 @@ def get_response_text(response_gen: Generator) -> str:
     for response in response_gen:
         response_text += response
     return response_text
+
+
+def get_response_context_rouge_score(
+    response: str, context: str, metric: str = "rougeL"
+) -> float:
+    """Caluclate the ROUGE score to measure overlap between response and context."""
+    scorer = rouge_scorer.RougeScorer([metric], use_stemmer=True)
+    scores = scorer.score(response, context)
+    return scores[metric].recall


### PR DESCRIPTION
Lately, a ton of comments have come up about the refine template being broken for gpt-3.5. Lots of stubborn answers along the lines of `The context provided is about ... Therefore, the original answer remains the same.`

While the refine template might need some tweaking, it got me thinking of how to possibly make the synthesize process better. One idea is to use ROUGE to measure overlap between the response and context and compare to some threshold. This led to two main features -> stopping when the overlap over the threshold, and not using responses that go under the threshold.

I added some functionality to do this. I need to test it a bit more, but wanted to get the idea out there sooner rather than later 👍🏻

I didn't add it to the requirements yet, but you'll want to install the [rouge-score package](https://pypi.org/project/rouge-score/):
`pip install rouge-score` 

You can use the new features like so (this uses default settings, you can turn things on as needed):
`response = index.query("my query", similarity_top_k=5, remove_outlier_responses=False, early_stopping=False, overlap_threshold=0.4)`