### PR TITLE
Adding kwargs to OpenAI get_embedding calls

### DIFF
--- a/llama_index/embeddings/base.py
+++ b/llama_index/embeddings/base.py
@@ -52,7 +52,6 @@ class BaseEmbedding:
         self,
         embed_batch_size: int = DEFAULT_EMBED_BATCH_SIZE,
         tokenizer: Optional[Callable] = None,
-        **kwargs
     ) -> None:
         """Init params."""
         self._total_tokens_used = 0

--- a/llama_index/embeddings/base.py
+++ b/llama_index/embeddings/base.py
@@ -52,6 +52,7 @@ class BaseEmbedding:
         self,
         embed_batch_size: int = DEFAULT_EMBED_BATCH_SIZE,
         tokenizer: Optional[Callable] = None,
+        **kwargs
     ) -> None:
         """Init params."""
         self._total_tokens_used = 0

--- a/llama_index/embeddings/openai.py
+++ b/llama_index/embeddings/openai.py
@@ -224,23 +224,33 @@ class OpenAIEmbedding(BaseEmbedding):
         self.deployment_name = deployment_name
         self.query_engine = get_engine(mode, model, _QUERY_MODE_MODEL_DICT)
         self.text_engine = get_engine(mode, model, _TEXT_MODE_MODEL_DICT)
+        self._extra_params = kwargs
 
     def _get_query_embedding(self, query: str) -> List[float]:
         """Get query embedding."""
         return get_embedding(
-            query, engine=self.query_engine, deployment_id=self.deployment_name
+            query,
+            engine=self.query_engine,
+            deployment_id=self.deployment_name,
+            **self._extra_params,
         )
 
     def _get_text_embedding(self, text: str) -> List[float]:
         """Get text embedding."""
         return get_embedding(
-            text, engine=self.text_engine, deployment_id=self.deployment_name
+            text,
+            engine=self.text_engine,
+            deployment_id=self.deployment_name,
+            **self._extra_params,
         )
 
     async def _aget_text_embedding(self, text: str) -> List[float]:
         """Asynchronously get text embedding."""
         return await aget_embedding(
-            text, engine=self.text_engine, deployment_id=self.deployment_name
+            text,
+            engine=self.text_engine,
+            deployment_id=self.deployment_name,
+            **self._extra_params,
         )
 
     def _get_text_embeddings(self, texts: List[str]) -> List[List[float]]:
