### PR TITLE
Minor vector store embedding result cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ Our vector store classes store embeddings and support lookup via similiarity sea
 These serve as the main data store and retrieval engine for our vector index.
 
 **Interface**:
-* `add` takes in a sequence of `NodeEmbeddingResults` and insert the embeddings (and possibly the node contents & metadata) into the vector store.
+* `add` takes in a sequence of `NodeWithEmbeddings` and insert the embeddings (and possibly the node contents & metadata) into the vector store.
 * `delete` removes entries given document IDs.
 * `query` retrieves top-k most similar entries given a query embedding.
 

--- a/llama_index/indices/vector_store/base.py
+++ b/llama_index/indices/vector_store/base.py
@@ -4,7 +4,7 @@ An index that that is built on top of an existing vector store.
 
 """
 
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from llama_index.callbacks.schema import CBEventType
 from llama_index.async_utils import run_async_tasks

--- a/llama_index/indices/vector_store/base.py
+++ b/llama_index/indices/vector_store/base.py
@@ -15,7 +15,10 @@ from llama_index.indices.base_retriever import BaseRetriever
 from llama_index.indices.service_context import ServiceContext
 from llama_index.storage.storage_context import StorageContext
 from llama_index.token_counter.token_counter import llm_token_counter
-from llama_index.vector_stores.types import NodeEmbeddingResult, VectorStore
+from llama_index.vector_stores.types import (
+    NodeWithEmbedding,
+    VectorStore,
+)
 
 
 class GPTVectorStoreIndex(BaseGPTIndex[IndexDict]):
@@ -57,29 +60,24 @@ class GPTVectorStoreIndex(BaseGPTIndex[IndexDict]):
         return VectorIndexRetriever(self, **kwargs)
 
     def _get_node_embedding_results(
-        self, nodes: Sequence[Node], existing_node_ids: Set
-    ) -> List[NodeEmbeddingResult]:
+        self, nodes: Sequence[Node]
+    ) -> List[NodeWithEmbedding]:
         """Get tuples of id, node, and embedding.
 
         Allows us to store these nodes in a vector store.
         Embeddings are called in batches.
 
         """
-        id_to_node_map: Dict[str, Node] = {}
         id_to_embed_map: Dict[str, List[float]] = {}
 
-        nodes_embedded = 0
         for n in nodes:
-            new_id = n.get_doc_id()
             if n.embedding is None:
-                nodes_embedded += 1
                 self._service_context.embed_model.queue_text_for_embedding(
-                    new_id, n.get_text()
+                    n.get_doc_id(), n.get_text()
                 )
             else:
-                id_to_embed_map[new_id] = n.embedding
+                id_to_embed_map[n.get_doc_id()] = n.embedding
 
-            id_to_node_map[new_id] = n
         event_id = self._service_context.callback_manager.on_event_start(
             CBEventType.EMBEDDING
         )
@@ -91,45 +89,37 @@ class GPTVectorStoreIndex(BaseGPTIndex[IndexDict]):
         ) = self._service_context.embed_model.get_queued_text_embeddings()
         self._service_context.callback_manager.on_event_end(
             CBEventType.EMBEDDING,
-            payload={"num_nodes": nodes_embedded},
+            payload={"num_nodes": len(result_ids)},
             event_id=event_id,
         )
         for new_id, text_embedding in zip(result_ids, result_embeddings):
             id_to_embed_map[new_id] = text_embedding
 
-        result_tups = []
-        for id, embed in id_to_embed_map.items():
-            doc_id = id_to_node_map[id].ref_doc_id
-            if doc_id is None:
-                raise ValueError("Reference doc id is None.")
-            result_tups.append(
-                NodeEmbeddingResult(id, id_to_node_map[id], embed, doc_id=doc_id)
-            )
-        return result_tups
+        results = []
+        for node in nodes:
+            embedding = id_to_embed_map[node.get_doc_id()]
+            result = NodeWithEmbedding(node=node, embedding=embedding)
+            results.append(result)
+        return results
 
     async def _aget_node_embedding_results(
         self,
         nodes: Sequence[Node],
-        existing_node_ids: Set,
-    ) -> List[NodeEmbeddingResult]:
+    ) -> List[NodeWithEmbedding]:
         """Asynchronously get tuples of id, node, and embedding.
 
         Allows us to store these nodes in a vector store.
         Embeddings are called in batches.
 
         """
-        id_to_node_map: Dict[str, Node] = {}
         id_to_embed_map: Dict[str, List[float]] = {}
 
         text_queue: List[Tuple[str, str]] = []
         for n in nodes:
-            new_id = n.get_doc_id()
             if n.embedding is None:
-                text_queue.append((new_id, n.get_text()))
+                text_queue.append((n.get_doc_id(), n.get_text()))
             else:
-                id_to_embed_map[new_id] = n.embedding
-
-            id_to_node_map[new_id] = n
+                id_to_embed_map[n.get_doc_id()] = n.embedding
 
         event_id = self._service_context.callback_manager.on_event_start(
             CBEventType.EMBEDDING
@@ -151,25 +141,18 @@ class GPTVectorStoreIndex(BaseGPTIndex[IndexDict]):
         for new_id, text_embedding in zip(result_ids, result_embeddings):
             id_to_embed_map[new_id] = text_embedding
 
-        result_tups = []
-        for id, embed in id_to_embed_map.items():
-            doc_id = id_to_node_map[id].ref_doc_id
-            if doc_id is None:
-                raise ValueError("Reference doc id is None.")
-            result_tups.append(
-                NodeEmbeddingResult(id, id_to_node_map[id], embed, doc_id=doc_id)
-            )
-        return result_tups
+        results = []
+        for node in nodes:
+            embedding = id_to_embed_map[node.get_doc_id()]
+            result = NodeWithEmbedding(node=node, embedding=embedding)
+            results.append(result)
+        return results
 
     async def _async_add_nodes_to_index(
         self, index_struct: IndexDict, nodes: Sequence[Node]
     ) -> None:
         """Asynchronously add nodes to index."""
-        embedding_results = await self._aget_node_embedding_results(
-            nodes,
-            set(),
-        )
-
+        embedding_results = await self._aget_node_embedding_results(nodes)
         new_ids = self._vector_store.add(embedding_results)
 
         # if the vector store doesn't store text, we need to add the nodes to the
@@ -185,11 +168,7 @@ class GPTVectorStoreIndex(BaseGPTIndex[IndexDict]):
         nodes: Sequence[Node],
     ) -> None:
         """Add document to index."""
-        embedding_results = self._get_node_embedding_results(
-            nodes,
-            set(),
-        )
-
+        embedding_results = self._get_node_embedding_results(nodes)
         new_ids = self._vector_store.add(embedding_results)
 
         if not self._vector_store.stores_text:

--- a/llama_index/vector_stores/chatgpt_plugin.py
+++ b/llama_index/vector_stores/chatgpt_plugin.py
@@ -9,14 +9,14 @@ from tqdm.auto import tqdm
 
 from llama_index.data_structs.node import Node, DocumentRelationship
 from llama_index.vector_stores.types import (
-    NodeEmbeddingResult,
+    NodeWithEmbedding,
     VectorStore,
     VectorStoreQueryResult,
     VectorStoreQuery,
 )
 
 
-def convert_docs_to_json(embedding_results: List[NodeEmbeddingResult]) -> List[Dict]:
+def convert_docs_to_json(embedding_results: List[NodeWithEmbedding]) -> List[Dict]:
     """Convert docs to JSON."""
     docs = []
     for embedding_result in embedding_results:
@@ -89,7 +89,7 @@ class ChatGPTRetrievalPluginClient(VectorStore):
 
     def add(
         self,
-        embedding_results: List[NodeEmbeddingResult],
+        embedding_results: List[NodeWithEmbedding],
     ) -> List[str]:
         """Add embedding_results to index."""
         headers = {"Authorization": f"Bearer {self._bearer_token}"}

--- a/llama_index/vector_stores/chatgpt_plugin.py
+++ b/llama_index/vector_stores/chatgpt_plugin.py
@@ -26,9 +26,8 @@ def convert_docs_to_json(embedding_results: List[NodeWithEmbedding]) -> List[Dic
         doc_dict = {
             "id": embedding_result.id,
             "text": embedding_result.node.get_text(),
-            # "source": embedding_result.node.source,
             # NOTE: this is the doc_id to reference document
-            "source_id": embedding_result.doc_id,
+            "source_id": embedding_result.ref_doc_id,
             # "url": "...",
             # "created_at": ...,
             # "author": "..."",

--- a/llama_index/vector_stores/chroma.py
+++ b/llama_index/vector_stores/chroma.py
@@ -6,7 +6,7 @@ from typing import Any, List, cast
 from llama_index.data_structs.node import DocumentRelationship, Node
 from llama_index.utils import truncate_text
 from llama_index.vector_stores.types import (
-    NodeEmbeddingResult,
+    NodeWithEmbedding,
     VectorStore,
     VectorStoreQuery,
     VectorStoreQueryResult,
@@ -44,11 +44,11 @@ class ChromaVectorStore(VectorStore):
 
         self._collection = cast(Collection, chroma_collection)
 
-    def add(self, embedding_results: List[NodeEmbeddingResult]) -> List[str]:
+    def add(self, embedding_results: List[NodeWithEmbedding]) -> List[str]:
         """Add embedding results to index.
 
         Args
