### PR TITLE
Do not duplicate extra_info into text when saving Node into vector store

### DIFF
--- a/llama_index/readers/weaviate/client.py
+++ b/llama_index/readers/weaviate/client.py
@@ -11,12 +11,9 @@ from typing import Any, Dict, List, Optional, Tuple, cast
 
 from llama_index.data_structs.data_structs import Node
 from llama_index.data_structs.node import DocumentRelationship
-from llama_index.readers.weaviate.utils import (parse_get_response,
-                                                validate_client)
-from llama_index.vector_stores.types import (VectorStoreQuery,
-                                             VectorStoreQueryMode)
-from llama_index.vector_stores.utils import (metadata_dict_to_node,
-                                             node_to_metadata_dict)
+from llama_index.readers.weaviate.utils import parse_get_response, validate_client
+from llama_index.vector_stores.types import VectorStoreQuery, VectorStoreQueryMode
+from llama_index.vector_stores.utils import metadata_dict_to_node, node_to_metadata_dict
 
 _logger = logging.getLogger(__name__)
 

--- a/llama_index/readers/weaviate/client.py
+++ b/llama_index/readers/weaviate/client.py
@@ -11,9 +11,12 @@ from typing import Any, Dict, List, Optional, Tuple, cast
 
 from llama_index.data_structs.data_structs import Node
 from llama_index.data_structs.node import DocumentRelationship
-from llama_index.readers.weaviate.utils import parse_get_response, validate_client
-from llama_index.vector_stores.types import VectorStoreQuery, VectorStoreQueryMode
-from llama_index.vector_stores.utils import metadata_dict_to_node, node_to_metadata_dict
+from llama_index.readers.weaviate.utils import (parse_get_response,
+                                                validate_client)
+from llama_index.vector_stores.types import (VectorStoreQuery,
+                                             VectorStoreQueryMode)
+from llama_index.vector_stores.utils import (metadata_dict_to_node,
+                                             node_to_metadata_dict)
 
 _logger = logging.getLogger(__name__)
 
@@ -165,7 +168,7 @@ def _add_node(
 ) -> str:
     """Add node."""
     metadata = {}
-    metadata["text"] = node.get_text()
+    metadata["text"] = node.text or ""
 
     additional_metadata = node_to_metadata_dict(node)
     metadata.update(additional_metadata)

--- a/llama_index/vector_stores/chroma.py
+++ b/llama_index/vector_stores/chroma.py
@@ -5,12 +5,14 @@ from typing import Any, List, Tuple, cast
 
 from llama_index.data_structs.node import DocumentRelationship, Node
 from llama_index.utils import truncate_text
-from llama_index.vector_stores.types import (MetadataFilters,
-                                             NodeWithEmbedding, VectorStore,
-                                             VectorStoreQuery,
-                                             VectorStoreQueryResult)
-from llama_index.vector_stores.utils import (metadata_dict_to_node,
-                                             node_to_metadata_dict)
+from llama_index.vector_stores.types import (
+    MetadataFilters,
+    NodeWithEmbedding,
+    VectorStore,
+    VectorStoreQuery,
+    VectorStoreQueryResult,
+)
+from llama_index.vector_stores.utils import metadata_dict_to_node, node_to_metadata_dict
 
 logger = logging.getLogger(__name__)
 

--- a/llama_index/vector_stores/chroma.py
+++ b/llama_index/vector_stores/chroma.py
@@ -5,14 +5,12 @@ from typing import Any, List, Tuple, cast
 
 from llama_index.data_structs.node import DocumentRelationship, Node
 from llama_index.utils import truncate_text
-from llama_index.vector_stores.types import (
-    MetadataFilters,
-    NodeWithEmbedding,
-    VectorStore,
-    VectorStoreQuery,
-    VectorStoreQueryResult,
-)
-from llama_index.vector_stores.utils import metadata_dict_to_node, node_to_metadata_dict
+from llama_index.vector_stores.types import (MetadataFilters,
+                                             NodeWithEmbedding, VectorStore,
+                                             VectorStoreQuery,
+                                             VectorStoreQueryResult)
+from llama_index.vector_stores.utils import (metadata_dict_to_node,
+                                             node_to_metadata_dict)
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +79,7 @@ class ChromaVectorStore(VectorStore):
             embeddings.append(result.embedding)
             metadatas.append(node_to_metadata_dict(result.node))
             ids.append(result.id)
