### PR TITLE
Fix error message when missing GITHUB_TOKEN

### DIFF
--- a/gpt_index/readers/github_readers/github_repository_reader.py
+++ b/gpt_index/readers/github_readers/github_repository_reader.py
@@ -89,7 +89,7 @@ class GithubRepositoryReader(BaseReader):
             if github_token is None:
                 raise ValueError(
                     "Please provide a Github token. "
-                    "You can do so by passing it as an argument or"
+                    "You can do so by passing it as an argument or "
                     + "by setting the GITHUB_TOKEN environment variable."
                 )
 


### PR DESCRIPTION
Trivial fix to fix the error message when missing a `GITHUB_TOKEN`. Current message has `"orby"`.

```
~/python/py311/lib/python3.11/site-packages/llama_index/readers/github_readers/github_repository_reader.py in __init__(self, owner, repo, use_parser, verbose, github_token, concurrent_requests, ignore_file_extensions, ignore_directories)
     88             github_token = os.getenv("GITHUB_TOKEN")
     89             if github_token is None:
---> 90                 raise ValueError(
     91                     "Please provide a Github token. "
     92                     "You can do so by passing it as an argument or"

ValueError: Please provide a Github token. You can do so by passing it as an argument orby setting the GITHUB_TOKEN environment variable.
```