-            embedding_results: List[NodeEmbeddingResult]: list of embedding results
+            embedding_results: List[NodeWithEmbedding]: list of embedding results
 
         """
         if not self._collection:

--- a/llama_index/vector_stores/chroma.py
+++ b/llama_index/vector_stores/chroma.py
@@ -61,7 +61,7 @@ class ChromaVectorStore(VectorStore):
         for result in embedding_results:
             embeddings.append(result.embedding)
             extra_info = result.node.extra_info or {}
-            metadatas.append({**extra_info, **{"document_id": result.doc_id}})
+            metadatas.append({**extra_info, **{"document_id": result.ref_doc_id}})
             ids.append(result.id)
             documents.append(result.node.get_text())
 

--- a/llama_index/vector_stores/deeplake.py
+++ b/llama_index/vector_stores/deeplake.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Optional, cast
 import numpy as np
 from llama_index.indices.query.embedding_utils import get_top_k_embeddings
 from llama_index.vector_stores.types import (
-    NodeEmbeddingResult,
+    NodeWithEmbedding,
     VectorStore,
     VectorStoreQuery,
     VectorStoreQueryResult,
@@ -139,11 +139,11 @@ class DeepLakeVectorStore(VectorStore):
         """Get client."""
         return self.ds
 
-    def add(self, embedding_results: List[NodeEmbeddingResult]) -> List[str]:
+    def add(self, embedding_results: List[NodeWithEmbedding]) -> List[str]:
         """Add the embeddings and their nodes into DeepLake.
 
         Args:
