### PR TITLE
docs: fixed outdated documentation about `insert_node` and added some doc helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: format lint
 
+GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
+
 format:
 	black .
 
@@ -10,3 +12,7 @@ lint:
 
 test:
 	pytest tests
+
+# Docs
+watch-docs: ## Build and watch documentation
+	sphinx-autobuild docs/ docs/_build/html --open-browser --watch $(GIT_ROOT)/gpt_index/

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,62 @@
+# LlamaIndex Documentation
+
+## A guide for docs contributors
+
+The `docs` directory contains the sphinx source text for LlamaIndex docs, visit
+https://gpt-index.readthedocs.io/ to read the full documentation.
+
+This guide is made for anyone who's interested in running LlamaIndex documentation locally,
+making changes to it and make contributions. LlamaIndex is made by the thriving community
+behind it, and you're always welcome to make contributions to the project and the 
+documentation. 
+
+## Build Docs
+
+If you haven't already, clone the LlamaIndex Github repo to a local directory:
+
+```bash
+git clone https://github.com/jerryjliu/llama_index.git && cd llama_index
+```
+
+Install all dependencies required for building docs (mainly `sphinx` and its extension):
+
+```bash
+pip install -r docs/requirements.txt
+```
+
+Build the sphinx docs:
+
+```bash
+cd docs
+make html
+```
+
+The docs HTML files are now generated under `docs/_build/html` directory, you can preview
+it locally with the following command:
+
+```bash
+python -m http.server 8000 -d _build/html
+```
+
+And open your browser at http://0.0.0.0:8000/ to view the generated docs.
+
+
+##### Watch Docs
+
+We recommend using sphinx-autobuild during development, which provides a live-reloading 
+server, that rebuilds the documentation and refreshes any open pages automatically when 
+changes are saved. This enables a much shorter feedback loop which can help boost 
+productivity when writing documentation.
+
+Simply run the following command from LlamaIndex project's root directory: 
+
+```bash
+sphinx-autobuild docs/ docs/_build/html
+```
+
+If you have `make` installed, you may also run:
+
+```bash
+make watch-docs
+```
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,14 +49,6 @@ changes are saved. This enables a much shorter feedback loop which can help boos
 productivity when writing documentation.
 
 Simply run the following command from LlamaIndex project's root directory: 
-
-```bash
-sphinx-autobuild docs/ docs/_build/html
-```
-
-If you have `make` installed, you may also run:
-
 ```bash
 make watch-docs
 ```
-

--- a/docs/guides/primer/usage_pattern.md
+++ b/docs/guides/primer/usage_pattern.md
@@ -111,7 +111,7 @@ created for each index during index construction. You can access the docstore
 associated with a given index through `index.docstore`.
 
 
-### Inserting Documents
+### Inserting Documents or Nodes
 
 You can also take advantage of the `insert` capability of indices to insert Document objects
 one at a time instead of during index construction. 
@@ -125,9 +125,19 @@ for doc in documents:
 
 ```
 
-See the [Update Index How-To](/how_to/index_structs/update.md) for details and an example notebook.
+If you want to insert nodes on directly you can use `insert_nodes` function
+instead.
 
-**NOTE**: An `insert_node` function is coming!
+```python
+from llama_index import GPTSimpleVectorIndex
+
+# nodes: Sequence[Node]
+index = GPTSimpleVectorIndex([])
+index.insert_nodes(nodes)
+
+```
+
+See the [Update Index How-To](/how_to/index_structs/update.md) for details and an example notebook.
 
 ### Customizing LLM's
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,5 @@ sphinx>=4.3.0
 furo>=2023.3.27
 docutils<0.17
 myst-parser
+sphinx-autobuild
+sphinx_rtd_theme


### PR DESCRIPTION
- Updated the section in Usage Patters about `insert_node` function
- added a README.md to /docs for others who are looking to contribute to docs
- added a makefile command for sphinx live rendering of docs.