-            documents.append(result.node.get_text())
+            documents.append(result.node.text or "")
 
         self._collection.add(
             embeddings=embeddings,

--- a/llama_index/vector_stores/metal.py
+++ b/llama_index/vector_stores/metal.py
@@ -133,7 +133,7 @@ class MetalVectorStore(VectorStore):
             ids.append(result.id)
 
             metadata = {}
-            metadata["text"] = result.node.get_text()
+            metadata["text"] = result.node.text or ""
 
             additional_metadata = node_to_metadata_dict(result.node)
             metadata.update(additional_metadata)

--- a/llama_index/vector_stores/myscale.py
+++ b/llama_index/vector_stores/myscale.py
@@ -102,7 +102,7 @@ class MyScaleVectorStore(VectorStore):
             "doc_id": {"type": "String", "extract_func": lambda x: x.ref_doc_id},
             "text": {
                 "type": "String",
-                "extract_func": lambda x: escape_str(x.node.get_text()),
+                "extract_func": lambda x: escape_str(x.node.text or ""),
             },
             "vector": {
                 "type": "Array(Float32)",

--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -11,13 +11,15 @@ from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
 from llama_index.data_structs.node import DocumentRelationship, Node
-from llama_index.vector_stores.types import (MetadataFilters,
-                                             NodeWithEmbedding, VectorStore,
-                                             VectorStoreQuery,
-                                             VectorStoreQueryMode,
-                                             VectorStoreQueryResult)
-from llama_index.vector_stores.utils import (metadata_dict_to_node,
-                                             node_to_metadata_dict)
+from llama_index.vector_stores.types import (
+    MetadataFilters,
+    NodeWithEmbedding,
+    VectorStore,
+    VectorStoreQuery,
+    VectorStoreQueryMode,
+    VectorStoreQueryResult,
+)
+from llama_index.vector_stores.utils import metadata_dict_to_node, node_to_metadata_dict
 
 _logger = logging.getLogger(__name__)
 

--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -11,15 +11,13 @@ from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
 from llama_index.data_structs.node import DocumentRelationship, Node
-from llama_index.vector_stores.types import (
-    MetadataFilters,
-    NodeWithEmbedding,
-    VectorStore,
-    VectorStoreQuery,
-    VectorStoreQueryMode,
-    VectorStoreQueryResult,
-)
-from llama_index.vector_stores.utils import metadata_dict_to_node, node_to_metadata_dict
+from llama_index.vector_stores.types import (MetadataFilters,
+                                             NodeWithEmbedding, VectorStore,
+                                             VectorStoreQuery,
+                                             VectorStoreQueryMode,
+                                             VectorStoreQueryResult)
+from llama_index.vector_stores.utils import (metadata_dict_to_node,
+                                             node_to_metadata_dict)
 
 _logger = logging.getLogger(__name__)
 
@@ -189,7 +187,7 @@ class PineconeVectorStore(VectorStore):
             node = result.node
 
             metadata = {
-                "text": node.get_text(),
+                "text": node.text or "",
                 "id": node_id,
             }
 

--- a/llama_index/vector_stores/qdrant.py
+++ b/llama_index/vector_stores/qdrant.py
@@ -86,12 +86,13 @@ class QdrantVectorStore(VectorStore):
             vectors = []
             payloads = []
             for result in result_batch:
+                assert isinstance(result, NodeWithEmbedding)
                 node_ids.append(result.id)
                 vectors.append(result.embedding)
                 node = result.node
 
                 metadata = {}
-                metadata["text"] = node.get_text()
+                metadata["text"] = node.text or None
                 additional_metadata = node_to_metadata_dict(node)
                 metadata.update(additional_metadata)
 

--- a/llama_index/vector_stores/qdrant.py
+++ b/llama_index/vector_stores/qdrant.py
@@ -92,7 +92,7 @@ class QdrantVectorStore(VectorStore):
                 node = result.node
 
                 metadata = {}
-                metadata["text"] = node.text or None
+                metadata["text"] = node.text or ""
                 additional_metadata = node_to_metadata_dict(node)
                 metadata.update(additional_metadata)
 

--- a/tests/indices/query/test_compose_vector.py
+++ b/tests/indices/query/test_compose_vector.py
@@ -1,23 +1,19 @@
 """Test recursive queries."""
 
 import asyncio
-import sys
 from typing import Any, Dict, List
-from unittest.mock import MagicMock
 
 import pytest
 
 from llama_index.data_structs.data_structs import IndexStruct
 from llama_index.embeddings.base import BaseEmbedding
 from llama_index.indices.composability.graph import ComposableGraph
-from llama_index.indices.keyword_table.simple_base import \
-    GPTSimpleKeywordTableIndex
+from llama_index.indices.keyword_table.simple_base import GPTSimpleKeywordTableIndex
 from llama_index.indices.service_context import ServiceContext
 from llama_index.indices.vector_store.base import GPTVectorStoreIndex
 from llama_index.readers.schema.base import Document
 from tests.indices.vector_store.utils import get_pinecone_storage_context
 from tests.mock_utils.mock_prompts import MOCK_QUERY_KEYWORD_EXTRACT_PROMPT
-from tests.mock_utils.mock_utils import mock_tokenizer
 
 
 class MockEmbedding(BaseEmbedding):
@@ -286,7 +282,6 @@ def test_recursive_query_vector_vector(
     query_str = "Cat?"
     response = query_engine.query(query_str)
     assert str(response) == ("Cat?:Cat?:This is a test v2.")
-
 
 
 def test_recursive_query_pinecone_pinecone(

--- a/tests/indices/query/test_compose_vector.py
+++ b/tests/indices/query/test_compose_vector.py
@@ -10,16 +10,13 @@ import pytest
 from llama_index.data_structs.data_structs import IndexStruct
 from llama_index.embeddings.base import BaseEmbedding
 from llama_index.indices.composability.graph import ComposableGraph
-from llama_index.indices.keyword_table.simple_base import GPTSimpleKeywordTableIndex
+from llama_index.indices.keyword_table.simple_base import \
+    GPTSimpleKeywordTableIndex
 from llama_index.indices.service_context import ServiceContext
 from llama_index.indices.vector_store.base import GPTVectorStoreIndex
 from llama_index.readers.schema.base import Document
-from llama_index.storage.storage_context import StorageContext
-from llama_index.vector_stores.pinecone import PineconeVectorStore
-from tests.indices.vector_store.utils import MockPineconeIndex
-from tests.mock_utils.mock_prompts import (
-    MOCK_QUERY_KEYWORD_EXTRACT_PROMPT,
-)
+from tests.indices.vector_store.utils import get_pinecone_storage_context
+from tests.mock_utils.mock_prompts import MOCK_QUERY_KEYWORD_EXTRACT_PROMPT
 from tests.mock_utils.mock_utils import mock_tokenizer
 
 
@@ -290,15 +287,6 @@ def test_recursive_query_vector_vector(
     response = query_engine.query(query_str)
     assert str(response) == ("Cat?:Cat?:This is a test v2.")
 
-
-def get_pinecone_storage_context() -> StorageContext:
-    # NOTE: mock pinecone import
-    sys.modules["pinecone"] = MagicMock()
-    return StorageContext.from_defaults(
-        vector_store=PineconeVectorStore(
-            pinecone_index=MockPineconeIndex(), tokenizer=mock_tokenizer
-        )
-    )
 
 
 def test_recursive_query_pinecone_pinecone(

--- a/tests/indices/vector_store/mock_services.py
+++ b/tests/indices/vector_store/mock_services.py
@@ -28,4 +28,3 @@ class MockEmbedding(BaseEmbedding):
             return [1, 0, 0, 0, 0]
         else:
             return [0, 0, 0, 0, 0]
-

--- a/tests/indices/vector_store/mock_services.py
+++ b/tests/indices/vector_store/mock_services.py
@@ -1,4 +1,5 @@
 from typing import List
+
 from llama_index.embeddings.base import BaseEmbedding
 
 
@@ -26,4 +27,5 @@ class MockEmbedding(BaseEmbedding):
             # this is used when "Hello world." is deleted.
             return [1, 0, 0, 0, 0]
         else:
-            raise ValueError("Invalid text for `_get_text_embedding`.")
+            return [0, 0, 0, 0, 0]
+

--- a/tests/indices/vector_store/test_pinecone.py
+++ b/tests/indices/vector_store/test_pinecone.py
@@ -5,14 +5,12 @@ from typing import List
 from unittest.mock import MagicMock, Mock
 
 import pytest
+
+from llama_index.data_structs.node import Node
 from llama_index.indices.service_context import ServiceContext
 from llama_index.indices.vector_store.base import GPTVectorStoreIndex
-
 from llama_index.readers.schema.base import Document
-from llama_index.storage.storage_context import StorageContext
-from llama_index.vector_stores.pinecone import PineconeVectorStore
-from tests.indices.vector_store.utils import MockPineconeIndex
-
+from tests.indices.vector_store.utils import get_pinecone_storage_context
 from tests.mock_utils.mock_utils import mock_tokenizer
 
 
@@ -34,13 +32,7 @@ def test_build_pinecone(
     mock_service_context: ServiceContext,
 ) -> None:
     """Test build GPTVectorStoreIndex with PineconeVectorStore."""
-    # NOTE: mock pinecone import
-    sys.modules["pinecone"] = MagicMock()
-    # NOTE: mock pinecone index
-    pinecone_index = MockPineconeIndex()
-
-    vector_store = PineconeVectorStore(pinecone_index=pinecone_index, tokenizer=Mock())
-    storage_context = StorageContext.from_defaults(vector_store=vector_store)
+    storage_context = get_pinecone_storage_context()
     index = GPTVectorStoreIndex.from_documents(
         documents=documents,
         storage_context=storage_context,
@@ -52,3 +44,21 @@ def test_build_pinecone(
     nodes = retriever.retrieve("What is?")
     assert len(nodes) == 1
     assert nodes[0].node.get_text() == "This is another test."
+
+def test_node_with_metadata(
+    mock_service_context: ServiceContext,
+) -> None:
+    storage_context = get_pinecone_storage_context()
+    nodes = [
+        Node(text='test node text', extra_info={'key': 'value'})
+    ]
+    index = GPTVectorStoreIndex(nodes, storage_context=storage_context, service_context=mock_service_context)
+
+    retriever = index.as_retriever(similarity_top_k=1)
+    nodes = retriever.retrieve("What is?")
+    assert len(nodes) == 1
+    assert nodes[0].node.text == 'test node text'
+    assert nodes[0].node.extra_info == {'key': 'value'}
+
+
+

--- a/tests/indices/vector_store/test_pinecone.py
+++ b/tests/indices/vector_store/test_pinecone.py
@@ -1,8 +1,6 @@
 """Test pinecone indexes."""
 
-import sys
 from typing import List
-from unittest.mock import MagicMock, Mock
 
 import pytest
 
@@ -45,20 +43,20 @@ def test_build_pinecone(
     assert len(nodes) == 1
     assert nodes[0].node.get_text() == "This is another test."
 
+
 def test_node_with_metadata(
     mock_service_context: ServiceContext,
 ) -> None:
     storage_context = get_pinecone_storage_context()
-    nodes = [
-        Node(text='test node text', extra_info={'key': 'value'})
-    ]
-    index = GPTVectorStoreIndex(nodes, storage_context=storage_context, service_context=mock_service_context)
+    input_nodes = [Node(text="test node text", extra_info={"key": "value"})]
+    index = GPTVectorStoreIndex(
+        input_nodes,
+        storage_context=storage_context,
+        service_context=mock_service_context,
+    )
 
     retriever = index.as_retriever(similarity_top_k=1)
     nodes = retriever.retrieve("What is?")
     assert len(nodes) == 1
-    assert nodes[0].node.text == 'test node text'
-    assert nodes[0].node.extra_info == {'key': 'value'}
-
-
-
+    assert nodes[0].node.text == "test node text"
+    assert nodes[0].node.extra_info == {"key": "value"}

--- a/tests/indices/vector_store/utils.py
+++ b/tests/indices/vector_store/utils.py
@@ -1,7 +1,12 @@
+import sys
 from typing import Any, Dict, List, Optional
 from unittest.mock import MagicMock
 
 import numpy as np
+
+from llama_index.storage.storage_context import StorageContext
+from llama_index.vector_stores.pinecone import PineconeVectorStore
+from tests.mock_utils.mock_utils import mock_tokenizer
 
 
 class MockPineconeIndex:
@@ -46,14 +51,18 @@ class MockPineconeIndex:
         for index in indices:
             tup = self._tuples[index]
             match = MagicMock()
-            match.metadata = {
-                "text": tup["metadata"]["text"],
-                "doc_id": tup["metadata"]["doc_id"],
-                "id": tup["metadata"]["id"],
-            }
-
+            match.metadata = tup['metadata']
             matches.append(match)
 
         response = MagicMock()
         response.matches = matches
         return response
+
+def get_pinecone_storage_context() -> StorageContext:
+    # NOTE: mock pinecone import
+    sys.modules["pinecone"] = MagicMock()
+    return StorageContext.from_defaults(
+        vector_store=PineconeVectorStore(
+            pinecone_index=MockPineconeIndex(), tokenizer=mock_tokenizer
+        )
+    )

--- a/tests/indices/vector_store/utils.py
+++ b/tests/indices/vector_store/utils.py
@@ -51,12 +51,13 @@ class MockPineconeIndex:
         for index in indices:
             tup = self._tuples[index]
             match = MagicMock()
-            match.metadata = tup['metadata']
+            match.metadata = tup["metadata"]
             matches.append(match)
 
         response = MagicMock()
         response.matches = matches
         return response
+
 
 def get_pinecone_storage_context() -> StorageContext:
     # NOTE: mock pinecone import


### PR DESCRIPTION
### Summary
* Previously, we were using `Node.get_text()` to save Node text into vector store, while also saving the extra info, this means that after loading the Node back, calling `Node.get_text()` would have the metadata injected twice into the Node text. 
* This fixes the bug, by saving the `Node.text` to avoid duplicating the metadata.