-            embedding_results (List[NodeEmbeddingResult]): The embeddings and their data
+            embedding_results (List[NodeWithEmbedding]): The embeddings and their data
                 to insert.
 
         Raises:

--- a/llama_index/vector_stores/deeplake.py
+++ b/llama_index/vector_stores/deeplake.py
@@ -162,7 +162,7 @@ class DeepLakeVectorStore(VectorStore):
         for result in embedding_results:
             embedding = result.embedding
             extra_info = result.node.extra_info or {}
-            metadata = {**extra_info, **{"document_id": result.doc_id}}
+            metadata = {**extra_info, **{"document_id": result.ref_doc_id}}
             id = result.id
             text = result.node.get_text()
 

--- a/llama_index/vector_stores/faiss.py
+++ b/llama_index/vector_stores/faiss.py
@@ -12,7 +12,7 @@ import numpy as np
 from llama_index.vector_stores.types import (
     DEFAULT_PERSIST_DIR,
     DEFAULT_PERSIST_FNAME,
-    NodeEmbeddingResult,
+    NodeWithEmbedding,
     VectorStore,
     VectorStoreQueryResult,
     VectorStoreQuery,
@@ -79,14 +79,14 @@ class FaissVectorStore(VectorStore):
 
     def add(
         self,
-        embedding_results: List[NodeEmbeddingResult],
+        embedding_results: List[NodeWithEmbedding],
     ) -> List[str]:
         """Add embedding results to index.
 
         NOTE: in the Faiss vector store, we do not store text in Faiss.
 
         Args
-            embedding_results: List[NodeEmbeddingResult]: list of embedding results
+            embedding_results: List[NodeWithEmbedding]: list of embedding results
 
         """
         new_ids = []

--- a/llama_index/vector_stores/lancedb.py
+++ b/llama_index/vector_stores/lancedb.py
@@ -73,7 +73,7 @@ class LanceDBVectorStore(VectorStore):
             data.append(
                 {
                     "id": result.id,
-                    "doc_id": result.doc_id,
+                    "doc_id": result.ref_doc_id,
                     "vector": result.embedding,
                     "text": result.node.get_text(),
                 }

--- a/llama_index/vector_stores/lancedb.py
+++ b/llama_index/vector_stores/lancedb.py
@@ -3,7 +3,7 @@ from typing import Any, List, Optional
 
 from llama_index.data_structs.node import DocumentRelationship, Node
 from llama_index.vector_stores.types import (
-    NodeEmbeddingResult,
+    NodeWithEmbedding,
     VectorStore,
     VectorStoreQueryResult,
     VectorStoreQuery,
@@ -65,7 +65,7 @@ class LanceDBVectorStore(VectorStore):
 
     def add(
         self,
-        embedding_results: List[NodeEmbeddingResult],
+        embedding_results: List[NodeWithEmbedding],
     ) -> List[str]:
         data = []
         ids = []

--- a/llama_index/vector_stores/milvus.py
+++ b/llama_index/vector_stores/milvus.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 
 from llama_index.data_structs.node import DocumentRelationship, Node
 from llama_index.vector_stores.types import (
-    NodeEmbeddingResult,
+    NodeWithEmbedding,
     VectorStore,
     VectorStoreQuery,
     VectorStoreQueryMode,
@@ -287,11 +287,11 @@ class MilvusVectorStore(VectorStore):
         """Get client."""
         return self.collection
 
-    def add(self, embedding_results: List[NodeEmbeddingResult]) -> List[str]:
+    def add(self, embedding_results: List[NodeWithEmbedding]) -> List[str]:
         """Add the embeddings and their nodes into Milvus.
 
         Args:
-            embedding_results (List[NodeEmbeddingResult]): The embeddings and their data
+            embedding_results (List[NodeWithEmbedding]): The embeddings and their data
                 to insert.
 
         Raises:

--- a/llama_index/vector_stores/milvus.py
+++ b/llama_index/vector_stores/milvus.py
@@ -318,7 +318,7 @@ class MilvusVectorStore(VectorStore):
         # Process that data we are going to insert
         for result in embedding_results:
             ids.append(result.id)
-            doc_ids.append(result.doc_id)
+            doc_ids.append(result.ref_doc_id)
             texts.append(result.node.get_text())
             embeddings.append(result.embedding)
 

--- a/llama_index/vector_stores/myscale.py
+++ b/llama_index/vector_stores/myscale.py
@@ -16,7 +16,7 @@ from llama_index.readers.myscale import (
 )
 from llama_index.utils import iter_batch
 from llama_index.vector_stores.types import (
-    NodeEmbeddingResult,
+    NodeWithEmbedding,
     VectorStore,
     VectorStoreQuery,
     VectorStoreQueryResult,
@@ -151,7 +151,7 @@ class MyScaleVectorStore(VectorStore):
 
     def _build_insert_statement(
         self,
-        values: List[NodeEmbeddingResult],
+        values: List[NodeWithEmbedding],
     ) -> str:
         _data = []
         for item in values:
@@ -173,12 +173,12 @@ class MyScaleVectorStore(VectorStore):
 
     def add(
         self,
-        embedding_results: List[NodeEmbeddingResult],
+        embedding_results: List[NodeWithEmbedding],
     ) -> List[str]:
         """Add embedding results to index.
 
         Args
-            embedding_results: List[NodeEmbeddingResult]: list of embedding results
+            embedding_results: List[NodeWithEmbedding]: list of embedding results
 
         """
 

--- a/llama_index/vector_stores/myscale.py
+++ b/llama_index/vector_stores/myscale.py
@@ -99,10 +99,10 @@ class MyScaleVectorStore(VectorStore):
         # schema column name, type, and construct format method
         self.column_config: Dict = {
             "id": {"type": "String", "extract_func": lambda x: x.id},
-            "doc_id": {"type": "String", "extract_func": lambda x: x.doc_id},
+            "doc_id": {"type": "String", "extract_func": lambda x: x.ref_doc_id},
             "text": {
                 "type": "String",
-                "extract_func": lambda x: escape_str(x.node.text),
+                "extract_func": lambda x: escape_str(x.node.get_text()),
             },
             "vector": {
                 "type": "Array(Float32)",

--- a/llama_index/vector_stores/opensearch.py
+++ b/llama_index/vector_stores/opensearch.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, cast
 
 from llama_index.data_structs import Node
 from llama_index.vector_stores.types import (
-    NodeEmbeddingResult,
+    NodeWithEmbedding,
     VectorStore,
     VectorStoreQueryResult,
     VectorStoreQuery,
@@ -96,7 +96,7 @@ class OpensearchVectorClient:
         # will 400 if the index already existed, so allow 400 errors right here
         assert res.status_code == 200 or res.status_code == 400
 
-    def index_results(self, results: List[NodeEmbeddingResult]) -> List[str]:
+    def index_results(self, results: List[NodeWithEmbedding]) -> List[str]:
         """Store results in the index."""
         bulk_req: List[Dict[Any, Any]] = []
         for result in results:
@@ -180,12 +180,12 @@ class OpensearchVectorStore(VectorStore):
 
     def add(
         self,
-        embedding_results: List[NodeEmbeddingResult],
+        embedding_results: List[NodeWithEmbedding],
     ) -> List[str]:
         """Add embedding results to index.
 
         Args
-            embedding_results: List[NodeEmbeddingResult]: list of embedding results
+            embedding_results: List[NodeWithEmbedding]: list of embedding results
 
         """
         self._client.index_results(embedding_results)

--- a/llama_index/vector_stores/opensearch.py
+++ b/llama_index/vector_stores/opensearch.py
@@ -103,7 +103,7 @@ class OpensearchVectorClient:
             bulk_req.append({"index": {"_index": self._index, "_id": result.id}})
             bulk_req.append(
                 {
-                    self._text_field: result.node.text,
+                    self._text_field: result.node.get_text(),
                     self._embedding_field: result.embedding,
                 }
             )

--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, Dict, List, Optional, cast
 
 from llama_index.data_structs.node import DocumentRelationship, Node
 from llama_index.vector_stores.types import (
-    NodeEmbeddingResult,
+    NodeWithEmbedding,
     VectorStore,
     VectorStoreQuery,
     VectorStoreQueryMode,
@@ -190,12 +190,12 @@ class PineconeVectorStore(VectorStore):
 
     def add(
         self,
-        embedding_results: List[NodeEmbeddingResult],
+        embedding_results: List[NodeWithEmbedding],
     ) -> List[str]:
         """Add embedding results to index.
 
         Args
-            embedding_results: List[NodeEmbeddingResult]: list of embedding results
+            embedding_results: List[NodeWithEmbedding]: list of embedding results
 
         """
         ids = []

--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -200,15 +200,14 @@ class PineconeVectorStore(VectorStore):
         """
         ids = []
         for result in embedding_results:
-            new_id = result.id
+            node_id = result.id
             node = result.node
-            text_embedding = result.embedding
 
             metadata = {
                 "text": node.get_text(),
                 # NOTE: this is the reference to source doc
-                "doc_id": result.doc_id,
-                "id": new_id,
+                "doc_id": node.ref_doc_id,
+                "id": node_id,
             }
             if node.extra_info:
                 # TODO: check if overlap with default metadata keys
@@ -233,8 +232,8 @@ class PineconeVectorStore(VectorStore):
             metadata.update(self._metadata_filters)
 
             entry = {
-                "id": new_id,
-                "values": text_embedding,
+                "id": node_id,
+                "values": result.embedding,
                 "metadata": metadata,
             }
             if self._add_sparse_vector:
@@ -245,7 +244,7 @@ class PineconeVectorStore(VectorStore):
             self._pinecone_index.upsert(
                 [entry], namespace=self._namespace, **self._pinecone_kwargs
             )
-            ids.append(new_id)
+            ids.append(node_id)
         return ids
 
     def delete(self, doc_id: str, **delete_kwargs: Any) -> None:

--- a/llama_index/vector_stores/qdrant.py
+++ b/llama_index/vector_stores/qdrant.py
@@ -72,16 +72,16 @@ class QdrantVectorStore(VectorStore):
 
         ids = []
         for result_batch in iter_batch(embedding_results, self._batch_size):
-            new_ids = []
+            node_ids = []
             vectors = []
             payloads = []
             for result in result_batch:
-                new_ids.append(result.id)
+                node_ids.append(result.id)
                 vectors.append(result.embedding)
                 node = result.node
                 payloads.append(
                     {
-                        "doc_id": result.doc_id,
+                        "doc_id": result.ref_doc_id,
                         "text": node.get_text(),
                         "extra_info": node.extra_info,
                     }
@@ -90,12 +90,12 @@ class QdrantVectorStore(VectorStore):
             self._client.upsert(
                 collection_name=self._collection_name,
                 points=rest.Batch.construct(
-                    ids=new_ids,
+                    ids=node_ids,
                     vectors=vectors,
                     payloads=payloads,
                 ),
             )
-            ids.extend(new_ids)
+            ids.extend(node_ids)
         return ids
 
     def delete(self, doc_id: str, **delete_kwargs: Any) -> None:

--- a/llama_index/vector_stores/qdrant.py
+++ b/llama_index/vector_stores/qdrant.py
@@ -9,7 +9,7 @@ from typing import Any, List, Optional, cast
 from llama_index.data_structs.node import DocumentRelationship, Node
 from llama_index.utils import iter_batch
 from llama_index.vector_stores.types import (
-    NodeEmbeddingResult,
+    NodeWithEmbedding,
     VectorStore,
     VectorStoreQueryResult,
     VectorStoreQuery,
@@ -55,11 +55,11 @@ class QdrantVectorStore(VectorStore):
 
         self._batch_size = kwargs.get("batch_size", 100)
 
-    def add(self, embedding_results: List[NodeEmbeddingResult]) -> List[str]:
+    def add(self, embedding_results: List[NodeWithEmbedding]) -> List[str]:
         """Add embedding results to index.
 
         Args
-            embedding_results: List[NodeEmbeddingResult]: list of embedding results
+            embedding_results: List[NodeWithEmbedding]: list of embedding results
 
         """
         from qdrant_client.http import models as rest

--- a/llama_index/vector_stores/simple.py
+++ b/llama_index/vector_stores/simple.py
@@ -14,7 +14,7 @@ from llama_index.indices.query.embedding_utils import (
 from llama_index.vector_stores.types import (
     DEFAULT_PERSIST_DIR,
     DEFAULT_PERSIST_FNAME,
-    NodeEmbeddingResult,
+    NodeWithEmbedding,
     VectorStore,
     VectorStoreQueryResult,
     VectorStoreQuery,
@@ -85,7 +85,7 @@ class SimpleVectorStore(VectorStore):
 
     def add(
         self,
-        embedding_results: List[NodeEmbeddingResult],
+        embedding_results: List[NodeWithEmbedding],
     ) -> List[str]:
         """Add embedding_results to index."""
         for result in embedding_results:

--- a/llama_index/vector_stores/simple.py
+++ b/llama_index/vector_stores/simple.py
@@ -89,9 +89,8 @@ class SimpleVectorStore(VectorStore):
     ) -> List[str]:
         """Add embedding_results to index."""
         for result in embedding_results:
-            text_id = result.id
-            self._data.embedding_dict[text_id] = result.embedding
-            self._data.text_id_to_doc_id[text_id] = result.doc_id
+            self._data.embedding_dict[result.id] = result.embedding
+            self._data.text_id_to_doc_id[result.id] = result.ref_doc_id
         return [result.id for result in embedding_results]
 
     def delete(self, doc_id: str, **delete_kwargs: Any) -> None:

--- a/llama_index/vector_stores/types.py
+++ b/llama_index/vector_stores/types.py
@@ -13,21 +13,17 @@ DEFAULT_PERSIST_FNAME = "vector_store.json"
 
 
 @dataclass
-class NodeEmbeddingResult:
+class NodeWithEmbedding:
     """Node embedding result.
 
     Args:
-        id (str): Node id
         node (Node): Node
         embedding (List[float]): Embedding
-        doc_id (str): Document id
 
     """
 
-    id: str
     node: Node
     embedding: List[float]
-    doc_id: str
 
 
 @dataclass
@@ -83,7 +79,7 @@ class VectorStore(Protocol):
 
     def add(
         self,
-        embedding_results: List[NodeEmbeddingResult],
+        embedding_results: List[NodeWithEmbedding],
     ) -> List[str]:
         """Add embedding results to vector store."""
         ...

--- a/llama_index/vector_stores/types.py
+++ b/llama_index/vector_stores/types.py
@@ -25,6 +25,14 @@ class NodeWithEmbedding:
     node: Node
     embedding: List[float]
 
+    @property
+    def id(self) -> str:
+        return self.node.get_doc_id()
+
+    @property
+    def ref_doc_id(self) -> Optional[str]:
+        return self.node.ref_doc_id
+
 
 @dataclass
 class VectorStoreQueryResult:

--- a/llama_index/vector_stores/types.py
+++ b/llama_index/vector_stores/types.py
@@ -14,7 +14,7 @@ DEFAULT_PERSIST_FNAME = "vector_store.json"
 
 @dataclass
 class NodeWithEmbedding:
-    """Node embedding result.
+    """Node with embedding.
 
     Args:
         node (Node): Node

--- a/llama_index/vector_stores/types.py
+++ b/llama_index/vector_stores/types.py
@@ -30,8 +30,8 @@ class NodeWithEmbedding:
         return self.node.get_doc_id()
 
     @property
-    def ref_doc_id(self) -> Optional[str]:
-        return self.node.ref_doc_id
+    def ref_doc_id(self) -> str:
+        return self.node.ref_doc_id or "None"
 
 
 @dataclass

--- a/llama_index/vector_stores/weaviate.py
+++ b/llama_index/vector_stores/weaviate.py
@@ -14,7 +14,7 @@ from llama_index.readers.weaviate.client import (
 )
 from llama_index.readers.weaviate.utils import get_default_class_prefix
 from llama_index.vector_stores.types import (
-    NodeEmbeddingResult,
+    NodeWithEmbedding,
     VectorStore,
     VectorStoreQueryResult,
     VectorStoreQuery,
@@ -75,12 +75,12 @@ class WeaviateVectorStore(VectorStore):
 
     def add(
         self,
-        embedding_results: List[NodeEmbeddingResult],
+        embedding_results: List[NodeWithEmbedding],
     ) -> List[str]:
         """Add embedding results to index.
 
         Args
-            embedding_results: List[NodeEmbeddingResult]: list of embedding results
+            embedding_results: List[NodeWithEmbedding]: list of embedding results
 
         """
         for result in embedding_results:

--- a/tests/indices/composability/test_utils.py
+++ b/tests/indices/composability/test_utils.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional
 
 from llama_index.vector_stores.types import (
-    NodeEmbeddingResult,
+    NodeWithEmbedding,
     VectorStore,
     VectorStoreQueryResult,
     VectorStoreQuery,
@@ -24,7 +24,7 @@ class MockVectorStore(VectorStore):
 
     def add(
         self,
-        embedding_results: List[NodeEmbeddingResult],
+        embedding_results: List[NodeWithEmbedding],
     ) -> List[str]:
         """Add embedding results to vector store."""
         raise NotImplementedError()

--- a/tests/indices/vector_store/test_faiss.py
+++ b/tests/indices/vector_store/test_faiss.py
@@ -13,7 +13,7 @@ from llama_index.indices.vector_store.base import GPTVectorStoreIndex
 from llama_index.readers.schema.base import Document
 from llama_index.storage.storage_context import StorageContext
 from llama_index.vector_stores.faiss import FaissVectorStore
-from llama_index.vector_stores.types import NodeEmbeddingResult, VectorStoreQuery
+from llama_index.vector_stores.types import NodeWithEmbedding, VectorStoreQuery
 
 
 @pytest.mark.skipif("CI" in os.environ, reason="no FAISS in CI")
@@ -71,11 +71,9 @@ def test_persist(tmp_path: Path) -> None:
 
     vector_store.add(
         [
-            NodeEmbeddingResult(
-                id="test id",
+            NodeWithEmbedding(
                 node=Node("test text"),
                 embedding=[0, 0, 0, 1, 1],
-                doc_id="test_doc",
             )
         ]
     )

--- a/tests/indices/vector_store/test_lancedb.py
+++ b/tests/indices/vector_store/test_lancedb.py
@@ -6,7 +6,7 @@ from llama_index.indices.service_context import ServiceContext
 from llama_index.storage.storage_context import StorageContext
 
 from llama_index.vector_stores.types import (
-    NodeEmbeddingResult,
+    NodeWithEmbedding,
     VectorStore,
     VectorStoreQuery,
     VectorStoreQueryResult,
@@ -37,7 +37,7 @@ class MockLanceDBVectorStore(VectorStore):
 
     def add(
         self,
-        embedding_results: List[NodeEmbeddingResult],
+        embedding_results: List[NodeWithEmbedding],
     ) -> List[str]:
         return []
 

--- a/tests/indices/vector_store/test_milvus.py
+++ b/tests/indices/vector_store/test_milvus.py
@@ -7,7 +7,7 @@ from llama_index.indices.vector_store import GPTVectorStoreIndex
 from llama_index.storage.storage_context import StorageContext
 
 from llama_index.vector_stores.types import (
-    NodeEmbeddingResult,
+    NodeWithEmbedding,
     VectorStore,
     VectorStoreQuery,
     VectorStoreQueryResult,
@@ -48,7 +48,7 @@ class MockMilvusVectorStore(VectorStore):
 
     def add(
         self,
-        embedding_results: List[NodeEmbeddingResult],
+        embedding_results: List[NodeWithEmbedding],
     ) -> List[str]:
         return []
 

--- a/tests/indices/vector_store/test_weaviate.py
+++ b/tests/indices/vector_store/test_weaviate.py
@@ -5,7 +5,7 @@ from llama_index.indices.service_context import ServiceContext
 from llama_index.indices.vector_store import GPTVectorStoreIndex
 from llama_index.storage.storage_context import StorageContext
 from llama_index.vector_stores.types import (
-    NodeEmbeddingResult,
+    NodeWithEmbedding,
     VectorStore,
     VectorStoreQuery,
     VectorStoreQueryResult,
@@ -30,7 +30,7 @@ class MockWeaviateVectorStore(VectorStore):
 
     def add(
         self,
-        embedding_results: List[NodeEmbeddingResult],
+        embedding_results: List[NodeWithEmbedding],
     ) -> List[str]:
         return []
 

--- a/tests/vector_stores/test_qdrant.py
+++ b/tests/vector_stores/test_qdrant.py
@@ -7,36 +7,35 @@ try:
 except ImportError:
     qdrant_client = None  # type: ignore
 
-from llama_index.data_structs import Node
+from llama_index.data_structs.node import Node, DocumentRelationship
 from llama_index.vector_stores import QdrantVectorStore
-from llama_index.vector_stores.types import NodeEmbeddingResult, VectorStoreQuery
+from llama_index.vector_stores.types import NodeWithEmbedding, VectorStoreQuery
 
 
 @pytest.fixture
-def node() -> Node:
-    return Node(text="lorem ipsum")
-
-
-@pytest.fixture
-def node_embeddings(node: Node) -> List[NodeEmbeddingResult]:
+def node_embeddings() -> List[NodeWithEmbedding]:
     return [
-        NodeEmbeddingResult(
-            id="c330d77f-90bd-4c51-9ed2-57d8d693b3b0",
+        NodeWithEmbedding(
             embedding=[1.0, 0.0],
-            doc_id="test-0",
-            node=node,
+            node=Node(
+                text="lorem ipsum",
+                doc_id="c330d77f-90bd-4c51-9ed2-57d8d693b3b0",
+                relationships={DocumentRelationship.SOURCE: "test-0"},
+            ),
         ),
-        NodeEmbeddingResult(
-            id="c3d1e1dd-8fb4-4b8f-b7ea-7fa96038d39d",
+        NodeWithEmbedding(
             embedding=[0.0, 1.0],
-            doc_id="test-1",
-            node=node,
+            node=Node(
+                text="lorem ipsum",
+                doc_id="c3d1e1dd-8fb4-4b8f-b7ea-7fa96038d39d",
+                relationships={DocumentRelationship.SOURCE: "test-1"},
+            ),
         ),
     ]
 
 
 @pytest.mark.skipif(qdrant_client is None, reason="qdrant-client not installed")
-def test_add_stores_data(node_embeddings: List[NodeEmbeddingResult]) -> None:
+def test_add_stores_data(node_embeddings: List[NodeWithEmbedding]) -> None:
     client = qdrant_client.QdrantClient(":memory:")
     qdrant_vector_store = QdrantVectorStore(collection_name="test", client=client)
 

--- a/tests/vector_stores/test_weaviate.py
+++ b/tests/vector_stores/test_weaviate.py
@@ -1,6 +1,6 @@
 import sys
 from unittest.mock import MagicMock
-from llama_index.data_structs.node import Node
+from llama_index.data_structs.node import DocumentRelationship, Node
 from llama_index.vector_stores.types import NodeWithEmbedding
 
 from llama_index.vector_stores.weaviate import WeaviateVectorStore
@@ -18,10 +18,12 @@ def test_weaviate_add() -> None:
     vector_store.add(
         [
             NodeWithEmbedding(
-                id="test node id",
-                node=Node(text="test node text"),
+                node=Node(
+                    text="test node text",
+                    doc_id="test node id",
+                    relationships={DocumentRelationship.SOURCE: "test doc id"},
+                ),
                 embedding=[0.5, 0.5],
-                doc_id="test doc id",
             )
         ]
     )

--- a/tests/vector_stores/test_weaviate.py
+++ b/tests/vector_stores/test_weaviate.py
@@ -1,7 +1,7 @@
 import sys
 from unittest.mock import MagicMock
 from llama_index.data_structs.node import Node
-from llama_index.vector_stores.types import NodeEmbeddingResult
+from llama_index.vector_stores.types import NodeWithEmbedding
 
 from llama_index.vector_stores.weaviate import WeaviateVectorStore
 
@@ -17,7 +17,7 @@ def test_weaviate_add() -> None:
 
     vector_store.add(
         [
-            NodeEmbeddingResult(
+            NodeWithEmbedding(
                 id="test node id",
                 node=Node(text="test node text"),
                 embedding=[0.5, 0.5],


### PR DESCRIPTION
### Summary
* Rename `NodeEmbeddingResult` to `NodeWithEmbedding`
* Clean up `_get_node_embedding_results` and `_aget_node_embedding_results` logic
* No longer require Node to have `ref_doc_id` defined.

Fixes: https://github.com/jerryjliu/llama_index/issues/1348