### PR TITLE
GPTTreeindex: limit # of active async llm calls, balance chunks per node

### DIFF
--- a/llama_index/indices/common_tree/base.py
+++ b/llama_index/indices/common_tree/base.py
@@ -85,7 +85,9 @@ class GPTTreeIndexBuilder:
             f"> Building index from nodes: {num_chunks} chunks"
         )
         nodes_per_chunk = [len(cur_node_list) // num_chunks + (1 if i < len(cur_node_list) % num_chunks else 0) for i in range(num_chunks)]
-
+        
+        indices, cur_nodes_chunks, text_chunks = [], [], []
+        
         pos = 0
         for i, num_nodes in enumerate(nodes_per_chunk):
             cur_nodes_chunk = cur_node_list[pos : pos + num_nodes]


### PR DESCRIPTION
suggest two tiny improvement for building GPTTrees, for problems I ran into:

- problem 1: with num_children 10 and 11 nodes on level 1, tree would build root node 1 with 10 childs, root node 2 with 1 child; performs better if balanced: root node 1 and 2 with 5 children each.
- problem 2: when having many chunks, e.g. ingesting whole books, async is important for indexing performance, but hundreds of async llm api calls mean chaos (rate limits, retries, timeouts), so idea: limiting number of active async jobs as possible fix.