### PR TITLE
chore: enable to pass tokenizer to embedding

### DIFF
--- a/gpt_index/embeddings/base.py
+++ b/gpt_index/embeddings/base.py
@@ -48,11 +48,15 @@ def similarity(
 class BaseEmbedding:
     """Base class for embeddings."""
 
-    def __init__(self, embed_batch_size: int = DEFAULT_EMBED_BATCH_SIZE) -> None:
+    def __init__(
+        self,
+        embed_batch_size: int = DEFAULT_EMBED_BATCH_SIZE,
+        tokenizer: Optional[Callable] = None,
+    ) -> None:
         """Init params."""
         self._total_tokens_used = 0
         self._last_token_usage: Optional[int] = None
-        self._tokenizer: Callable = globals_helper.tokenizer
+        self._tokenizer = tokenizer or globals_helper.tokenizer
         # list of tuples of id, text
         self._text_queue: List[Tuple[str, str]] = []
         if embed_batch_size <= 0:


### PR DESCRIPTION
## Summary

Enable to pass tokenizer to `BaseEmbedding` to abvoid special character check.

## Motivation

https://github.com/jerryjliu/llama_index/issues/1206
