### PR TITLE
Duplicate Logs Fix

### DIFF
--- a/gpt_index/indices/response/response_builder.py
+++ b/gpt_index/indices/response/response_builder.py
@@ -257,7 +257,6 @@ class CompactAndRefine(Refine):
             streaming=streaming,
         )
 
-    @llm_token_counter("aget_response")
     async def aget_response(
         self,
         query_str: str,
@@ -267,7 +266,6 @@ class CompactAndRefine(Refine):
     ) -> RESPONSE_TEXT_TYPE:
         return self.get_response(query_str, text_chunks, prev_response)
 
-    @llm_token_counter("get_response")
     def get_response(
         self,
         query_str: str,


### PR DESCRIPTION
It looks like the response_mode="compact" option was giving duplicate logs: https://github.com/jerryjliu/llama_index/issues/1384

Since it was call super().get_response, just had to remove the extra token counter wrapper

Also, it looks like the optimizer is logging on every text chunk. Kind of annoying, but it looks like a decent refactor to avoid that (ideally, we could use the token counter here). I could take a stab at that too if you think it's worthwhile lol