### PR TITLE
Add sources to create_llama_agent wrapper

### DIFF
--- a/examples/chatbot/Chatbot_SEC.ipynb
+++ b/examples/chatbot/Chatbot_SEC.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 1,
    "id": "YC4R6nkCp91d",
    "metadata": {
     "colab": {
@@ -17,26 +17,26 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "mkdir: data: File exists\n",
-      "--2023-03-20 12:23:22--  https://www.dropbox.com/s/948jr9cfs7fgj99/UBER.zip?dl=1\n",
-      "Resolving www.dropbox.com (www.dropbox.com)... 162.125.7.18\n",
-      "Connecting to www.dropbox.com (www.dropbox.com)|162.125.7.18|:443... connected.\n",
+      "mkdir: cannot create directory ‘data’: File exists\n",
+      "--2023-04-17 19:02:24--  https://www.dropbox.com/s/948jr9cfs7fgj99/UBER.zip?dl=1\n",
+      "Resolving www.dropbox.com (www.dropbox.com)... 162.125.1.18, 2620:100:6016:18::a27d:112\n",
+      "Connecting to www.dropbox.com (www.dropbox.com)|162.125.1.18|:443... connected.\n",
       "HTTP request sent, awaiting response... 302 Found\n",
       "Location: /s/dl/948jr9cfs7fgj99/UBER.zip [following]\n",
-      "--2023-03-20 12:23:23--  https://www.dropbox.com/s/dl/948jr9cfs7fgj99/UBER.zip\n",
+      "--2023-04-17 19:02:24--  https://www.dropbox.com/s/dl/948jr9cfs7fgj99/UBER.zip\n",
       "Reusing existing connection to www.dropbox.com:443.\n",
       "HTTP request sent, awaiting response... 302 Found\n",
-      "Location: https://ucaa655ca6057ed572944f7098ed.dl.dropboxusercontent.com/cd/0/get/B4lkBQS1ORFWkoF22J5uXSUYctyVcX-qJNXbH9hQ2FASvz436JWKvdNH7VLLFb83xEq5b-sd0HfffkWLDu66-22ks2Q0i6miTSF9PAsfWClLoyZMbWr0EYfI4uUWk9z8V0OEZ9wXrlqm6YW3NIfK0N15W9EVQKpN_EJScpk71Bc5Cg/file?dl=1# [following]\n",
-      "--2023-03-20 12:23:23--  https://ucaa655ca6057ed572944f7098ed.dl.dropboxusercontent.com/cd/0/get/B4lkBQS1ORFWkoF22J5uXSUYctyVcX-qJNXbH9hQ2FASvz436JWKvdNH7VLLFb83xEq5b-sd0HfffkWLDu66-22ks2Q0i6miTSF9PAsfWClLoyZMbWr0EYfI4uUWk9z8V0OEZ9wXrlqm6YW3NIfK0N15W9EVQKpN_EJScpk71Bc5Cg/file?dl=1\n",
-      "Resolving ucaa655ca6057ed572944f7098ed.dl.dropboxusercontent.com (ucaa655ca6057ed572944f7098ed.dl.dropboxusercontent.com)... 162.125.7.15\n",
-      "Connecting to ucaa655ca6057ed572944f7098ed.dl.dropboxusercontent.com (ucaa655ca6057ed572944f7098ed.dl.dropboxusercontent.com)|162.125.7.15|:443... connected.\n",
+      "Location: https://ucc1001c276b1921faf30a16a022.dl.dropboxusercontent.com/cd/0/get/B6bcRz_9WwprtoTL16Ml04tUVrdAYD7jxldrY39JEWnrY99aZ58ry_fxNNZxJ9oLBROEWFtIY-Wtu9DoWpzKaiKJTUn-j-1mDIRMXngXOV0deIke4g98TilzGoikCh-7p3bOhNotBLslHnt2b4I0ncRe1PDsv7BnktdUofZ5SrZmig/file?dl=1# [following]\n",
+      "--2023-04-17 19:02:25--  https://ucc1001c276b1921faf30a16a022.dl.dropboxusercontent.com/cd/0/get/B6bcRz_9WwprtoTL16Ml04tUVrdAYD7jxldrY39JEWnrY99aZ58ry_fxNNZxJ9oLBROEWFtIY-Wtu9DoWpzKaiKJTUn-j-1mDIRMXngXOV0deIke4g98TilzGoikCh-7p3bOhNotBLslHnt2b4I0ncRe1PDsv7BnktdUofZ5SrZmig/file?dl=1\n",
+      "Resolving ucc1001c276b1921faf30a16a022.dl.dropboxusercontent.com (ucc1001c276b1921faf30a16a022.dl.dropboxusercontent.com)... 162.125.1.15, 2620:100:6016:15::a27d:10f\n",
+      "Connecting to ucc1001c276b1921faf30a16a022.dl.dropboxusercontent.com (ucc1001c276b1921faf30a16a022.dl.dropboxusercontent.com)|162.125.1.15|:443... connected.\n",
       "HTTP request sent, awaiting response... 200 OK\n",
       "Length: 1820227 (1.7M) [application/binary]\n",
       "Saving to: ‘data/UBER.zip’\n",
       "\n",
-      "data/UBER.zip       100%[===================>]   1.74M  10.5MB/s    in 0.2s    \n",
+      "data/UBER.zip       100%[===================>]   1.74M  9.74MB/s    in 0.2s    \n",
       "\n",
-      "2023-03-20 12:23:24 (10.5 MB/s) - ‘data/UBER.zip’ saved [1820227/1820227]\n",
+      "2023-04-17 19:02:25 (9.74 MB/s) - ‘data/UBER.zip’ saved [1820227/1820227]\n",
       "\n",
       "Archive:  data/UBER.zip\n",
       "   creating: data/UBER/\n",
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 1,
    "id": "CuHeyb224pI2",
    "metadata": {
     "id": "CuHeyb224pI2"
@@ -83,10 +83,64 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "QaFX6KfIz-Zn",
+   "execution_count": 3,
+   "id": "3a5cb155-cfe0-4c89-a2b4-c61d5b7cbe61",
    "metadata": {
-    "id": "QaFX6KfIz-Zn"
+    "id": "3a5cb155-cfe0-4c89-a2b4-c61d5b7cbe61"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "  <style>\n",
+       "    pre {\n",
+       "        white-space: pre-wrap;\n",
+       "    }\n",
+       "  </style>\n",
+       "  "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/loganm/miniconda3/envs/gpt_index/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
+   "source": [
+    "from gpt_index import download_loader, GPTSimpleVectorIndex, ServiceContext\n",
+    "from pathlib import Path"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "354ddbdf-0045-474b-b6f2-1b4c22ad360a",
+   "metadata": {
+    "id": "354ddbdf-0045-474b-b6f2-1b4c22ad360a",
+    "tags": []
+   },
+   "source": [
+    "### Ingest Unstructured Data Through the Unstructured.io Reader\n",
+    "\n",
+    "Leverage the capabilities of Unstructured.io HTML parsing.\n",
+    "Downloaded through LlamaHub."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "61fed4f1-8cca-4d98-b916-a3184279e256",
+   "metadata": {
+    "tags": []
    },
    "outputs": [
     {
@@ -109,64 +163,43 @@
     }
    ],
    "source": [
-    "import os\n",
-    "os.environ['OPENAI_API_KEY'] = \"\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "3a5cb155-cfe0-4c89-a2b4-c61d5b7cbe61",
-   "metadata": {
-    "id": "3a5cb155-cfe0-4c89-a2b4-c61d5b7cbe61"
-   },
-   "outputs": [],
-   "source": [
-    "from gpt_index import download_loader, GPTSimpleVectorIndex, ServiceContext\n",
-    "from pathlib import Path"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "354ddbdf-0045-474b-b6f2-1b4c22ad360a",
-   "metadata": {
-    "id": "354ddbdf-0045-474b-b6f2-1b4c22ad360a",
-    "tags": []
-   },
-   "source": [
-    "### Ingest Unstructured Data Through the Unstructured.io Reader\n",
-    "\n",
-    "Leverage the capabilities of Unstructured.io HTML parsing.\n",
-    "Downloaded through LlamaHub."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "61fed4f1-8cca-4d98-b916-a3184279e256",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
     "years = [2022, 2021, 2020, 2019]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "id": "0371970e-c11c-4534-aa22-7cfdfe411bb3",
    "metadata": {
     "id": "0371970e-c11c-4534-aa22-7cfdfe411bb3"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "  <style>\n",
+       "    pre {\n",
+       "        white-space: pre-wrap;\n",
+       "    }\n",
+       "  </style>\n",
+       "  "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "UnstructuredReader = download_loader(\"UnstructuredReader\", refresh_cache=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 6,
    "id": "29084a11-f3da-428d-ae17-27b85a365e84",
    "metadata": {
     "colab": {
@@ -177,13 +210,31 @@
    },
    "outputs": [
     {
+     "data": {
+      "text/html": [
+       "\n",
+       "  <style>\n",
+       "    pre {\n",
+       "        white-space: pre-wrap;\n",
+       "    }\n",
+       "  </style>\n",
+       "  "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[nltk_data] Downloading package punkt to /Users/jerryliu/nltk_data...\n",
+      "[nltk_data] Downloading package punkt to /home/loganm/nltk_data...\n",
       "[nltk_data]   Package punkt is already up-to-date!\n",
       "[nltk_data] Downloading package averaged_perceptron_tagger to\n",
-      "[nltk_data]     /Users/jerryliu/nltk_data...\n",
+      "[nltk_data]     /home/loganm/nltk_data...\n",
       "[nltk_data]   Package averaged_perceptron_tagger is already up-to-\n",
       "[nltk_data]       date!\n",
       "INFO:unstructured:Reading document from string ...\n",
@@ -226,13 +277,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "8fbe18a6-4a08-441d-adae-a6195f2cdcb1",
    "metadata": {
     "id": "8fbe18a6-4a08-441d-adae-a6195f2cdcb1",
     "outputId": "bdc1d207-efb2-4f82-bf6c-668cfb7ca98f"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "  <style>\n",
+       "    pre {\n",
+       "        white-space: pre-wrap;\n",
+       "    }\n",
+       "  </style>\n",
+       "  "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
+      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total embedding token usage: 232797 tokens\n",
+      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
+      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total embedding token usage: 241424 tokens\n",
+      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
+      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total embedding token usage: 257154 tokens\n",
+      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
+      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total embedding token usage: 246480 tokens\n"
+     ]
+    }
+   ],
    "source": [
     "# initialize simple vector indices + global vector index\n",
     "# NOTE: don't run this cell if the indices are already loaded! \n",
@@ -247,12 +331,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "d3a5e993-99ae-445a-bcae-e2d415d84e34",
    "metadata": {
     "id": "d3a5e993-99ae-445a-bcae-e2d415d84e34"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "  <style>\n",
+       "    pre {\n",
+       "        white-space: pre-wrap;\n",
+       "    }\n",
+       "  </style>\n",
+       "  "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Load indices from disk\n",
     "index_set = {}\n",
@@ -276,12 +379,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "f3fb341a-19a3-4e4a-9369-7ddc46b8c2a6",
    "metadata": {
     "id": "f3fb341a-19a3-4e4a-9369-7ddc46b8c2a6"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "  <style>\n",
+       "    pre {\n",
+       "        white-space: pre-wrap;\n",
+       "    }\n",
+       "  </style>\n",
+       "  "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "from gpt_index import GPTListIndex, LLMPredictor\n",
     "from langchain import OpenAI\n",
@@ -290,12 +412,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "966388cb-2fe4-4427-ad2e-cea6a0375233",
    "metadata": {
     "id": "966388cb-2fe4-4427-ad2e-cea6a0375233"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "  <style>\n",
+       "    pre {\n",
+       "        white-space: pre-wrap;\n",
+       "    }\n",
+       "  </style>\n",
+       "  "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# set summary text for each doc\n",
     "index_summaries = [f\"UBER 10-k Filing for {year} fiscal year\" for year in years]"
@@ -303,12 +444,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "f9e453b1-6782-45b5-8258-dfc386e6cf22",
    "metadata": {
     "id": "f9e453b1-6782-45b5-8258-dfc386e6cf22"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "  <style>\n",
+       "    pre {\n",
+       "        white-space: pre-wrap;\n",
+       "    }\n",
+       "  </style>\n",
+       "  "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# set number of output tokens\n",
     "llm_predictor = LLMPredictor(llm=OpenAI(temperature=0, max_tokens=512))\n",
@@ -317,7 +477,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "3b758fc2-bb21-46da-91b5-53e399eecfb0",
    "metadata": {
     "id": "3b758fc2-bb21-46da-91b5-53e399eecfb0",
@@ -325,11 +485,29 @@
    },
    "outputs": [
     {
+     "data": {
+      "text/html": [
+       "\n",
+       "  <style>\n",
+       "    pre {\n",
+       "        white-space: pre-wrap;\n",
+       "    }\n",
+       "  </style>\n",
+       "  "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_documents] Total LLM token usage: 0 tokens\n",
-      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_documents] Total embedding token usage: 0 tokens\n"
+      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
+      "INFO:gpt_index.token_counter.token_counter:> [build_index_from_nodes] Total embedding token usage: 0 tokens\n"
      ]
     }
    ],
@@ -346,24 +524,62 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 13,
    "id": "NLtnE--Mya7P",
    "metadata": {
     "id": "NLtnE--Mya7P"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "  <style>\n",
+       "    pre {\n",
+       "        white-space: pre-wrap;\n",
+       "    }\n",
+       "  </style>\n",
+       "  "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "graph.save_to_disk('10k_graph.json')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "b92a0ba3-5c6b-485f-8f8d-5e164689ff05",
    "metadata": {
     "id": "b92a0ba3-5c6b-485f-8f8d-5e164689ff05"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "  <style>\n",
+       "    pre {\n",
+       "        white-space: pre-wrap;\n",
+       "    }\n",
+       "  </style>\n",
+       "  "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "graph = ComposableGraph.load_from_disk('10k_graph.json', service_context=service_context)"
    ]
@@ -382,12 +598,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "id": "6c2de0f3-9ec3-4f80-bd36-a509f8bfd4b8",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "  <style>\n",
+       "    pre {\n",
+       "        white-space: pre-wrap;\n",
+       "    }\n",
+       "  </style>\n",
+       "  "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "from langchain.agents import Tool\n",
     "from langchain.chains.conversation.memory import ConversationBufferMemory\n",
@@ -399,12 +634,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 16,
    "id": "c9a6faa1-dc06-4d9c-98b4-06e7ee19c559",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "  <style>\n",
+       "    pre {\n",
+       "        white-space: pre-wrap;\n",
+       "    }\n",
+       "  </style>\n",
+       "  "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# define a decompose transform\n",
     "from gpt_index.indices.query.query_transform.base import DecomposeQueryTransform\n",
@@ -436,12 +690,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 17,
    "id": "e763ceba-1c54-4abb-9589-c0628d18c5e5",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "  <style>\n",
+       "    pre {\n",
+       "        white-space: pre-wrap;\n",
+       "    }\n",
+       "  </style>\n",
+       "  "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# define toolkit\n",
     "index_configs = []\n",
@@ -451,7 +724,7 @@
     "        name=f\"Vector Index {y}\",\n",
     "        description=f\"useful for when you want to answer queries about the {y} SEC 10-K for Uber\",\n",
     "        index_query_kwargs={\"similarity_top_k\": 3},\n",
-    "        tool_kwargs={\"return_direct\": True}\n",
+    "        tool_kwargs={\"return_direct\": True, \"return_sources\": True},\n",
     "    )\n",
     "    index_configs.append(tool_config)\n",
     "    \n",
@@ -461,7 +734,8 @@
     "    name=f\"Graph Index\",\n",
     "    description=\"useful for when you want to answer queries that require analyzing multiple SEC 10-K documents for Uber.\",\n",
     "    query_configs=query_configs,\n",
-    "    tool_kwargs={\"return_direct\": True}\n",
+    "    tool_kwargs={\"return_direct\": True, \"return_sources\": True},\n",
+    "    return_sources=True\n",
     ")\n",
     "\n",
     "toolkit = LlamaToolkit(\n",
@@ -472,12 +746,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 18,
    "id": "c28cd7ee-15ef-4240-aff3-ecc0ba335df2",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "  <style>\n",
+       "    pre {\n",
+       "        white-space: pre-wrap;\n",
+       "    }\n",
+       "  </style>\n",
+       "  "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "memory = ConversationBufferMemory(memory_key=\"chat_history\")\n",
     "llm=OpenAI(temperature=0)\n",
@@ -491,10 +784,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 19,
    "id": "92bd0eaa-73ad-4735-8234-a376fd1b3a6a",
    "metadata": {},
    "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "  <style>\n",
+       "    pre {\n",
+       "        white-space: pre-wrap;\n",
+       "    }\n",
+       "  </style>\n",
+       "  "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -515,7 +826,7 @@
        "'Hi Bob, nice to meet you! How can I help you today?'"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -526,10 +837,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 20,
    "id": "19ca8476-bfeb-4c88-a0ff-15424e2d91c7",
    "metadata": {},
    "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "  <style>\n",
+       "    pre {\n",
+       "        white-space: pre-wrap;\n",
+       "    }\n",
+       "  </style>\n",
+       "  "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -547,7 +876,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:gpt_index.token_counter.token_counter:> [query] Total LLM token usage: 2006 tokens\n",
+      "INFO:gpt_index.token_counter.token_counter:> [query] Total LLM token usage: 2198 tokens\n",
       "INFO:gpt_index.token_counter.token_counter:> [query] Total embedding token usage: 3 tokens\n"
      ]
     },
@@ -556,12 +885,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Observation: \u001b[33;1m\u001b[1;3m\n",
-      "\n",
-      "Risk Factors\n",
-      "\n",
-      "The COVID-19 pandemic and the impact of actions to mitigate the pandemic has adversely affected and continues to adversely affect our business, financial condition, and results of operations. The risks associated with the pandemic include, but are not limited to, the classification of Drivers as independent contractors, the economic impact of the pandemic, the potential cascading effects of the pandemic on our business, financial performance, and results of operations, the practices necessitated by the outbreak and related governmental actions, the increase in remote working and the associated privacy, cybersecurity and fraud risks, the legal and regulatory challenges associated with the pandemic, the workforce reductions announced in May 2020, the launch of new, or expansion of existing, services, features, or health and safety requirements in response to COVID-19, and the potential fines or other enforcement measures that could adversely impact our financial results or operations.\u001b[0m\n",
-      "\u001b[32;1m\u001b[1;3m\u001b[0m\n",
+      "Observation: \u001b[33;1m\u001b[1;3m{'answer': '\\n\\nRisk factors include the COVID-19 pandemic and the impact of actions to mitigate the pandemic, the potential classification of Drivers as employees, workers or quasi-employees instead of independent contractors, the highly competitive nature of the mobility, delivery, and logistics industries, unresolved staff comments, legal proceedings, mine safety disclosures, market for registrant’s common equity, related stockholder matters and issuer purchases of equity securities, quantitative and qualitative disclosures about market risk, changes in and disagreements with accountants on accounting and financial disclosure, controls and procedures, certain relationships and related transactions, and director independence, and principal accounting fees and services. Additionally, this Annual Report on Form 10-K contains forward-looking statements within the meaning of the Private Securities Litigation Reform Act of 1995, which may affect the accuracy of the information provided. \\n\\nRisk factors also include the potential for lower fares or service fees, significant Driver incentives and consumer discounts and promotions, significant losses since inception, the need to attract and maintain a critical mass of Drivers, consumers, merchants, shippers, and carriers, the potential for negative media coverage and negative publicity, and the need to optimize organizational structure and effectively manage growth. Platform users may also engage in activities that could harm our', 'sources': [{'start': 87353, 'end': 89573, 'ref_doc_id': '7843f18e-066f-4d78-a3f5-bf2bf9ae386a', 'score': 0.8321939180445632}, {'start': 6620, 'end': 8321, 'ref_doc_id': '7843f18e-066f-4d78-a3f5-bf2bf9ae386a', 'score': 0.8186035956077489}, {'start': 89611, 'end': 91789, 'ref_doc_id': '7843f18e-066f-4d78-a3f5-bf2bf9ae386a', 'score': 0.816380689156515}]}\u001b[0m\u001b[32;1m\u001b[1;3m\u001b[0m\n",
       "\n",
       "\u001b[1m> Finished chain.\u001b[0m\n"
      ]
@@ -569,10 +893,10 @@
     {
      "data": {
       "text/plain": [
-       "'\\n\\nRisk Factors\\n\\nThe COVID-19 pandemic and the impact of actions to mitigate the pandemic has adversely affected and continues to adversely affect our business, financial condition, and results of operations. The risks associated with the pandemic include, but are not limited to, the classification of Drivers as independent contractors, the economic impact of the pandemic, the potential cascading effects of the pandemic on our business, financial performance, and results of operations, the practices necessitated by the outbreak and related governmental actions, the increase in remote working and the associated privacy, cybersecurity and fraud risks, the legal and regulatory challenges associated with the pandemic, the workforce reductions announced in May 2020, the launch of new, or expansion of existing, services, features, or health and safety requirements in response to COVID-19, and the potential fines or other enforcement measures that could adversely impact our financial results or operations.'"
+       "\"{'answer': '\\\\n\\\\nRisk factors include the COVID-19 pandemic and the impact of actions to mitigate the pandemic, the potential classification of Drivers as employees, workers or quasi-employees instead of independent contractors, the highly competitive nature of the mobility, delivery, and logistics industries, unresolved staff comments, legal proceedings, mine safety disclosures, market for registrant’s common equity, related stockholder matters and issuer purchases of equity securities, quantitative and qualitative disclosures about market risk, changes in and disagreements with accountants on accounting and financial disclosure, controls and procedures, certain relationships and related transactions, and director independence, and principal accounting fees and services. Additionally, this Annual Report on Form 10-K contains forward-looking statements within the meaning of the Private Securities Litigation Reform Act of 1995, which may affect the accuracy of the information provided. \\\\n\\\\nRisk factors also include the potential for lower fares or service fees, significant Driver incentives and consumer discounts and promotions, significant losses since inception, the need to attract and maintain a critical mass of Drivers, consumers, merchants, shippers, and carriers, the potential for negative media coverage and negative publicity, and the need to optimize organizational structure and effectively manage growth. Platform users may also engage in activities that could harm our', 'sources': [{'start': 87353, 'end': 89573, 'ref_doc_id': '7843f18e-066f-4d78-a3f5-bf2bf9ae386a', 'score': 0.8321939180445632}, {'start': 6620, 'end': 8321, 'ref_doc_id': '7843f18e-066f-4d78-a3f5-bf2bf9ae386a', 'score': 0.8186035956077489}, {'start': 89611, 'end': 91789, 'ref_doc_id': '7843f18e-066f-4d78-a3f5-bf2bf9ae386a', 'score': 0.816380689156515}]}\""
       ]
      },
-     "execution_count": 16,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -583,12 +907,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 21,
    "id": "05b5cd50-cf28-4ad1-b1c2-067f626bad93",
    "metadata": {
     "tags": []
    },
    "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "  <style>\n",
+       "    pre {\n",
+       "        white-space: pre-wrap;\n",
+       "    }\n",
+       "  </style>\n",
+       "  "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -599,127 +941,15 @@
       "\u001b[32;1m\u001b[1;3m\n",
       "Thought: Do I need to use a tool? Yes\n",
       "Action: Graph Index\n",
-      "Action Input: Compare/contrast the risk factors described in the Uber 10-K across years.\u001b[0m\u001b[33;1m\u001b[1;3m> Current query: Compare/contrast the risk factors described in the Uber 10-K across years.\n",
-      "\u001b[0m\u001b[38;5;200m\u001b[1;3m> New query:  What are the risk factors described in the Uber 10-K for the 2022 fiscal year?\n",
-      "\u001b[0m\u001b[33;1m\u001b[1;3m> Current query: Compare/contrast the risk factors described in the Uber 10-K across years.\n",
-      "\u001b[0m\u001b[38;5;200m\u001b[1;3m> New query:  What are the risk factors described in the Uber 10-K for the 2022 fiscal year?\n",
-      "\u001b[0m"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:gpt_index.token_counter.token_counter:> [query] Total LLM token usage: 964 tokens\n",
-      "INFO:gpt_index.token_counter.token_counter:> [query] Total embedding token usage: 18 tokens\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36;1m\u001b[1;3m> Got response: \n",
-      "The risk factors described in the Uber 10-K for the 2022 fiscal year include: the potential for changes in the classification of Drivers, the potential for increased competition, the potential for...\n",
-      "\u001b[0m\u001b[33;1m\u001b[1;3m> Current query: Compare/contrast the risk factors described in the Uber 10-K across years.\n",
-      "\u001b[0m\u001b[38;5;200m\u001b[1;3m> New query:  What are the risk factors described in the Uber 10-K for the 2021 fiscal year?\n",
-      "\u001b[0m\u001b[33;1m\u001b[1;3m> Current query: Compare/contrast the risk factors described in the Uber 10-K across years.\n",
-      "\u001b[0m\u001b[38;5;200m\u001b[1;3m> New query:  What are the risk factors described in the Uber 10-K for the 2021 fiscal year?\n",
-      "\u001b[0m"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:gpt_index.token_counter.token_counter:> [query] Total LLM token usage: 590 tokens\n",
-      "INFO:gpt_index.token_counter.token_counter:> [query] Total embedding token usage: 18 tokens\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36;1m\u001b[1;3m> Got response: \n",
-      "1. The COVID-19 pandemic and the impact of actions to mitigate the pandemic have adversely affected and may continue to adversely affect parts of our business.\n",
+      "Action Input: Compare/contrast the risk factors described in the Uber 10-K across years.\n",
+      "AI: The Graph Index tool has been used to compare and contrast the risk factors described in the Uber 10-K across years. The following are the key differences: \n",
       "\n",
-      "2. Our business would be adversely ...\n",
-      "\u001b[0m\u001b[33;1m\u001b[1;3m> Current query: Compare/contrast the risk factors described in the Uber 10-K across years.\n",
-      "\u001b[0m\u001b[38;5;200m\u001b[1;3m> New query:  What are the risk factors described in the Uber 10-K for the 2020 fiscal year?\n",
-      "\u001b[0m\u001b[33;1m\u001b[1;3m> Current query: Compare/contrast the risk factors described in the Uber 10-K across years.\n",
-      "\u001b[0m\u001b[38;5;200m\u001b[1;3m> New query:  What are the risk factors described in the Uber 10-K for the 2020 fiscal year?\n",
-      "\u001b[0m"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:gpt_index.token_counter.token_counter:> [query] Total LLM token usage: 516 tokens\n",
-      "INFO:gpt_index.token_counter.token_counter:> [query] Total embedding token usage: 18 tokens\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36;1m\u001b[1;3m> Got response: \n",
-      "The risk factors described in the Uber 10-K for the 2020 fiscal year include: the timing of widespread adoption of vaccines against the virus, additional actions that may be taken by governmental ...\n",
-      "\u001b[0m\u001b[33;1m\u001b[1;3m> Current query: Compare/contrast the risk factors described in the Uber 10-K across years.\n",
-      "\u001b[0m\u001b[38;5;200m\u001b[1;3m> New query:  What are the risk factors described in the Uber 10-K for the 2019 fiscal year?\n",
-      "\u001b[0m\u001b[33;1m\u001b[1;3m> Current query: Compare/contrast the risk factors described in the Uber 10-K across years.\n",
-      "\u001b[0m\u001b[38;5;200m\u001b[1;3m> New query:  What are the risk factors described in the Uber 10-K for the 2019 fiscal year?\n",
-      "\u001b[0m"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:gpt_index.token_counter.token_counter:> [query] Total LLM token usage: 1020 tokens\n",
-      "INFO:gpt_index.token_counter.token_counter:> [query] Total embedding token usage: 18 tokens\n",
-      "INFO:gpt_index.indices.common.tree.base:> Building index from nodes: 0 chunks\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36;1m\u001b[1;3m> Got response: \n",
-      "Risk factors described in the Uber 10-K for the 2019 fiscal year include: competition from other transportation providers; the impact of government regulations; the impact of litigation; the impac...\n",
-      "\u001b[0m"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:gpt_index.token_counter.token_counter:> [query] Total LLM token usage: 7039 tokens\n",
-      "INFO:gpt_index.token_counter.token_counter:> [query] Total embedding token usage: 72 tokens\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "• In 2020, the risk factors included the COVID-19 pandemic and the impact of actions to mitigate the pandemic, the potential classification of Drivers as employees, workers or quasi-employees instead of independent contractors, the highly competitive nature of the mobility, delivery, and logistics industries, unresolved staff comments, legal proceedings, mine safety disclosures, market for registrant’s common equity, related stockholder matters and issuer purchases of equity securities, quantitative and qualitative disclosures about market risk, changes in and disagreements with accountants on accounting and financial disclosure, controls and procedures, certain relationships and related transactions, and director independence, and principal accounting fees and services. \n",
       "\n",
-      "Observation: \u001b[36;1m\u001b[1;3m\n",
-      "In 2020, the risk factors included the timing of widespread adoption of vaccines against the virus, additional actions that may be taken by governmental authorities, the further impact on the business of Drivers, Merchants, consumers, and business partners, and the legal challenges to the classification of Drivers as independent contractors. In 2019, the risk factors included competition from other transportation providers, the impact of government regulations, the impact of litigation, the impact of negative publicity, the impact of changes in tax laws, the impact of changes in labor laws, the impact of changes in technology, the impact of cybersecurity risks, the impact of changes in economic conditions, the impact of changes in the financial markets, and the impact of changes in the competitive landscape. In 2022, the risk factors include the potential for changes in the classification of Drivers, the potential for increased competition, the potential for changes in laws and regulations, the potential for litigation and regulatory actions, the potential for disruption of our business operations, the potential for failure to protect our intellectual property, the potential for failure to attract and retain key personnel, the potential for failure to maintain relationships with third-party providers, the potential for failure to maintain brand and reputation, the potential for failure to develop and maintain secure technology, the potential for failure to comply with data privacy and security laws, the potential for failure to comply with anti-corruption laws, the potential for failure to comply with labor and employment laws, the potential for failure to comply with environmental laws, the potential for failure to comply with anti-trust laws, the potential for failure to comply with export control laws, the potential for failure to comply with anti-money laundering laws, the potential for failure to comply with tax laws, the potential for failure to comply with consumer protection laws, the potential for failure to comply with anti-discrimination laws, the potential for failure to comply with anti-bribery laws, the potential for failure to comply with anti-boycott laws, the potential for failure to comply with sanctions laws, the potential for failure to comply with anti-terrorism laws, the potential for failure to comply with anti-corruption laws, the potential for failure to comply with anti-fraud laws, and the potential for failure to comply with anti-trust laws.\n",
-      "\n",
-      "The risk factors described in the Uber 10-K have remained largely consistent across years, with some changes to reflect the current environment. In 2020, the risk factors focused more on the impact of the virus and the legal challenges to the classification of Drivers as independent contractors. In 2019, the risk\u001b[0m\n",
-      "\u001b[32;1m\u001b[1;3m\u001b[0m\n",
+      "• In 2021, the risk factors included the potential for lower fares or service fees, significant Driver incentives and consumer discounts and promotions, significant losses since inception, the need to attract and maintain a critical mass of Drivers, consumers\u001b[0m\n",
       "\n",
       "\u001b[1m> Finished chain.\u001b[0m\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'\\nIn 2020, the risk factors included the timing of widespread adoption of vaccines against the virus, additional actions that may be taken by governmental authorities, the further impact on the business of Drivers, Merchants, consumers, and business partners, and the legal challenges to the classification of Drivers as independent contractors. In 2019, the risk factors included competition from other transportation providers, the impact of government regulations, the impact of litigation, the impact of negative publicity, the impact of changes in tax laws, the impact of changes in labor laws, the impact of changes in technology, the impact of cybersecurity risks, the impact of changes in economic conditions, the impact of changes in the financial markets, and the impact of changes in the competitive landscape. In 2022, the risk factors include the potential for changes in the classification of Drivers, the potential for increased competition, the potential for changes in laws and regulations, the potential for litigation and regulatory actions, the potential for disruption of our business operations, the potential for failure to protect our intellectual property, the potential for failure to attract and retain key personnel, the potential for failure to maintain relationships with third-party providers, the potential for failure to maintain brand and reputation, the potential for failure to develop and maintain secure technology, the potential for failure to comply with data privacy and security laws, the potential for failure to comply with anti-corruption laws, the potential for failure to comply with labor and employment laws, the potential for failure to comply with environmental laws, the potential for failure to comply with anti-trust laws, the potential for failure to comply with export control laws, the potential for failure to comply with anti-money laundering laws, the potential for failure to comply with tax laws, the potential for failure to comply with consumer protection laws, the potential for failure to comply with anti-discrimination laws, the potential for failure to comply with anti-bribery laws, the potential for failure to comply with anti-boycott laws, the potential for failure to comply with sanctions laws, the potential for failure to comply with anti-terrorism laws, the potential for failure to comply with anti-corruption laws, the potential for failure to comply with anti-fraud laws, and the potential for failure to comply with anti-trust laws.\\n\\nThe risk factors described in the Uber 10-K have remained largely consistent across years, with some changes to reflect the current environment. In 2020, the risk factors focused more on the impact of the virus and the legal challenges to the classification of Drivers as independent contractors. In 2019, the risk'"
-      ]
-     },
-     "execution_count": 31,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -727,7 +957,20 @@
     "    \"Compare/contrast the risk factors described in the Uber 10-K across years. Give answer in bullet points.\"\n",
     ")\n",
     "\n",
-    "agent_chain.run(input=cross_query_str)"
+    "response = agent_chain.run(input=cross_query_str)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54305c87",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# parse the response w/ sources\n",
+    "import json\n",
+    "response_json = json.loads(response)\n",
+    "print(response)"
    ]
   },
   {
@@ -814,9 +1057,9 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "llama_index",
+   "display_name": "gpt_index",
    "language": "python",
-   "name": "llama_index"
+   "name": "gpt_index"
   },
   "language_info": {
    "codemirror_mode": {
@@ -828,7 +1071,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.11.0"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/gpt_index/indices/query/query_runner.py
+++ b/gpt_index/indices/query/query_runner.py
@@ -13,13 +13,9 @@ from gpt_index.data_structs.struct_type import IndexStructType
 from gpt_index.docstore import BaseDocumentStore
 from gpt_index.indices.query.base import BaseGPTIndexQuery
 from gpt_index.indices.query.query_combiner.base import (
-    BaseQueryCombiner,
-    get_default_query_combiner,
-)
+    BaseQueryCombiner, get_default_query_combiner)
 from gpt_index.indices.query.query_transform.base import (
-    BaseQueryTransform,
-    IdentityQueryTransform,
-)
+    BaseQueryTransform, IdentityQueryTransform)
 from gpt_index.indices.query.schema import QueryBundle, QueryConfig, QueryMode
 from gpt_index.indices.service_context import ServiceContext
 from gpt_index.response.schema import RESPONSE_TYPE
@@ -171,7 +167,6 @@ class QueryRunner:
         query_context = self._query_context.get(index_struct.index_id, {})
         query_kwargs.update(query_context)
 
-        print(query_kwargs)
         query_obj = query_cls.from_args(
             index_struct=index_struct,
             docstore=self._docstore,

--- a/gpt_index/indices/query/query_runner.py
+++ b/gpt_index/indices/query/query_runner.py
@@ -13,9 +13,13 @@ from gpt_index.data_structs.struct_type import IndexStructType
 from gpt_index.docstore import BaseDocumentStore
 from gpt_index.indices.query.base import BaseGPTIndexQuery
 from gpt_index.indices.query.query_combiner.base import (
-    BaseQueryCombiner, get_default_query_combiner)
+    BaseQueryCombiner,
+    get_default_query_combiner,
+)
 from gpt_index.indices.query.query_transform.base import (
-    BaseQueryTransform, IdentityQueryTransform)
+    BaseQueryTransform,
+    IdentityQueryTransform,
+)
 from gpt_index.indices.query.schema import QueryBundle, QueryConfig, QueryMode
 from gpt_index.indices.service_context import ServiceContext
 from gpt_index.response.schema import RESPONSE_TYPE

--- a/gpt_index/langchain_helpers/agents/tools.py
+++ b/gpt_index/langchain_helpers/agents/tools.py
@@ -5,8 +5,20 @@ from typing import Dict, List, cast
 from langchain.tools import BaseTool
 from pydantic import BaseModel, Field
 
-from gpt_index.indices.composability.graph import QUERY_CONFIG_TYPE, ComposableGraph
 from gpt_index.indices.base import BaseGPTIndex
+from gpt_index.indices.composability.graph import (QUERY_CONFIG_TYPE,
+                                                   ComposableGraph)
+from gpt_index.response.schema import RESPONSE_TYPE
+
+
+def _get_response_with_sources(response: RESPONSE_TYPE) -> str:
+    """Return a response with source node info."""
+    source_data = []
+    for source_node in response.source_nodes:
+        source_data.append(source_node.node.node_info)
+        source_data[-1]['ref_doc_id'] = source_node.node.ref_doc_id
+        source_data[-1]['score'] = source_node.score
+    return str({'answer': str(response), 'sources': source_data})
 
 
 class IndexToolConfig(BaseModel):
@@ -45,24 +57,31 @@ class LlamaIndexTool(BaseTool):
     # NOTE: name/description still needs to be set
     index: BaseGPTIndex
     query_kwargs: Dict = Field(default_factory=dict)
+    return_sources: bool = False
 
     @classmethod
     def from_tool_config(cls, tool_config: IndexToolConfig) -> "LlamaIndexTool":
         """Create a tool from a tool config."""
+        return_sources = tool_config.tool_kwargs.pop('return_sources', False)
         return cls(
             index=tool_config.index,
             name=tool_config.name,
             description=tool_config.description,
+            return_sources=return_sources,
             query_kwargs=tool_config.index_query_kwargs,
             **tool_config.tool_kwargs,
         )
 
     def _run(self, tool_input: str) -> str:
         response = self.index.query(tool_input, **self.query_kwargs)
+        if self.return_sources:
+            return _get_response_with_sources(response)
         return str(response)
 
     async def _arun(self, tool_input: str) -> str:
         response = await self.index.aquery(tool_input, **self.query_kwargs)
+        if self.return_sources:
+            return _get_response_with_sources(response)
         return str(response)
 
 
@@ -72,14 +91,17 @@ class LlamaGraphTool(BaseTool):
     # NOTE: name/description still needs to be set
     graph: ComposableGraph
     query_configs: List[Dict] = Field(default_factory=list)
+    return_sources: bool = False
 
     @classmethod
     def from_tool_config(cls, tool_config: GraphToolConfig) -> "LlamaGraphTool":
         """Create a tool from a tool config."""
+        return_sources = tool_config.tool_kwargs.pop('return_sources', False)
         return cls(
             graph=tool_config.graph,
             name=tool_config.name,
             description=tool_config.description,
+            return_sources=return_sources,
             query_configs=tool_config.query_configs,
             **tool_config.tool_kwargs,
         )
@@ -87,9 +109,13 @@ class LlamaGraphTool(BaseTool):
     def _run(self, tool_input: str) -> str:
         query_configs = cast(List[QUERY_CONFIG_TYPE], self.query_configs)
         response = self.graph.query(tool_input, query_configs=query_configs)
+        if self.return_sources:
+            return _get_response_with_sources(response)
         return str(response)
 
     async def _arun(self, tool_input: str) -> str:
         query_configs = cast(List[QUERY_CONFIG_TYPE], self.query_configs)
         response = await self.graph.aquery(tool_input, query_configs=query_configs)
+        if self.return_sources:
+            return _get_response_with_sources(response)
         return str(response)

--- a/gpt_index/langchain_helpers/agents/tools.py
+++ b/gpt_index/langchain_helpers/agents/tools.py
@@ -6,8 +6,7 @@ from langchain.tools import BaseTool
 from pydantic import BaseModel, Field
 
 from gpt_index.indices.base import BaseGPTIndex
-from gpt_index.indices.composability.graph import (QUERY_CONFIG_TYPE,
-                                                   ComposableGraph)
+from gpt_index.indices.composability.graph import QUERY_CONFIG_TYPE, ComposableGraph
 from gpt_index.response.schema import RESPONSE_TYPE
 
 
@@ -15,10 +14,13 @@ def _get_response_with_sources(response: RESPONSE_TYPE) -> str:
     """Return a response with source node info."""
     source_data = []
     for source_node in response.source_nodes:
-        source_data.append(source_node.node.node_info)
-        source_data[-1]['ref_doc_id'] = source_node.node.ref_doc_id
-        source_data[-1]['score'] = source_node.score
-    return str({'answer': str(response), 'sources': source_data})
+        metadata = (
+            source_node.node.node_info if source_node.node.node_info is not None else {}
+        )
+        source_data.append(metadata)
+        source_data[-1]["ref_doc_id"] = source_node.node.ref_doc_id
+        source_data[-1]["score"] = source_node.score
+    return str({"answer": str(response), "sources": source_data})
 
 
 class IndexToolConfig(BaseModel):
@@ -62,7 +64,7 @@ class LlamaIndexTool(BaseTool):
     @classmethod
     def from_tool_config(cls, tool_config: IndexToolConfig) -> "LlamaIndexTool":
         """Create a tool from a tool config."""
-        return_sources = tool_config.tool_kwargs.pop('return_sources', False)
+        return_sources = tool_config.tool_kwargs.pop("return_sources", False)
         return cls(
             index=tool_config.index,
             name=tool_config.name,
@@ -96,7 +98,7 @@ class LlamaGraphTool(BaseTool):
     @classmethod
     def from_tool_config(cls, tool_config: GraphToolConfig) -> "LlamaGraphTool":
         """Create a tool from a tool config."""
-        return_sources = tool_config.tool_kwargs.pop('return_sources', False)
+        return_sources = tool_config.tool_kwargs.pop("return_sources", False)
         return cls(
             graph=tool_config.graph,
             name=tool_config.name,


### PR DESCRIPTION
A (highly requested) feature is to add some sort of "sources" option to the llama+langchain agent wrappers

So, here is my initial attempt at doing that 👍🏻 

Basically, in your tool kwargs, you can set `{..., return_sources: True}`, and the agent will spit on a json string containing the answer + source details. (since the response have to be a string, you can load the response with `json.loads()`)