### PR TITLE
Change RedisVectorStore index logic

### DIFF
--- a/docs/examples/vector_stores/RedisIndexDemo.ipynb
+++ b/docs/examples/vector_stores/RedisIndexDemo.ipynb
@@ -20,7 +20,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 1,
+            "execution_count": 12,
             "id": "47264e32",
             "metadata": {
                 "ExecuteTime": {
@@ -28,28 +28,26 @@
                     "start_time": "2023-02-10T12:20:23.967877Z"
                 }
             },
-            "outputs": [
-                {
-                    "name": "stderr",
-                    "output_type": "stream",
-                    "text": [
-                        "/Users/sam.partee/.virtualenvs/llama/lib/python3.8/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-                        "  from .autonotebook import tqdm as notebook_tqdm\n"
-                    ]
-                }
-            ],
+            "outputs": [],
             "source": [
-                "import logging\n",
+                "import os\n",
                 "import sys\n",
+                "import logging\n",
+                "import textwrap\n",
+                "\n",
+                "import warnings\n",
+                "warnings.filterwarnings(\"ignore\")\n",
+                "\n",
+                "# stop huggingface warnings\n",
+                "os.environ[\"TOKENIZERS_PARALLELISM\"] = \"false\"\n",
                 "\n",
                 "# Uncomment to see debug logs\n",
-                "# logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)\n",
-                "# logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))\n",
+                "#logging.basicConfig(stream=sys.stdout, level=logging.INFO)\n",
+                "#logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))\n",
                 "\n",
                 "from llama_index import GPTVectorStoreIndex, SimpleDirectoryReader, Document\n",
                 "from llama_index.vector_stores import RedisVectorStore\n",
-                "from IPython.display import Markdown, display\n",
-                "import textwrap"
+                "from IPython.display import Markdown, display"
             ]
         },
         {
@@ -83,7 +81,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 21,
+            "execution_count": 22,
             "id": "0c9f4d21-145a-401e-95ff-ccb259e8ef84",
             "metadata": {
                 "ExecuteTime": {
@@ -97,8 +95,7 @@
             "outputs": [],
             "source": [
                 "import os\n",
-                "os.environ[\"OPENAI_API_KEY\"] = \"sk-<your-key>\"\n",
-                "os.environ[\"TOKENIZERS_PARALLELISM\"] = \"False\""
+                "os.environ[\"OPENAI_API_KEY\"] = \"sk-<your key here>\""
             ]
         },
         {
@@ -129,13 +126,13 @@
                     "name": "stdout",
                     "output_type": "stream",
                     "text": [
-                        "Document ID: 061e0348-0ae4-4231-b114-0af254f43a10 Document Hash: 77ae91ab542f3abb308c4d7c77c9bc4c9ad0ccd63144802b7cbe7e1bb3a4094e\n"
+                        "Document ID: 09206095-be73-4069-b9f6-ff76d1f03343 Document Hash: 77ae91ab542f3abb308c4d7c77c9bc4c9ad0ccd63144802b7cbe7e1bb3a4094e\n"
                     ]
                 }
             ],
             "source": [
                 "# load documents\n",
-                "documents = SimpleDirectoryReader('../paul_graham_essay/data').load_data()\n",
+                "documents = SimpleDirectoryReader('../../../examples/paul_graham_essay/data/').load_data()\n",
                 "print('Document ID:', documents[0].doc_id, 'Document Hash:', documents[0].doc_hash)"
             ]
         },
@@ -231,36 +228,12 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 7,
+            "execution_count": 8,
             "id": "35369eda",
             "metadata": {
                 "ExecuteTime": {
                     "end_time": "2023-02-10T12:20:51.328762Z",
                     "start_time": "2023-02-10T12:20:33.822688Z"
-                }
-            },
-            "outputs": [
-                {
-                    "name": "stderr",
-                    "output_type": "stream",
-                    "text": [
-                        "Token indices sequence length is longer than the specified maximum sequence length for this model (1812 > 1024). Running this sequence through the model will result in indexing errors\n"
-                    ]
-                }
-            ],
-            "source": [
-                "query_engine = index.as_query_engine()\n",
-                "response = query_engine.query(\"What did the author learn?\")"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 8,
-            "id": "bedbb693-725f-478f-be26-fa7180ea38b2",
-            "metadata": {
-                "ExecuteTime": {
-                    "end_time": "2023-02-10T12:20:51.337062Z",
-                    "start_time": "2023-02-10T12:20:51.330857Z"
                 }
             },
             "outputs": [
@@ -276,6 +249,8 @@
                 }
             ],
             "source": [
+                "query_engine = index.as_query_engine()\n",
+                "response = query_engine.query(\"What did the author learn?\")\n",
                 "print(textwrap.fill(str(response), 100))"
             ]
         },
