### PR TITLE
Fixed an issue where document inserts would not also set the doc_hash after insert

### DIFF
--- a/gpt_index/indices/base.py
+++ b/gpt_index/indices/base.py
@@ -147,6 +147,7 @@ class BaseGPTIndex(Generic[IS], ABC):
         """Insert a document."""
         nodes = self.service_context.node_parser.get_nodes_from_documents([document])
         self.insert_nodes(nodes, **insert_kwargs)
+        self.docstore.set_document_hash(document.get_doc_id(), document.get_doc_hash())
 
     @abstractmethod
     def _delete(self, doc_id: str, **delete_kwargs: Any) -> None:


### PR DESCRIPTION
This is a bug that has a downstream effect of affecting refreshes. During a refresh, the code checks to see if the doc_hash of the updated document matches the doc_hash of the doc stored in the index. This was not being set during insert.

This has fixed the refresh issue in my code. Now, I don't get stuck in refresh loops.