@@ -251,11 +261,17 @@ class OpenAIEmbedding(BaseEmbedding):
 
         """
         return get_embeddings(
-            texts, engine=self.text_engine, deployment_id=self.deployment_name
+            texts,
+            engine=self.text_engine,
+            deployment_id=self.deployment_name,
+            **self._extra_params,
         )
 
     async def _aget_text_embeddings(self, texts: List[str]) -> List[List[float]]:
         """Asynchronously get text embeddings."""
         return await aget_embeddings(
-            texts, engine=self.text_engine, deployment_id=self.deployment_name
+            texts,
+            engine=self.text_engine,
+            deployment_id=self.deployment_name,
+            **self._extra_params,
         )

--- a/llama_index/embeddings/openai.py
+++ b/llama_index/embeddings/openai.py
@@ -1,12 +1,16 @@
 """OpenAI embeddings file."""
 
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Callable
 
 import openai
 from tenacity import retry, stop_after_attempt, wait_random_exponential
 
 from llama_index.embeddings.base import BaseEmbedding
+from llama_index.callbacks.base import CallbackManager
+
+# Passed to the base embedding class
+DEFAULT_EMBED_BATCH_SIZE = 10
 
 
 class OpenAIEmbeddingMode(str, Enum):
@@ -217,14 +221,17 @@ class OpenAIEmbedding(BaseEmbedding):
         mode: str = OpenAIEmbeddingMode.TEXT_SEARCH_MODE,
         model: str = OpenAIEmbeddingModelType.TEXT_EMBED_ADA_002,
         deployment_name: Optional[str] = None,
+        embed_batch_size: int = DEFAULT_EMBED_BATCH_SIZE,
+        tokenizer: Optional[Callable] = None,
+        callback_manager: Optional[CallbackManager] = None,
         **kwargs: Any,
     ) -> None:
         """Init params."""
-        super().__init__(**kwargs)
+        super()._init_(embed_batch_size, tokenizer, callback_manager)
         self.deployment_name = deployment_name
         self.query_engine = get_engine(mode, model, _QUERY_MODE_MODEL_DICT)
         self.text_engine = get_engine(mode, model, _TEXT_MODE_MODEL_DICT)
-        self._extra_params = kwargs
+        self.openai_kwargs = kwargs
 
     def _get_query_embedding(self, query: str) -> List[float]:
         """Get query embedding."""
@@ -232,7 +239,7 @@ class OpenAIEmbedding(BaseEmbedding):
             query,
             engine=self.query_engine,
             deployment_id=self.deployment_name,
-            **self._extra_params,
+            **self.openai_kwargs,
         )
 
     def _get_text_embedding(self, text: str) -> List[float]:
@@ -241,7 +248,7 @@ class OpenAIEmbedding(BaseEmbedding):
             text,
             engine=self.text_engine,
             deployment_id=self.deployment_name,
-            **self._extra_params,
+            **self.openai_kwargs,
         )
 
     async def _aget_text_embedding(self, text: str) -> List[float]:
@@ -250,7 +257,7 @@ class OpenAIEmbedding(BaseEmbedding):
             text,
             engine=self.text_engine,
             deployment_id=self.deployment_name,
-            **self._extra_params,
+            **self.openai_kwargs,
         )
 
     def _get_text_embeddings(self, texts: List[str]) -> List[List[float]]:
@@ -264,7 +271,7 @@ class OpenAIEmbedding(BaseEmbedding):
             texts,
             engine=self.text_engine,
             deployment_id=self.deployment_name,
-            **self._extra_params,
+            **self.openai_kwargs,
         )
 
     async def _aget_text_embeddings(self, texts: List[str]) -> List[List[float]]:
@@ -273,5 +280,5 @@ class OpenAIEmbedding(BaseEmbedding):
             texts,
             engine=self.text_engine,
             deployment_id=self.deployment_name,
-            **self._extra_params,
+            **self.openai_kwargs,
         )

--- a/llama_index/embeddings/openai.py
+++ b/llama_index/embeddings/openai.py
@@ -6,11 +6,8 @@ from typing import Any, Dict, List, Optional, Tuple, Callable
 import openai
 from tenacity import retry, stop_after_attempt, wait_random_exponential
 
-from llama_index.embeddings.base import BaseEmbedding
+from llama_index.embeddings.base import BaseEmbedding, DEFAULT_EMBED_BATCH_SIZE
 from llama_index.callbacks.base import CallbackManager
-
-# Passed to the base embedding class
-DEFAULT_EMBED_BATCH_SIZE = 10
 
 
 class OpenAIEmbeddingMode(str, Enum):
@@ -227,7 +224,7 @@ class OpenAIEmbedding(BaseEmbedding):
         **kwargs: Any,
     ) -> None:
         """Init params."""
-        super()._init_(embed_batch_size, tokenizer, callback_manager)
+        super().__init__(embed_batch_size, tokenizer, callback_manager)
         self.deployment_name = deployment_name
         self.query_engine = get_engine(mode, model, _QUERY_MODE_MODEL_DICT)
         self.text_engine = get_engine(mode, model, _TEXT_MODE_MODEL_DICT)


### PR DESCRIPTION
Sorry, I'm new to open source and I accidentally closed [my last PR](https://github.com/jerryjliu/llama_index/pull/2527)

### Why is this needed?
* OpenAI now supports another parameter (user) while generating embeddings and might support more in the future.
* Passing headers to the Embeddings API endpoints is also limited in the current implementation

### What is included in this commit?
* Added kwargs to the BaseEmbedding and OpenAIEmbedding classes and functions to support extra parameters to be passed as needed.

I've reverted the changes discussed in the last PR. We still need to add kwargs to the base embeddings class as well, I felt removing everything from kwargs in the OpenAI class might be more messy.