@@ -289,21 +264,6 @@
                     "start_time": "2023-02-10T12:20:51.338718Z"
                 }
             },
-            "outputs": [],
-            "source": [
-                "response = query_engine.query(\"What was a hard moment for the author?\")"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 10,
-            "id": "1a720ad6",
-            "metadata": {
-                "ExecuteTime": {
-                    "end_time": "2023-02-10T12:21:10.355872Z",
-                    "start_time": "2023-02-10T12:21:10.343486Z"
-                }
-            },
             "outputs": [
                 {
                     "name": "stdout",
@@ -311,11 +271,13 @@
                     "text": [
                         " A hard moment for the author was when he realized that the AI programs of the time were a hoax and\n",
                         "that there was an unbridgeable gap between what they could do and actually understanding natural\n",
-                        "language.\n"
+                        "language. He had invested a lot of time and energy into learning about AI and was disappointed to\n",
+                        "find out that the field was not as promising as he had thought.\n"
                     ]
                 }
             ],
             "source": [
+                "response = query_engine.query(\"What was a hard moment for the author?\")\n",
                 "print(textwrap.fill(str(response), 100))"
             ]
         },
@@ -332,7 +294,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 11,
+            "execution_count": 13,
             "id": "09836567",
             "metadata": {},
             "outputs": [
@@ -350,7 +312,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 13,
+            "execution_count": 14,
             "id": "93ef500b",
             "metadata": {},
             "outputs": [],
@@ -360,7 +322,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 14,
+            "execution_count": 15,
             "id": "ed5ab256",
             "metadata": {},
             "outputs": [
@@ -388,17 +350,17 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 15,
+            "execution_count": 16,
             "id": "6fe322f7",
             "metadata": {},
             "outputs": [
                 {
                     "data": {
                         "text/plain": [
-                            "'061e0348-0ae4-4231-b114-0af254f43a10'"
+                            "'09206095-be73-4069-b9f6-ff76d1f03343'"
                         ]
                     },
-                    "execution_count": 15,
+                    "execution_count": 16,
                     "metadata": {},
                     "output_type": "execute_result"
                 }
@@ -410,7 +372,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 16,
+            "execution_count": 17,
             "id": "ae4fb2b0",
             "metadata": {},
             "outputs": [
@@ -418,7 +380,7 @@
                     "name": "stdout",
                     "output_type": "stream",
                     "text": [
-                        "Number of documents 43\n"
+                        "Number of documents 24\n"
                     ]
                 }
             ],
@@ -429,7 +391,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 17,
+            "execution_count": 18,
             "id": "0ce45788",
             "metadata": {},
             "outputs": [],
@@ -439,7 +401,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 18,
+            "execution_count": 19,
             "id": "4a1ac683",
             "metadata": {},
             "outputs": [
@@ -447,7 +409,7 @@
                     "name": "stdout",
                     "output_type": "stream",
                     "text": [
-                        "Number of documents 33\n"
+                        "Number of documents 14\n"
                     ]
                 }
             ],
@@ -457,7 +419,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 19,
+            "execution_count": 20,
             "id": "c380605a",
             "metadata": {},
             "outputs": [],
@@ -469,7 +431,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 20,
+            "execution_count": 21,
             "id": "474ad4ee",
             "metadata": {},
             "outputs": [
@@ -484,14 +446,6 @@
             "source": [
                 "print(\"Number of documents\", len(redis_client.keys()))"
             ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "4a028452",
-            "metadata": {},
-            "outputs": [],
-            "source": []
         }
     ],
     "metadata": {

--- a/docs/examples/vector_stores/RedisIndexDemo.ipynb
+++ b/docs/examples/vector_stores/RedisIndexDemo.ipynb
@@ -132,7 +132,7 @@
             ],
             "source": [
                 "# load documents\n",
-                "documents = SimpleDirectoryReader('../../../examples/paul_graham_essay/data/').load_data()\n",
+                "documents = SimpleDirectoryReader('../data/paul_graham').load_data()\n",
                 "print('Document ID:', documents[0].doc_id, 'Document Hash:', documents[0].doc_hash)"
             ]
         },

