### PR TITLE
Add a batched query method in LangchainEmbedding for the LangChain embeddings interface

### DIFF
--- a/gpt_index/embeddings/langchain.py
+++ b/gpt_index/embeddings/langchain.py
@@ -28,3 +28,7 @@ class LangchainEmbedding(BaseEmbedding):
     def _get_text_embedding(self, text: str) -> List[float]:
         """Get text embedding."""
         return self._langchain_embedding.embed_documents([text])[0]
+
+    def _get_text_embeddings(self, texts: List[str]) -> List[List[float]]:
+        """Get text embeddings."""
+        return self._langchain_embedding.embed_documents(texts)


### PR DESCRIPTION
Currently the class LangchainEmbedding that wrappers a LangChain Embeddings class does not have a batched query method. If someone uses LangchainEmbedding to get embeddings of a bunch of documents, it will always call the method `langchain.embeddings.base.Embeddings.embed_documents` one by one like this: 

1. `BaseEmbedding.get_queued_text_embeddings` convert texts in queue into batches
2. `_get_text_embeddings` is called but there is no such method in LangchainEmbedding
3. `BaseEmbedding._get_text_embeddings` is called and the `LangchainEmbedding._get_text_embedding` for every single text.

Simply adding a `_get_text_embeddings` overriding it can fix is issue :)

I think #843 is propably related to this. He set the `chunk_size` of LangChain's embedding class but that class is wrappered by LangchainEmbedding in llama_index so the `chunk_size` just doesn't work.