### PR TITLE
[DRAFT] add time weighting to simple vector index 

### DIFF
--- a/examples/vector_indices/SimpleIndexDemo-TimeWeighted.ipynb
+++ b/examples/vector_indices/SimpleIndexDemo-TimeWeighted.ipynb
@@ -1,0 +1,266 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9c48213d-6e6a-4c10-838a-2a7c710c3a05",
+   "metadata": {},
+   "source": [
+    "# Simple Index Demo"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50d3b817-b70e-4667-be4f-d3a0fe4bd119",
+   "metadata": {},
+   "source": [
+    "#### Load documents, build the GPTSimpleVectorIndex"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "690a6918-7c75-4f95-9ccc-d2c4a1fe00d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "import sys\n",
+    "\n",
+    "logging.basicConfig(stream=sys.stdout, level=logging.INFO)\n",
+    "logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))\n",
+    "\n",
+    "from gpt_index import GPTSimpleVectorIndex, SimpleDirectoryReader, ServiceContext\n",
+    "from gpt_index.docstore import SimpleDocumentStore\n",
+    "from gpt_index.node_parser import SimpleNodeParser\n",
+    "from IPython.display import Markdown, display\n",
+    "from datetime import datetime, timedelta"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ca84c38-64a2-436d-90b4-bb3781ee3c41",
+   "metadata": {},
+   "source": [
+    "### Parse Documents into Nodes, add to Docstore\n",
+    "\n",
+    "In this example, there are 3 different versions of PG's essay. They are largely identical **except** \n",
+    "for one specific section, which details the amount of funding they raised for Viaweb. \n",
+    "\n",
+    "V1: 50k, V2: 30k, V3: 10K\n",
+    "\n",
+    "V1: 2020-01-01, V2: 2020-02-03, V3: 2022-04-12\n",
+    "\n",
+    "The idea is to encourage index to fetch the most recent info (which is V3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "id": "1947c07b-f68f-43c7-90f9-99a2fa40a3bc",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# load documents\n",
+    "now = datetime.now()\n",
+    "key = \"__last_accessed__\"\n",
+    "\n",
+    "\n",
+    "doc1 = SimpleDirectoryReader(\n",
+    "    input_files=['../node_postprocessor/test_versioned_data/paul_graham_essay_v1.txt']\n",
+    ").load_data()[0]\n",
+    "\n",
+    "\n",
+    "doc2 = SimpleDirectoryReader(\n",
+    "    input_files=['../node_postprocessor/test_versioned_data/paul_graham_essay_v2.txt']\n",
+    ").load_data()[0]\n",
+    "\n",
+    "doc3 = SimpleDirectoryReader(\n",
+    "    input_files=['../node_postprocessor/test_versioned_data/paul_graham_essay_v3.txt']\n",
+    ").load_data()[0]\n",
+    "\n",
+    "\n",
+    "# define service context (wrapper container around current classes)\n",
+    "service_context = ServiceContext.from_defaults(chunk_size_limit=512)\n",
+    "node_parser = service_context.node_parser\n",
+    "\n",
+    "# use node parser in service context to parse docs into nodes\n",
+    "nodes1 = node_parser.get_nodes_from_documents([doc1])\n",
+    "nodes2 = node_parser.get_nodes_from_documents([doc2])    \n",
+    "nodes3 = node_parser.get_nodes_from_documents([doc3])\n",
+    "    \n",
+    "\n",
+    "# fetch the modified chunk from each document, set node info\n",
+    "nodes1[22].node_info[key] = (now - timedelta(hours=3)).timestamp()\n",
+    "nodes2[22].node_info[key] = (now - timedelta(hours=2)).timestamp()\n",
+    "nodes3[22].node_info[key] = (now - timedelta(hours=1)).timestamp()\n",
+    "\n",
+    "\n",
+    "# add to docstore\n",
+    "docstore = SimpleDocumentStore()\n",
+    "nodes = [nodes1[22], nodes2[22], nodes3[22]]\n",
+    "docstore.add_documents(nodes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad144ee7-96da-4dd6-be00-fd6cf0c78e58",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "index = GPTSimpleVectorIndex(nodes, docstore=docstore)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "id": "2bbccf1d-ac39-427c-b3a3-f8e9d1d12348",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# save index to disk\n",
+    "index.save_to_disk('index_simple.json')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "id": "197ca78e-1310-474d-91e3-877c3636b901",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load index from disk\n",
+    "index = GPTSimpleVectorIndex.load_from_disk('index_simple.json')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6caf93b-6345-4c65-a346-a95b0f1746c4",
+   "metadata": {},
+   "source": [
+    "#### Query Index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "id": "d8f377c4-371c-4b6c-8722-1c2228586021",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# set time decay\n",
+    "from gpt_index.vector_stores.types import VectorStoreQueryConfig\n",
+    "\n",
+    "# disable time access refresh for now (enabled by default)\n",
+    "query_config = VectorStoreQueryConfig(\n",
+    "    use_time_decay=True, time_decay_rate=0.5, time_access_refresh=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "id": "c1c5ab85-25e4-4460-8b6a-3c119d92ba48",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:gpt_index.token_counter.token_counter:> [query] Total LLM token usage: 1690 tokens\n",
+      "> [query] Total LLM token usage: 1690 tokens\n",
+      "> [query] Total LLM token usage: 1690 tokens\n",
+      "INFO:gpt_index.token_counter.token_counter:> [query] Total embedding token usage: 22 tokens\n",
+      "> [query] Total embedding token usage: 22 tokens\n",
+      "> [query] Total embedding token usage: 22 tokens\n"
+     ]
+    }
+   ],
+   "source": [
+    "response = index.query(\n",
+    "    \"How much did the author raise in seed funding from Idelle's husband (Julian) for Viaweb?\", \n",
+    "    similarity_top_k=3,\n",
+    "    vector_store_query_config=query_config\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "id": "ad61b781-4be4-4b8c-9ddd-4069cb926877",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[1681975247.558827, 1681971647.558827, 1681968047.558827]"
+      ]
+     },
+     "execution_count": 71,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[n.node_info[key] for n in response.source_nodes]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 73,
+   "id": "4c2929fb",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Node(text='Engineering that seemed to be at least as big as the group that actually wrote the software. Now you could just update the software right on the server.\\n\\nWe started a new company we called Viaweb, after the fact that our software worked via the web, and we got $50,000 in seed funding from Idelle\\'s husband Julian. In return for that and doing the initial legal work and giving us business advice, we gave him 10% of the company. Ten years later this deal became the model for Y Combinator\\'s. We knew founders needed something like this, because we\\'d needed it ourselves.\\n\\nAt this stage I had a negative net worth, because the thousand dollars or so I had in the bank was more than counterbalanced by what I owed the government in taxes. (Had I diligently set aside the proper proportion of the money I\\'d made consulting for Interleaf? No, I had not.) So although Robert had his graduate student stipend, I needed that seed funding to live on.\\n\\nWe originally hoped to launch in September, but we got more ambitious about the software as we worked on it. Eventually we managed to build a WYSIWYG site builder, in the sense that as you were creating pages, they looked exactly like the static ones that would be generated later, except that instead of leading to static pages, the links all referred to closures stored in a hash table on the server.\\n\\nIt helped to have studied art, because the main goal of an online store builder is to make users look legit, and the key to looking legit is high production values. If you get page layouts and fonts and colors right, you can make a guy running a store out of his bedroom look more legit than a big company.\\n\\n(If you\\'re curious why my site looks so old-fashioned, it\\'s because it\\'s still made with this software. It may look clunky today, but in 1996 it was the last word in slick.)\\n\\nIn September, Robert rebelled. \"We\\'ve been working on this for a month,\" he said, \"and it\\'s still not done.\" This is funny in retrospect, because he would still be working on it almost 3 years later. But I decided it might be prudent to', doc_id='1e224e26-4909-4521-b3b6-cb1ef1f47a74', embedding=None, doc_hash='b11d013ec2af3de0379f92305d352ad6057cf7273fb4879685eb2e4e3adbfce9', extra_info=None, node_info={'start': 45309, 'end': 47377, '__last_accessed__': 1681718968.489189}, relationships={<DocumentRelationship.SOURCE: '1'>: 'ea6de381-bcb4-4575-8f3f-179a80eba4f1', <DocumentRelationship.PREVIOUS: '2'>: '978628b8-55d7-4a9a-a169-391dc7cf411a', <DocumentRelationship.NEXT: '3'>: 'edab60f8-78d8-451e-83c3-de653be93de0'})\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(response.source_nodes[0].node.get_text())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10957d33-fd6b-4db1-99bb-e7320d3fb152",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "llama_index",
+   "language": "python",
+   "name": "llama_index"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gpt_index/data_structs/node_v2.py
+++ b/gpt_index/data_structs/node_v2.py
@@ -71,6 +71,12 @@ class Node(BaseDocument):
     # document relationships
     relationships: Dict[DocumentRelationship, Any] = field(default_factory=dict)
 
+    def get_node_info(self) -> Dict[str, Any]:
+        """Get node info."""
+        if self.node_info is None:
+            raise ValueError("Node info not set.")
+        return self.node_info
+
     @property
     def ref_doc_id(self) -> Optional[str]:
         """Source document id.

--- a/gpt_index/vector_stores/__init__.py
+++ b/gpt_index/vector_stores/__init__.py
@@ -13,6 +13,7 @@ from gpt_index.vector_stores.pinecone import PineconeVectorStore
 from gpt_index.vector_stores.qdrant import QdrantVectorStore
 from gpt_index.vector_stores.simple import SimpleVectorStore
 from gpt_index.vector_stores.weaviate import WeaviateVectorStore
+from gpt_index.vector_stores.types import VectorStoreQueryConfig
 
 __all__ = [
     "SimpleVectorStore",
@@ -26,4 +27,5 @@ __all__ = [
     "ChatGPTRetrievalPluginClient",
     "MilvusVectorStore",
     "DeepLakeVectorStore",
+    "VectorStoreQueryConfig",
 ]

--- a/gpt_index/vector_stores/types.py
+++ b/gpt_index/vector_stores/types.py
@@ -1,11 +1,12 @@
 """Vector store index types."""
 
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
 
 from enum import Enum
 from gpt_index.data_structs.node_v2 import Node
+from gpt_index.docstore import BaseDocumentStore
 
 
 @dataclass
@@ -44,20 +45,76 @@ class VectorStoreQueryMode(str, Enum):
 
 
 @dataclass
+class VectorStoreQueryConfig:
+    """Vector store query config."""
+
+    similarity_top_k: int = 1
+    doc_ids: Optional[List[str]] = None
+    # NOTE: current mode
+    mode: VectorStoreQueryMode = VectorStoreQueryMode.DEFAULT
+    # NOTE: only for hybrid search (0 for bm25, 1 for vector search)
+    alpha: Optional[float] = None
+    # NOTE: only for time-weighted search atm
+    use_time_decay: bool = False
+    time_decay_rate: float = 0.99
+    last_accessed_key: Optional[str] = "__last_accessed__"
+    # whether to refresh last_accessed_key
+    time_access_refresh: bool = True
+
+
+@dataclass
 class VectorStoreQuery:
     """Vector store query."""
 
     # dense embedding
     query_embedding: Optional[List[float]] = None
-    similarity_top_k: int = 1
-    doc_ids: Optional[List[str]] = None
+    # similarity_top_k: int = 1
     query_str: Optional[str] = None
 
-    # NOTE: current mode
-    mode: VectorStoreQueryMode = VectorStoreQueryMode.DEFAULT
+    # used for embedding-only indexes; can look up node in docstore.
+    docstore: Optional[BaseDocumentStore] = None
 
-    # NOTE: only for hybrid search (0 for bm25, 1 for vector search)
-    alpha: Optional[float] = None
+    query_config: VectorStoreQueryConfig = field(default_factory=VectorStoreQueryConfig)
+
+    @property
+    def similarity_top_k(self) -> int:
+        """Get similarity top k."""
+        return self.query_config.similarity_top_k
+
+    @property
+    def doc_ids(self) -> Optional[List[str]]:
+        """Get doc ids."""
+        return self.query_config.doc_ids
+
+    @property
+    def mode(self) -> VectorStoreQueryMode:
+        """Get mode."""
+        return self.query_config.mode
+
+    @property
+    def alpha(self) -> Optional[float]:
+        """Get alpha."""
+        return self.query_config.alpha
+
+    @property
+    def use_time_decay(self) -> bool:
+        """Get use time decay."""
+        return self.query_config.use_time_decay
+
+    @property
+    def time_decay_rate(self) -> float:
+        """Get time decay rate."""
+        return self.query_config.time_decay_rate
+
+    # # NOTE: current mode
+    # mode: VectorStoreQueryMode = VectorStoreQueryMode.DEFAULT
+
+    # # NOTE: only for hybrid search (0 for bm25, 1 for vector search)
+    # alpha: Optional[float] = None
+
+    # # NOTE: only for time-weighted search atm
+    # use_time_decay: bool = False
+    # time_decay_rate: float = 0.99
 
 
 @runtime_checkable

--- a/tests/indices/vector_store/test_qdrant.py
+++ b/tests/indices/vector_store/test_qdrant.py
@@ -9,7 +9,11 @@ except ImportError:
 
 from gpt_index.data_structs import Node
 from gpt_index.vector_stores import QdrantVectorStore
-from gpt_index.vector_stores.types import NodeEmbeddingResult, VectorStoreQuery
+from gpt_index.vector_stores.types import (
+    NodeEmbeddingResult,
+    VectorStoreQuery,
+    VectorStoreQueryConfig,
+)
 
 
 @pytest.fixture
@@ -66,7 +70,8 @@ def test_build_query_filter_returns_match_any() -> None:
     client = qdrant_client.QdrantClient(":memory:")
     qdrant_vector_store = QdrantVectorStore(collection_name="test", client=client)
 
-    query = VectorStoreQuery(doc_ids=["1", "2", "3"])
+    query_config = VectorStoreQueryConfig(doc_ids=["1", "2", "3"])
+    query = VectorStoreQuery(query_config=query_config)
     query_filter = cast(Filter, qdrant_vector_store._build_query_filter(query))
 
     assert query_filter is not None
@@ -102,7 +107,8 @@ def test_build_query_filter_returns_combined_filter() -> None:
     client = qdrant_client.QdrantClient(":memory:")
     qdrant_vector_store = QdrantVectorStore(collection_name="test", client=client)
 
-    query = VectorStoreQuery(query_str="lorem", doc_ids=["1", "2", "3"])
+    query_config = VectorStoreQueryConfig(doc_ids=["1", "2", "3"])
+    query = VectorStoreQuery(query_str="lorem", query_config=query_config)
     query_filter = cast(Filter, qdrant_vector_store._build_query_filter(query))
 
     assert query_filter is not None

--- a/tests/vector_stores/__init__.py
+++ b/tests/vector_stores/__init__.py
@@ -1,0 +1,1 @@
+"""Init params."""

--- a/tests/vector_stores/test_base.py
+++ b/tests/vector_stores/test_base.py
@@ -1,0 +1,60 @@
+"""Vector store."""
+
+from gpt_index.vector_stores.simple import get_top_k_nodes
+from gpt_index.vector_stores.types import VectorStoreQueryConfig
+from gpt_index.data_structs.node_v2 import Node
+from unittest.mock import patch
+from typing import Dict, cast
+import datetime
+
+
+def test_get_top_k_nodes() -> None:
+    """Test get top k nodes."""
+
+    times = [0, 1, 2, 3]
+    key = "__last_accessed__"
+    nodes = [
+        Node(text="lorem ipsum", node_info={key: time}, doc_id=str(idx))
+        for idx, time in enumerate(times)
+    ]
+
+    # try with high time decay
+    query_embedding = [0.0, 0.0, 1.0]
+    node_embeddings = [[0.0, 0.0, 1.0] for _ in range(4)]
+
+    query_config = VectorStoreQueryConfig(
+        use_time_decay=True, time_decay_rate=0.9999, similarity_top_k=1
+    )
+
+    similarities, ids = get_top_k_nodes(
+        query_embedding, nodes, node_embeddings, query_config=query_config, now=4.0
+    )
+    assert len(similarities) == 1
+    assert ids == ["3"]
+
+    assert cast(Dict, nodes[0].node_info)[key] == 0
+    assert cast(Dict, nodes[1].node_info)[key] == 1
+    assert cast(Dict, nodes[2].node_info)[key] == 2
+    assert cast(Dict, nodes[3].node_info)[key] != 3
+
+    # try with low time decay - all nodes should be weighted similarly
+    # mock datetime.now
+    times = [0, 1, 2, 3]
+    key = "__last_accessed__"
+    nodes = [
+        Node(text="lorem ipsum", node_info={key: time}, doc_id=str(idx))
+        for idx, time in enumerate(times)
+    ]
+    query_config = VectorStoreQueryConfig(
+        use_time_decay=True, time_decay_rate=0.000000000002, similarity_top_k=1
+    )
+    query_embedding = [0.0, 0.0, 1.0]
+    # downweight newer nodes (so that newer nodes are less relevant)
+    node_embeddings = [[0.0, 0.0, -float(idx)] for idx in range(4)]
+    similarities, ids = get_top_k_nodes(
+        query_embedding, nodes, node_embeddings, query_config=query_config, now=4.0
+    )
+    assert len(similarities) == 1
+    assert ids == ["0"]
+    assert cast(Dict, nodes[0].node_info)[key] != 0
+    assert cast(Dict, nodes[3].node_info)[key] == 3


### PR DESCRIPTION
Implements time weighting (for simple vector index only for now). 

Turns out, this was a slightly more complicated change than I anticipated. 

Most of this is due to the fact that the vector store itself doesn't have access to the Node, so I had to pass along the docstore in the query call.

Main changes:
- separate out config args into VectorStoreQueryConfig
- Implement the time-weighted retrieval (as new function, with Nodes)
- Pass docstore into vector store query call.