--- a/llama_index/vector_stores/redis.py
+++ b/llama_index/vector_stores/redis.py
@@ -120,19 +120,20 @@ class RedisVectorStore(VectorStore):
         Raises:
             ValueError: If the index already exists and overwrite is False.
         """
+        # check to see if empty document list was passed
+        if len(embedding_results) == 0:
+            return []
 
-        # check index exists, call once to avoid calling multiple times
-        index_exists = self._index_exists()
-        if index_exists and self._overwrite:
-            self.delete_index()
+        # set vector dim for creation if index doesn't exist
+        self._index_args["dims"] = len(embedding_results[0].embedding)
 
-        elif index_exists and not self._overwrite:
-            raise ValueError("Index already exists and overwrite is False.")
-
-        else:  # index does not exist, create it
-            # get vector dim from embedding results if index does not exist
-            # as it will be created from the embedding result attributes.
-            self._index_args["dims"] = len(embedding_results[0].embedding)
+        if self._index_exists():
+            if self._overwrite:
+                self.delete_index()
+                self._create_index()
+            else:
+                logging.info(f"Adding document to existing index {self._index_name}")
+        else:
             self._create_index()
 
         ids = []

--- a/llama_index/vector_stores/redis.py
+++ b/llama_index/vector_stores/redis.py
@@ -170,6 +170,13 @@ class RedisVectorStore(VectorStore):
         query_str = "@doc_id:{%s}" % self.tokenizer.escape(doc_id)
         # find all documents that match a doc_id
         results = self._redis_client.ft(self._index_name).search(query_str)
+        if len(results.docs) == 0:
+            # don't raise an error but warn the user that document wasn't found
+            # could be a result of eviction policy
+            _logger.warning(
+                f"Could not find document with doc_id {doc_id} in index {self._index_name}"
+            )
+            return
 
         for doc in results.docs:
             self._redis_client.delete(doc.id)
@@ -190,8 +197,14 @@ class RedisVectorStore(VectorStore):
 
         Returns:
             VectorStoreQueryResult: query result
+
+        Raises:
+            ValueError: If query.query_embedding is None.
+            redis.exceptions.RedisError: If there is an error querying the index.
+            redis.exceptions.TimeoutError: If there is a timeout querying the index.
         """
-        from redis.exceptions import ResponseError as RedisResponseError
+        from redis.exceptions import RedisError
+        from redis.exceptions import TimeoutError as RedisTimeoutError
 
         return_fields = ["id", "doc_id", "text", self._vector_key, "vector_score"]
 
@@ -212,8 +225,11 @@ class RedisVectorStore(VectorStore):
             results = self._redis_client.ft(self._index_name).search(
                 redis_query, query_params=query_params  # type: ignore
             )
-        except RedisResponseError as e:
-            _logger.error(f"Error querying index {self._index_name}: {e}")
+        except RedisTimeoutError as e:
+            _logger.error(f"Query timed out on {self._index_name}: {e}")
+            raise e
+        except RedisError as e:
+            _logger.error(f"Error querying {self._index_name}: {e}")
             raise e
 
         ids = []
