### PR TITLE
Workaround for issue with Azure embedding requiring deployment_id or engine 

### DIFF
--- a/llama_index/embeddings/openai.py
+++ b/llama_index/embeddings/openai.py
@@ -103,7 +103,7 @@ def get_embedding(
 
     """
     text = text.replace("\n", " ")
-    return openai.Embedding.create(input=[text], model=engine)["data"][0]["embedding"]
+    return openai.Embedding.create(input=[text], model=engine, engine=engine)["data"][0]["embedding"]
 
 
 @retry(wait=wait_random_exponential(min=1, max=20), stop=stop_after_attempt(6))


### PR DESCRIPTION
fixes #2129 - This issue specifically happens for Azure implementation of OpenAI.

Azure OpenAI APIs work a bit differently (using deployment_name vs engine/mode/model_type for OpenAI) though they share some common logic. 
Fix passes an 'engine' parameter (in additional to the current 'model' param) to satisfy openai expectation. For some reason the llama-index code is not passing through the engine param as it is and instead uses it as 'model' when calling 
`openai.Embedding.create()`