### PR TITLE
Qdrant index filters results by MUST match on query

### DIFF
--- a/gpt_index/vector_stores/qdrant.py
+++ b/gpt_index/vector_stores/qdrant.py
@@ -221,13 +221,4 @@ class QdrantVectorStore(VectorStore):
                     match=MatchAny(any=[doc_id for doc_id in query.doc_ids]),
                 )
             )
-
-        if query.query_str:
-            must_conditions.append(
-                FieldCondition(
-                    key="text",
-                    match=MatchText(text=query.query_str),
-                )
-            )
-
         return Filter(must=must_conditions)

--- a/gpt_index/vector_stores/qdrant.py
+++ b/gpt_index/vector_stores/qdrant.py
@@ -209,7 +209,6 @@ class QdrantVectorStore(VectorStore):
             FieldCondition,
             Filter,
             MatchAny,
-            MatchText,
         )
 
         must_conditions = []


### PR DESCRIPTION
Qdrant client was adding the query string as MUST match filter, which effectively filtered all nodes out from query results, if using queries longer than a few words.

This should only be added when the user defines must match keywords, not by default, imo. So I deleted it :shrug:

There's a chance I'm misreading this, but what do you think?