@@ -239,13 +255,23 @@ class RedisVectorStore(VectorStore):
         Args:
             persist_path (str): Path to persist the vector store to. (doesn't apply)
             in_background (bool, optional): Persist in background. Defaults to True.
+
+        Raises:
+            redis.execptions.RedisError: If there is an error persisting the index to disk.
         """
-        if in_background:
-            _logger.info("Saving index to disk in background")
-            self._redis_client.bgsave()
-        else:
-            _logger.info("Saving index to disk")
-            self._redis_client.save()
+        from redis.exceptions import RedisError
+
+        try:
+            if in_background:
+                _logger.info("Saving index to disk in background")
+                self._redis_client.bgsave()
+            else:
+                _logger.info("Saving index to disk")
+                self._redis_client.save()
+
+        except RedisError as e:
+            _logger.error(f"Error saving index to disk: {e}")
+            raise e
 
     def _create_index(self) -> None:
         # should never be called outside class and hence should not raise importerror
@@ -312,34 +338,40 @@ class RedisVectorStore(VectorStore):
         returns:
             A RediSearch VectorField.
         """
+        from redis import DataError
         from redis.commands.search.field import VectorField
 
-        if algorithm.upper() == "HNSW":
-            return VectorField(
-                name,
-                "HNSW",
-                {
-                    "TYPE": datatype.upper(),
-                    "DIM": dims,
-                    "DISTANCE_METRIC": distance_metric.upper(),
-                    "INITIAL_CAP": initial_cap,
-                    "M": m,
-                    "EF_CONSTRUCTION": ef_construction,
-                    "EF_RUNTIME": ef_runtime,
-                    "EPSILON": epsilon,
-                },
-            )
-        else:
-            return VectorField(
-                name,
-                "FLAT",
-                {
-                    "TYPE": datatype.upper(),
-                    "DIM": dims,
-                    "DISTANCE_METRIC": distance_metric.upper(),
-                    "INITIAL_CAP": initial_cap,
-                    "BLOCK_SIZE": block_size,
-                },
+        try:
+            if algorithm.upper() == "HNSW":
+                return VectorField(
+                    name,
+                    "HNSW",
+                    {
+                        "TYPE": datatype.upper(),
+                        "DIM": dims,
+                        "DISTANCE_METRIC": distance_metric.upper(),
+                        "INITIAL_CAP": initial_cap,
+                        "M": m,
+                        "EF_CONSTRUCTION": ef_construction,
+                        "EF_RUNTIME": ef_runtime,
+                        "EPSILON": epsilon,
+                    },
+                )
+            else:
+                return VectorField(
+                    name,
+                    "FLAT",
+                    {
+                        "TYPE": datatype.upper(),
+                        "DIM": dims,
+                        "DISTANCE_METRIC": distance_metric.upper(),
+                        "INITIAL_CAP": initial_cap,
+                        "BLOCK_SIZE": block_size,
+                    },
+                )
+        except DataError as e:
+            raise ValueError(
+                f"Failed to create Redis index vector field with error: {e}"
             )
 
 
@@ -347,5 +379,9 @@ def cast_metadata_types(mapping: Optional[Dict[str, Any]]) -> Dict[str, str]:
     metadata = {}
     if mapping:
         for key, value in mapping.items():
-            metadata[str(key)] = str(value)
+            try:
+                metadata[str(key)] = str(value)
+            except (TypeError, ValueError) as e:
+                # warn the user and continue
+                _logger.warning("Failed to cast metadata key %s to string: %s", key, e)
     return metadata

--- a/llama_index/vector_stores/redis.py
+++ b/llama_index/vector_stores/redis.py
@@ -257,7 +257,8 @@ class RedisVectorStore(VectorStore):
             in_background (bool, optional): Persist in background. Defaults to True.
 
         Raises:
-            redis.execptions.RedisError: If there is an error persisting the index to disk.
+            redis.exceptions.RedisError: If there is an error
+                                         persisting the index to disk.
         """
         from redis.exceptions import RedisError
 

--- a/llama_index/vector_stores/redis.py
+++ b/llama_index/vector_stores/redis.py
@@ -174,7 +174,7 @@ class RedisVectorStore(VectorStore):
             # don't raise an error but warn the user that document wasn't found
             # could be a result of eviction policy
             _logger.warning(
-                f"Could not find document with doc_id {doc_id} in index {self._index_name}"
+                f"Document with doc_id {doc_id} not found in index {self._index_name}"
             )
             return
 
@@ -383,5 +383,5 @@ def cast_metadata_types(mapping: Optional[Dict[str, Any]]) -> Dict[str, str]:
                 metadata[str(key)] = str(value)
             except (TypeError, ValueError) as e:
                 # warn the user and continue
-                _logger.warning("Failed to cast metadata key %s to string: %s", key, e)
+                _logger.warning("Failed to cast metadata to string", e)
     return metadata


### PR DESCRIPTION
This PR changes the index creation/deletion logic within ``RedisVectorStore`` and address a subtle bug

The general change is allowing users to add to existing indices when they don't specify overwrite. This use case came up when needing to continually add batches of documents to a redis store through an HTTPS route. the logic now allows for

1. if no index is created by that name, one is created and documents are added to that index
2. If an index exists, but overwrite is false, documents are added to that index if by the same index name and prefix
3. if an index exists, and overwrite is true, the index is deleted, created, and documents are added.

Bug:
Passing an empty set of documents resulted in a IndexError. This should simply return as no documents were added.

General error handling and cleanup was added as well.
