### PR TITLE
pin requests version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ install_requires = [
     "tenacity>=8.2.0,<9.0.0",
     "openai>=0.26.4",
     "pandas",
+    "requests<2.30.0",
 ]
 
 # NOTE: if python version >= 3.9, install tiktoken


### PR DESCRIPTION
some users have reported that the new requests version (2.30.0) breaks download_loader in llama_hub 