### PR TITLE
fix: github api client should raise http error explicitly

### DIFF
--- a/gpt_index/readers/github_readers/github_api_client.py
+++ b/gpt_index/readers/github_readers/github_api_client.py
@@ -258,6 +258,7 @@ class GithubClient:
                 response = await _client.request(
                     method, url=self._endpoints[endpoint].format(**kwargs)
                 )
+                response.raise_for_status()
             except httpx.HTTPError as excp:
                 print(f"HTTP Exception for {excp.request.url} - {excp}")
                 raise excp


### PR DESCRIPTION
## Summary

GitHub API Client should raise error explicitly.

## Motivation

https://github.com/jerryjliu/llama_index/issues/1194

## Check

- [x] Code should raise error explicitly
- [x] If no error happens, code works correctly

### AS-IS

https://user-images.githubusercontent.com/13391129/233758402-263b0a30-ed5a-4c81-ab32-4268433ffed3.mov

### Code should raise error explicitly

https://user-images.githubusercontent.com/13391129/233758319-b0713bdb-9d26-41f7-8830-c08c35c5ce94.mov

### If no error happens, code works correctly

https://user-images.githubusercontent.com/13391129/233758434-1e889ddb-0dbd-46f6-8c77-4efd31ee8e01.mov
