### PR TITLE
fix: Switch from warn to warning

### DIFF
--- a/llama_index/llm_predictor/base.py
+++ b/llama_index/llm_predictor/base.py
@@ -58,7 +58,7 @@ def _get_llm_metadata(llm: BaseLanguageModel) -> LLMMetadata:
                 max_input_size=GPT4_32K_CONTEXT_SIZE, num_output=max_tokens
             )
         else:
-            logger.warn(
+            logger.warning(
                 "Unknown max input size for %s, using defaults.", llm.model_name
             )
             return LLMMetadata()


### PR DESCRIPTION
/opt/hostedtoolcache/Python/3.11.3/x64/lib/python3.11/site-packages/llama_index/llm_predictor/base.py:61: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead

FIxes: #3035