### PR TITLE
Modify the BaseGPTIndex delete function to call docstore delete to delete the metadata.

### DIFF
--- a/llama_index/indices/base.py
+++ b/llama_index/indices/base.py
@@ -197,6 +197,10 @@ class BaseGPTIndex(Generic[IS], ABC):
         """
         logger.debug(f"> Deleting document: {doc_id}")
         self._delete(doc_id, **delete_kwargs)
+        if hasattr(self.docstore, "delete_document"):
+            self.docstore.delete_document(doc_id, raise_error=False)
+        if hasattr(self.index_struct, "delete"):
+            self.index_struct.delete(doc_id)
         self._storage_context.index_store.add_index_struct(self._index_struct)
 
     def update(self, document: Document, **update_kwargs: Any) -> None:


### PR DESCRIPTION

The reason is that there is a bug where the docstore metadata will not delete the doc_id when calling delete. This code change has been verified and fixes the issue. raise_error is set to False, because the doc_id might not be in "docstore/data", but it would be in "docstore/metadata".