### PR TITLE
bump langchain dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 install_requires = [
     "dataclasses_json",
-    "langchain>=0.0.152",
+    "langchain>=0.0.154",
     "numpy",
     "tenacity>=8.2.0,<9.0.0",
     "openai>=0.26.4",


### PR DESCRIPTION
We should pin to the langchain version that has the new (https://github.com/jerryjliu/llama_index/issues/1909)