### PR TITLE
add storage docs

### DIFF
--- a/docs/how_to/storage.rst
+++ b/docs/how_to/storage.rst
@@ -2,12 +2,14 @@ Storage
 ============
 
 LlamaIndex provides a high-level interface for ingesting, indexing, and querying your external data.
-By default, LlamaIndex hides away the complexities and let you query your data in under 5 lines of code.
+By default, LlamaIndex hides away the complexities and let you query your data in [under 5 lines of code](how_to/storage/customization.md).
 Under the hood, LlamaIndex also supports a swappable **storage layer** that allows you to customize:
 
 - Document Stores: where ingested documents (i.e., `Node` objects) are stored,
 - Index Stores: where index metadata are stored,
 - Vector Stores: where embedding vectors are stored.
+
+The Document/Index stores rely on a common Key-Value store abstraction, which is also detailed below.
 
 .. toctree::
    :maxdepth: 1
@@ -18,3 +20,4 @@ Under the hood, LlamaIndex also supports a swappable **storage layer** that allo
    storage/docstores.md
    storage/index_stores.md
    storage/vector_stores.md
+   storage/kv_stores.md

--- a/docs/how_to/storage/customization.md
+++ b/docs/how_to/storage/customization.md
@@ -1,4 +1,3 @@
-
 # Customizing Storage
 
 By default, LlamaIndex hides away the complexities and let you query your data in under 5 lines of code:

--- a/docs/how_to/storage/docstores.md
+++ b/docs/how_to/storage/docstores.md
@@ -1,6 +1,8 @@
 # Document Stores
 Document stores contain ingested document chunks, which we call `Node` objects.
 
+See the [API Reference](/reference/storage/docstore.rst) for more details.
+
 
 ### Simple Document Store
 By default, the `SimpleDocumentStore` stores `Node` objects in-memory. 

--- a/docs/how_to/storage/index_stores.md
+++ b/docs/how_to/storage/index_stores.md
@@ -2,6 +2,8 @@
 
 Index stores contains lightweight index metadata (i.e. additional state information created when building an index).
 
+See the [API Reference](/reference/storage/index_store.rst) for more details.
+
 ### Simple Index Store
 By default, LlamaIndex uses a simple index store backed by an in-memory key-value store.
 They can be persisted to (and loaded from) disk by calling `index_store.persist()` (and `SimpleIndexStore.from_persist_dir(...)` respectively).

--- a/docs/how_to/storage/kv_stores.md
+++ b/docs/how_to/storage/kv_stores.md
@@ -1,0 +1,11 @@
+# Key-Value Stores
+
+Key-Value stores are the underlying storage abstractions that power our [Document Stores](/how_to/storage/docstores.md) and [Index Stores](/how_to/storage/index_stores.md).
+
+We provide the following key-value stores:
+- **Simple Key-Value Store**: An in-memory KV store. The user can choose to call `persist` on this kv store to persist data to disk.
+- **MongoDB Key-Value Store**: A MongoDB KV store.
+
+See the [API Reference](/reference/storage/kv_store.rst) for more details.
+
+Note: At the moment, these storage abstractions are not externally facing.

--- a/docs/how_to/storage/save_load.md
+++ b/docs/how_to/storage/save_load.md
@@ -1,7 +1,7 @@
 # Persisting & Loading Data
 
 ## Persisting Data
-By default, LlamaIndex stores data in-memory, and need to be explicitly persisted if desired:
+By default, LlamaIndex stores data in-memory, and this data can be explicitly persisted if desired:
 ```python
 storage_context.persist()
 ```
@@ -21,7 +21,9 @@ storage_context = StorageContext.from_defaults(
 )
 ```
 
-To load the previously constructed indices:
+We can then load specific indices from the `StorageContext` through some convenience functions below.
+
+
 ```python
 from llama_index import load_index_from_storage, load_indices_from_storage, load_graph_from_storage
 
@@ -30,13 +32,15 @@ index = load_index_from_storage(storage_context, index_id="<index_id>") # need t
 index = load_index_from_storage(storage_context) # don't need to specify index_id if there's only one index in storage context
 
 # load multiple indices
-indices = load_indice_from_storage(storage_context) # loads all indices
-indices = load_indice_from_storage(storage_context, index_ids=<index_ids>) # loads specific indices
+indices = load_indices_from_storage(storage_context) # loads all indices
+indices = load_indices_from_storage(storage_context, index_ids=<index_ids>) # loads specific indices
 
 # load composable graph
 graph = load_graph_from_storage(storage_context, root_id="<root_id>") # loads graph with the specified root_id
 
 ```
+
+Here's the full [API Reference on saving and loading](/reference/storage/indices_save_load.rst).
 
 
 

--- a/docs/reference/storage.rst
+++ b/docs/reference/storage.rst
@@ -8,7 +8,9 @@ LlamaIndex offers core abstractions around storage of Nodes, indices, and vector
 A key abstraction is the `StorageContext` - this contains the underlying
 `BaseDocumentStore` (for nodes), `BaseIndexStore` (for indices), and `VectorStore` (for vectors).
 
-See below pages for more details.
+The Document/Node and index stores rely on a common `KVStore` abstraction, which is also detailed below.
+
+We show the API references for the Storage Classes, saving/loading indices from the Storage Context, and the Storage Context class itself below.
 
 .. toctree::
    :maxdepth: 1
@@ -17,6 +19,14 @@ See below pages for more details.
    storage/docstore.rst
    storage/index_store.rst
    storage/vector_store.rst
+   storage/kv_store.rst
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Saving/Loading Indices
+
+   storage/indices_save_load.rst
+
 
 .. automodule:: gpt_index.storage.storage_context
    :members:

--- a/docs/reference/storage/indices_save_load.rst
+++ b/docs/reference/storage/indices_save_load.rst
@@ -1,0 +1,8 @@
+.. _Ref-Indices-SaveLoad:
+
+Save / Load Indices
+=====================
+
+.. automodule:: gpt_index.indices.loading
+   :members:
+   :inherited-members:

--- a/docs/reference/storage/kv_store.rst
+++ b/docs/reference/storage/kv_store.rst
@@ -1,0 +1,9 @@
+.. _Ref-Storage-KVStore:
+
+
+KV Storage
+=================
+
+.. automodule:: gpt_index.storage.kvstore
+   :members:
+   :inherited-members:

--- a/gpt_index/storage/kvstore/__init__.py
+++ b/gpt_index/storage/kvstore/__init__.py
@@ -1,0 +1,4 @@
+from gpt_index.storage.kvstore.simple_kvstore import SimpleKVStore
+from gpt_index.storage.kvstore.mongodb_kvstore import MongoDBKVStore
+
+__all__ = ["SimpleKVStore", "MongoDBKVStore"]


### PR DESCRIPTION
Thought it would be good to expose the base kv store class for transparency (even if not user-facing).

Also exposing saving/loading in ref docs.

Also added some links 