### PR TITLE
feat: use fsspec to manage storage contexts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,9 @@
   "python.formatting.provider": "black",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-      "source.organizeImports": true,
+    "source.organizeImports": true,
   },
+  "editor.rulers": [
+    88,
+  ],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,9 +2,6 @@
   "python.formatting.provider": "black",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.organizeImports": true,
+      "source.organizeImports": true,
   },
-  "editor.rulers": [
-    88,
-  ],
 }

--- a/docs/examples/vector_stores/SimpleIndexDemo.ipynb
+++ b/docs/examples/vector_stores/SimpleIndexDemo.ipynb
@@ -10,6 +10,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "id": "50d3b817-b70e-4667-be4f-d3a0fe4bd119",
             "metadata": {},
@@ -42,7 +43,7 @@
             "outputs": [],
             "source": [
                 "# load documents\n",
-                "documents = SimpleDirectoryReader('../paul_graham_essay/data').load_data()"
+                "documents = SimpleDirectoryReader('../../../examples/paul_graham_essay/data').load_data()"
             ]
         },
         {
@@ -66,7 +67,7 @@
             "source": [
                 "# save index to disk\n",
                 "index.set_index_id(\"vector_index\")\n",
-                "index.storage_context.persist('storage')"
+                "index.storage_context.persist('./storage')"
             ]
         },
         {
@@ -83,6 +84,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "id": "b6caf93b-6345-4c65-a346-a95b0f1746c4",
             "metadata": {},
@@ -115,6 +117,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "id": "c80abba3-d338-42fd-9df3-b4e5ceb01cdf",
             "metadata": {},
@@ -133,17 +136,21 @@
             },
             "outputs": [],
             "source": [
-                "query_mode = \"svm\"\n",
-                "# query_mode = \"linear_regression\"\n",
-                "# query_mode = \"logistic_regression\"\n",
-                "\n",
+                "query_modes = [\n",
+                "    \"svm\",\n",
+                "    \"linear_regression\",\n",
+                "    \"logistic_regression\",\n",
+                "]\n",
+                "for query_mode in query_modes:\n",
                 "# set Logging to DEBUG for more detailed outputs\n",
-                "query_engine = index.as_query_engine(\n",
-                "    vector_store_query_mode=query_mode\n",
-                ")\n",
-                "response = query_engine.query(\n",
-                "    \"What did the author do growing up?\"\n",
-                ")"
+                "    query_engine = index.as_query_engine(\n",
+                "        vector_store_query_mode=query_mode\n",
+                "    )\n",
+                "    response = query_engine.query(\n",
+                "        \"What did the author do growing up?\"\n",
+                "    )\n",
+                "    print(f\"Query mode: {query_mode}\")\n",
+                "    display(Markdown(f\"<b>{response}</b>\"))"
             ]
         },
         {
@@ -169,6 +176,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "id": "0da9092e",
             "metadata": {},
@@ -212,6 +220,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "id": "5636a15c-8938-4809-958b-03b8c445ecbd",
             "metadata": {},
@@ -230,6 +239,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "id": "c0c5d984-db20-4679-adb1-1ea956a64150",
             "metadata": {},
@@ -294,9 +304,9 @@
     ],
     "metadata": {
         "kernelspec": {
-            "display_name": "llama_index",
+            "display_name": "Python 3",
             "language": "python",
-            "name": "llama_index"
+            "name": "python3"
         },
         "language_info": {
             "codemirror_mode": {
@@ -308,7 +318,7 @@
             "name": "python",
             "nbconvert_exporter": "python",
             "pygments_lexer": "ipython3",
-            "version": "3.10.10"
+            "version": "3.10.6"
         }
     },
     "nbformat": 4,

--- a/docs/examples/vector_stores/SimpleIndexOnS3.ipynb
+++ b/docs/examples/vector_stores/SimpleIndexOnS3.ipynb
@@ -1,0 +1,234 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:numexpr.utils:Note: NumExpr detected 32 cores but \"NUMEXPR_MAX_THREADS\" not set, so enforcing safe limit of 8.\n",
+      "Note: NumExpr detected 32 cores but \"NUMEXPR_MAX_THREADS\" not set, so enforcing safe limit of 8.\n",
+      "INFO:numexpr.utils:NumExpr defaulting to 8 threads.\n",
+      "NumExpr defaulting to 8 threads.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/hua/code/llama_index/.hermit/python/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
+   "source": [
+    "import logging\n",
+    "import sys\n",
+    "\n",
+    "logging.basicConfig(stream=sys.stdout, level=logging.INFO)\n",
+    "logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))\n",
+    "\n",
+    "from llama_index import GPTVectorStoreIndex, SimpleDirectoryReader, load_index_from_storage, StorageContext\n",
+    "from IPython.display import Markdown, display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dotenv\n",
+    "import s3fs\n",
+    "import os\n",
+    "dotenv.load_dotenv(\"../../../.env\")\n",
+    "\n",
+    "AWS_KEY = os.environ['AWS_ACCESS_KEY_ID']\n",
+    "AWS_SECRET = os.environ['AWS_SECRET_ACCESS_KEY']\n",
+    "R2_ACCOUNT_ID = os.environ['R2_ACCOUNT_ID']\n",
+    "\n",
+    "assert AWS_KEY is not None and AWS_KEY != \"\"\n",
+    "\n",
+    "s3 = s3fs.S3FileSystem(\n",
+    "   key=AWS_KEY,\n",
+    "   secret=AWS_SECRET,\n",
+    "   endpoint_url=f'https://{R2_ACCOUNT_ID}.r2.cloudflarestorage.com',\n",
+    "   s3_additional_kwargs={'ACL': 'public-read'}\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1\n"
+     ]
+    }
+   ],
+   "source": [
+    "# load documents\n",
+    "documents = SimpleDirectoryReader('../../../examples/paul_graham_essay/data/').load_data()\n",
+    "print(len(documents))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:llama_index.token_counter.token_counter:> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
+      "> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
+      "INFO:llama_index.token_counter.token_counter:> [build_index_from_nodes] Total embedding token usage: 20729 tokens\n",
+      "> [build_index_from_nodes] Total embedding token usage: 20729 tokens\n"
+     ]
+    }
+   ],
+   "source": [
+    "index = GPTVectorStoreIndex.from_documents(documents, fs=s3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# save index to disk\n",
+    "index.set_index_id(\"vector_index\")\n",
+    "index.storage_context.persist('llama-index/storage_demo', fs=s3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'Key': 'llama-index/storage_demo/docstore.json',\n",
+       "  'LastModified': datetime.datetime(2023, 5, 14, 20, 23, 53, 213000, tzinfo=tzutc()),\n",
+       "  'ETag': '\"3993f79a6f7cf908a8e53450a2876cf0\"',\n",
+       "  'Size': 107529,\n",
+       "  'StorageClass': 'STANDARD',\n",
+       "  'type': 'file',\n",
+       "  'size': 107529,\n",
+       "  'name': 'llama-index/storage_demo/docstore.json'},\n",
+       " {'Key': 'llama-index/storage_demo/index_store.json',\n",
+       "  'LastModified': datetime.datetime(2023, 5, 14, 20, 23, 53, 783000, tzinfo=tzutc()),\n",
+       "  'ETag': '\"5b084883bf0b08e3c2b979af7c16be43\"',\n",
+       "  'Size': 3105,\n",
+       "  'StorageClass': 'STANDARD',\n",
+       "  'type': 'file',\n",
+       "  'size': 3105,\n",
+       "  'name': 'llama-index/storage_demo/index_store.json'},\n",
+       " {'Key': 'llama-index/storage_demo/vector_store.json',\n",
+       "  'LastModified': datetime.datetime(2023, 5, 14, 20, 23, 54, 232000, tzinfo=tzutc()),\n",
+       "  'ETag': '\"75535cf22c23bcd8ead21b8a52e9517a\"',\n",
+       "  'Size': 829290,\n",
+       "  'StorageClass': 'STANDARD',\n",
+       "  'type': 'file',\n",
+       "  'size': 829290,\n",
+       "  'name': 'llama-index/storage_demo/vector_store.json'}]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "s3.listdir('llama-index/storage_demo')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load index from s3\n",
+    "sc = StorageContext.from_defaults(persist_dir='llama-index/storage_demo', fs=s3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:llama_index.indices.loading:Loading indices with ids: ['vector_index']\n",
+      "Loading indices with ids: ['vector_index']\n"
+     ]
+    }
+   ],
+   "source": [
+    "index2 = load_index_from_storage(sc, 'vector_index')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict_keys(['f8891670-813b-4cfa-9025-fcdc8ba73449', '985a2c69-9da5-40cf-ba30-f984921187c1', 'c55f077c-0bfb-4036-910c-6fd5f26f7372', 'b47face6-f25b-4381-bb8d-164f179d6888', '16304ef7-2378-4776-b86d-e8ed64c8fb58', '62dfdc7a-6a2f-4d5f-9033-851fbc56c14a', 'a51ef189-3924-494b-84cf-e23df673e29c', 'f94aca2b-34ac-4ec4-ac41-d31cd3b7646f', 'ad89e2fb-e0fc-4615-a380-8245bd6546af', '3dbba979-ca08-4321-b4de-be5236ac2e11', '634b2d6d-0bff-4384-898f-b521470db8ac', 'ee9551ba-7a44-493d-997b-8eeab9c04e25', 'b21fe2b5-d8e3-4895-8424-fa9e3da76711', 'bd2609e8-8b52-49e8-8ee7-41b64b3ce9e1', 'a08b739e-efd9-4a61-8517-c4f9cea8cf7d', '8d4babaf-37f1-454a-8be4-b67e1b8e428f', '05389153-4567-4e53-a2ea-bc3e020ee1b2', 'd29531a5-c5d2-4e1d-ab99-56f2b4bb7f37', '2ccb3c63-3407-4acf-b5bb-045caa588bbc', 'a0b1bebb-3dcd-4bf8-9ebb-a4cd2cb82d53', '21517b34-6c1b-4607-bf89-7ab59b85fba6', 'f2487d52-1e5e-4482-a182-218680ef306e', '979998ce-39ee-41bc-a9be-b3ed68d7c304', '3e658f36-a13e-407a-8624-0adf9e842676'])"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "index2.docstore.docs.keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/how_to/storage.rst
+++ b/docs/how_to/storage.rst
@@ -13,8 +13,18 @@ Under the hood, LlamaIndex also supports swappable **storage components** that a
 
 The Document/Index stores rely on a common Key-Value store abstraction, which is also detailed below.
 
+LlamaIndex supports persisting data to any storage backend supported by `fsspec <https://filesystem-spec.readthedocs.io/en/latest/index.html> _`. 
+We have confirmed support for the following storage backends:
+
+- Local filesystem
+- AWS S3
+- Cloudflare R2
+
+For an example of how to use LlamaIndex with Cloudflare R2, see `this example </examples/vector_stores/SimpleIndexOnS3.ipynb>`_.
+
 
 .. image:: ../_static/storage/storage.png
+   :class: only-light
 
 
 .. toctree::

--- a/llama_index/storage/docstore/simple_docstore.py
+++ b/llama_index/storage/docstore/simple_docstore.py
@@ -1,4 +1,5 @@
 import os
+import fsspec
 from typing import Optional
 from llama_index.storage.docstore.keyval_docstore import KVDocumentStore
 from llama_index.storage.kvstore.simple_kvstore import SimpleKVStore
@@ -35,42 +36,47 @@ class SimpleDocumentStore(KVDocumentStore):
         cls,
         persist_dir: str = DEFAULT_PERSIST_DIR,
         namespace: Optional[str] = None,
+        fs: Optional[fsspec.AbstractFileSystem] = None,
     ) -> "SimpleDocumentStore":
         """Create a SimpleDocumentStore from a persist directory.
 
         Args:
             persist_dir (str): directory to persist the store
             namespace (Optional[str]): namespace for the docstore
+            fs (Optional[fsspec.AbstractFileSystem]): filesystem to use
 
         """
 
         persist_path = os.path.join(persist_dir, DEFAULT_PERSIST_FNAME)
-        return cls.from_persist_path(persist_path, namespace=namespace)
+        return cls.from_persist_path(persist_path, namespace=namespace, fs=fs)
 
     @classmethod
     def from_persist_path(
         cls,
         persist_path: str,
         namespace: Optional[str] = None,
+        fs: Optional[fsspec.AbstractFileSystem] = None,
     ) -> "SimpleDocumentStore":
         """Create a SimpleDocumentStore from a persist path.
 
         Args:
             persist_path (str): Path to persist the store
             namespace (Optional[str]): namespace for the docstore
+            fs (Optional[fsspec.AbstractFileSystem]): filesystem to use
 
         """
 
-        simple_kvstore = SimpleKVStore.from_persist_path(persist_path)
+        simple_kvstore = SimpleKVStore.from_persist_path(persist_path, fs=fs)
         return cls(simple_kvstore, namespace)
 
     def persist(
         self,
         persist_path: str = DEFAULT_PERSIST_PATH,
+        fs: Optional[fsspec.AbstractFileSystem] = None,
     ) -> None:
         """Persist the store."""
         if isinstance(self._kvstore, BaseInMemoryKVStore):
-            self._kvstore.persist(persist_path)
+            self._kvstore.persist(persist_path, fs=fs)
 
     @classmethod
     def from_dict(

--- a/llama_index/storage/docstore/types.py
+++ b/llama_index/storage/docstore/types.py
@@ -1,9 +1,10 @@
+import os
+import fsspec
 from abc import ABC, abstractmethod
 from typing import Dict, List, Optional, Sequence
 from llama_index.data_structs.node import Node
 
 from llama_index.schema import BaseDocument
-import os
 
 
 DEFAULT_PERSIST_FNAME = "docstore.json"
@@ -13,7 +14,12 @@ DEFAULT_PERSIST_PATH = os.path.join(DEFAULT_PERSIST_DIR, DEFAULT_PERSIST_FNAME)
 
 class BaseDocumentStore(ABC):
     # ===== Save/load =====
-    def persist(self, persist_path: str = DEFAULT_PERSIST_PATH) -> None:
+    def persist(
+        self,
+        persist_path: str = DEFAULT_PERSIST_PATH,
+        fs: Optional[fsspec.AbstractFileSystem] = None,
+    ) -> None:
+        """Persist the docstore to a file."""
         pass
 
     # ===== Main interface =====

--- a/llama_index/storage/index_store/simple_index_store.py
+++ b/llama_index/storage/index_store/simple_index_store.py
@@ -22,10 +22,9 @@ class SimpleIndexStore(KVIndexStore):
     def __init__(
         self,
         simple_kvstore: Optional[SimpleKVStore] = None,
-        fs: Optional[fsspec.AbstractFileSystem] = None,
     ) -> None:
         """Init a SimpleIndexStore."""
-        simple_kvstore = simple_kvstore or SimpleKVStore(fs=fs)
+        simple_kvstore = simple_kvstore or SimpleKVStore()
         super().__init__(simple_kvstore)
 
     @classmethod

--- a/llama_index/storage/index_store/simple_index_store.py
+++ b/llama_index/storage/index_store/simple_index_store.py
@@ -1,5 +1,6 @@
 import os
 from typing import Optional
+import fsspec
 from llama_index.storage.index_store.keyval_index_store import KVIndexStore
 from llama_index.storage.kvstore.simple_kvstore import SimpleKVStore
 from llama_index.storage.kvstore.types import BaseInMemoryKVStore
@@ -18,28 +19,44 @@ class SimpleIndexStore(KVIndexStore):
 
     """
 
-    def __init__(self, simple_kvstore: Optional[SimpleKVStore] = None) -> None:
-        simple_kvstore = simple_kvstore or SimpleKVStore()
+    def __init__(
+        self,
+        simple_kvstore: Optional[SimpleKVStore] = None,
+        fs: Optional[fsspec.AbstractFileSystem] = None,
+    ) -> None:
+        """Init a SimpleIndexStore."""
+        simple_kvstore = simple_kvstore or SimpleKVStore(fs=fs)
         super().__init__(simple_kvstore)
 
     @classmethod
     def from_persist_dir(
-        cls, persist_dir: str = DEFAULT_PERSIST_DIR
+        cls,
+        persist_dir: str = DEFAULT_PERSIST_DIR,
+        fs: Optional[fsspec.AbstractFileSystem] = None,
     ) -> "SimpleIndexStore":
         """Create a SimpleIndexStore from a persist directory."""
         persist_path = os.path.join(persist_dir, DEFAULT_PERSIST_FNAME)
-        return cls.from_persist_path(persist_path)
+        return cls.from_persist_path(persist_path, fs=fs)
 
     @classmethod
-    def from_persist_path(cls, persist_path: str) -> "SimpleIndexStore":
+    def from_persist_path(
+        cls,
+        persist_path: str,
+        fs: Optional[fsspec.AbstractFileSystem] = None,
+    ) -> "SimpleIndexStore":
         """Create a SimpleIndexStore from a persist path."""
-        simple_kvstore = SimpleKVStore.from_persist_path(persist_path)
+        fs = fs or fsspec.filesystem("file")
+        simple_kvstore = SimpleKVStore.from_persist_path(persist_path, fs=fs)
         return cls(simple_kvstore)
 
-    def persist(self, persist_path: str = DEFAULT_PERSIST_PATH) -> None:
+    def persist(
+        self,
+        persist_path: str = DEFAULT_PERSIST_PATH,
+        fs: Optional[fsspec.AbstractFileSystem] = None,
+    ) -> None:
         """Persist the store."""
         if isinstance(self._kvstore, BaseInMemoryKVStore):
-            self._kvstore.persist(persist_path)
+            self._kvstore.persist(persist_path, fs=fs)
 
     @classmethod
     def from_dict(cls, save_dict: dict) -> "SimpleIndexStore":

--- a/llama_index/storage/index_store/types.py
+++ b/llama_index/storage/index_store/types.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 
 from llama_index.data_structs.data_structs import IndexStruct
 import os
+import fsspec
 
 DEFAULT_PERSIST_DIR = "./storage"
 DEFAULT_PERSIST_FNAME = "index_store.json"
@@ -28,6 +29,10 @@ class BaseIndexStore(ABC):
     ) -> Optional[IndexStruct]:
         pass
 
-    def persist(self, persist_path: str = DEFAULT_PERSIST_PATH) -> None:
+    def persist(
+        self,
+        persist_path: str = DEFAULT_PERSIST_PATH,
+        fs: Optional[fsspec.AbstractFileSystem] = None,
+    ) -> None:
         """Persist the index store to disk."""
         pass

--- a/llama_index/storage/kvstore/simple_kvstore.py
+++ b/llama_index/storage/kvstore/simple_kvstore.py
@@ -26,11 +26,9 @@ class SimpleKVStore(BaseInMemoryKVStore):
     def __init__(
         self,
         data: Optional[DATA_TYPE] = None,
-        fs: Optional[fsspec.AbstractFileSystem] = None,
     ) -> None:
         """Init a SimpleKVStore."""
         self._data: DATA_TYPE = data or {}
-        self._fs = fs or fsspec.filesystem("file")
 
     def put(self, key: str, val: dict, collection: str = DEFAULT_COLLECTION) -> None:
         """Put a key-value pair into the store."""
@@ -63,7 +61,7 @@ class SimpleKVStore(BaseInMemoryKVStore):
         self, persist_path: str, fs: Optional[fsspec.AbstractFileSystem] = None
     ) -> None:
         """Persist the store."""
-        fs = fs or self._fs
+        fs = fs or fsspec.filesystem("file")
         dirpath = os.path.dirname(persist_path)
         if not fs.exists(dirpath):
             fs.makedirs(dirpath)
@@ -80,7 +78,7 @@ class SimpleKVStore(BaseInMemoryKVStore):
         logger.debug(f"Loading {__name__} from {persist_path}.")
         with fs.open(persist_path, "rb") as f:
             data = json.load(f)
-        return cls(data, fs)
+        return cls(data)
 
     def to_dict(self) -> dict:
         """Save the store as dict."""

--- a/llama_index/storage/kvstore/simple_kvstore.py
+++ b/llama_index/storage/kvstore/simple_kvstore.py
@@ -5,8 +5,7 @@ from typing import Dict, Optional
 
 import fsspec
 
-from llama_index.storage.kvstore.types import (DEFAULT_COLLECTION,
-                                               BaseInMemoryKVStore)
+from llama_index.storage.kvstore.types import DEFAULT_COLLECTION, BaseInMemoryKVStore
 
 logger = logging.getLogger(__name__)
 

--- a/llama_index/storage/kvstore/simple_kvstore.py
+++ b/llama_index/storage/kvstore/simple_kvstore.py
@@ -1,14 +1,12 @@
 import json
+import logging
 import os
 from typing import Dict, Optional
-import logging
+
 import fsspec
 
-from llama_index.storage.kvstore.types import (
-    DEFAULT_COLLECTION,
-    BaseInMemoryKVStore,
-)
-
+from llama_index.storage.kvstore.types import (DEFAULT_COLLECTION,
+                                               BaseInMemoryKVStore)
 
 logger = logging.getLogger(__name__)
 
@@ -20,8 +18,6 @@ class SimpleKVStore(BaseInMemoryKVStore):
 
     Args:
         data (Optional[DATA_TYPE]): data to initialize the store with
-        fs (Optional[fsspec.AbstractFileSystem]): filesystem to use. defaults to local
-            storage
     """
 
     def __init__(

--- a/llama_index/storage/kvstore/simple_kvstore.py
+++ b/llama_index/storage/kvstore/simple_kvstore.py
@@ -20,7 +20,8 @@ class SimpleKVStore(BaseInMemoryKVStore):
 
     Args:
         data (Optional[DATA_TYPE]): data to initialize the store with
-        fs (Optional[fsspec.AbstractFileSystem]): filesystem to use. defaults to local storage
+        fs (Optional[fsspec.AbstractFileSystem]): filesystem to use. defaults to local
+            storage
     """
 
     def __init__(

--- a/llama_index/storage/kvstore/types.py
+++ b/llama_index/storage/kvstore/types.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import Dict, Optional
+import fsspec
 
 DEFAULT_COLLECTION = "data"
 
@@ -28,7 +29,9 @@ class BaseInMemoryKVStore(BaseKVStore):
     """Base in-memory key-value store."""
 
     @abstractmethod
-    def persist(self, persist_path: str) -> None:
+    def persist(
+        self, persist_path: str, fs: Optional[fsspec.AbstractFileSystem] = None
+    ) -> None:
         pass
 
     @classmethod

--- a/llama_index/storage/storage_context.py
+++ b/llama_index/storage/storage_context.py
@@ -1,18 +1,21 @@
 from dataclasses import dataclass
-from typing import Optional
 from pathlib import Path
-import fsspec
-from llama_index.constants import DOC_STORE_KEY, INDEX_STORE_KEY, VECTOR_STORE_KEY
-from llama_index.storage.docstore.simple_docstore import SimpleDocumentStore
-from llama_index.storage.docstore.types import BaseDocumentStore
-from llama_index.storage.docstore.types import DEFAULT_PERSIST_FNAME as DOCSTORE_FNAME
-from llama_index.storage.index_store.types import (
-    DEFAULT_PERSIST_FNAME as INDEX_STORE_FNAME,
-)
-from llama_index.vector_stores.simple import DEFAULT_PERSIST_FNAME as VECTOR_STORE_FNAME
+from typing import Optional
 
+import fsspec
+
+from llama_index.constants import (DOC_STORE_KEY, INDEX_STORE_KEY,
+                                   VECTOR_STORE_KEY)
+from llama_index.storage.docstore.simple_docstore import SimpleDocumentStore
+from llama_index.storage.docstore.types import \
+    DEFAULT_PERSIST_FNAME as DOCSTORE_FNAME
+from llama_index.storage.docstore.types import BaseDocumentStore
 from llama_index.storage.index_store.simple_index_store import SimpleIndexStore
+from llama_index.storage.index_store.types import \
+    DEFAULT_PERSIST_FNAME as INDEX_STORE_FNAME
 from llama_index.storage.index_store.types import BaseIndexStore
+from llama_index.vector_stores.simple import \
+    DEFAULT_PERSIST_FNAME as VECTOR_STORE_FNAME
 from llama_index.vector_stores.simple import SimpleVectorStore
 from llama_index.vector_stores.types import VectorStore
 
@@ -34,7 +37,6 @@ class StorageContext:
     docstore: BaseDocumentStore
     index_store: BaseIndexStore
     vector_store: VectorStore
-    fs: fsspec.AbstractFileSystem
 
     @classmethod
     def from_defaults(
@@ -53,7 +55,6 @@ class StorageContext:
             vector_store (Optional[VectorStore]): vector store
 
         """
-        fs = fs or fsspec.filesystem("file")
         if persist_dir is None:
             docstore = docstore or SimpleDocumentStore()
             index_store = index_store or SimpleIndexStore()
@@ -69,7 +70,7 @@ class StorageContext:
                 persist_dir, fs=fs
             )
 
-        return cls(docstore, index_store, vector_store, fs)
+        return cls(docstore, index_store, vector_store)
 
     def persist(
         self,
@@ -85,7 +86,6 @@ class StorageContext:
             persist_dir (str): directory to persist the storage context
 
         """
-        fs = fs or self.fs
         docstore_path = str(Path(persist_dir) / docstore_fname)
         index_store_path = str(Path(persist_dir) / index_store_fname)
         vector_store_path = str(Path(persist_dir) / vector_store_fname)
@@ -124,5 +124,4 @@ class StorageContext:
             docstore=docstore,
             index_store=index_store,
             vector_store=vector_store,
-            fs=fsspec.filesystem("file"),
         )

--- a/llama_index/storage/storage_context.py
+++ b/llama_index/storage/storage_context.py
@@ -4,18 +4,16 @@ from typing import Optional
 
 import fsspec
 
-from llama_index.constants import (DOC_STORE_KEY, INDEX_STORE_KEY,
-                                   VECTOR_STORE_KEY)
+from llama_index.constants import DOC_STORE_KEY, INDEX_STORE_KEY, VECTOR_STORE_KEY
 from llama_index.storage.docstore.simple_docstore import SimpleDocumentStore
-from llama_index.storage.docstore.types import \
-    DEFAULT_PERSIST_FNAME as DOCSTORE_FNAME
+from llama_index.storage.docstore.types import DEFAULT_PERSIST_FNAME as DOCSTORE_FNAME
 from llama_index.storage.docstore.types import BaseDocumentStore
 from llama_index.storage.index_store.simple_index_store import SimpleIndexStore
-from llama_index.storage.index_store.types import \
-    DEFAULT_PERSIST_FNAME as INDEX_STORE_FNAME
+from llama_index.storage.index_store.types import (
+    DEFAULT_PERSIST_FNAME as INDEX_STORE_FNAME,
+)
 from llama_index.storage.index_store.types import BaseIndexStore
-from llama_index.vector_stores.simple import \
-    DEFAULT_PERSIST_FNAME as VECTOR_STORE_FNAME
+from llama_index.vector_stores.simple import DEFAULT_PERSIST_FNAME as VECTOR_STORE_FNAME
 from llama_index.vector_stores.simple import SimpleVectorStore
 from llama_index.vector_stores.types import VectorStore
 

--- a/llama_index/vector_stores/faiss.py
+++ b/llama_index/vector_stores/faiss.py
@@ -7,6 +7,7 @@ An index that that is built on top of an existing vector store.
 import logging
 import os
 import fsspec
+from fsspec.implementations.local import LocalFileSystem
 from typing import Any, List, cast, Optional
 
 import numpy as np
@@ -62,7 +63,10 @@ class FaissVectorStore(VectorStore):
         fs: Optional[fsspec.AbstractFileSystem] = None,
     ) -> "FaissVectorStore":
         persist_path = os.path.join(persist_dir, DEFAULT_PERSIST_FNAME)
-        return cls.from_persist_path(persist_path=persist_path, fs=fs)
+        # only support local storage for now
+        if fs and not isinstance(fs, LocalFileSystem):
+            raise NotImplementedError(f"FAISS only supports local storage for now.")
+        return cls.from_persist_path(persist_path=persist_path, fs=None)
 
     @classmethod
     def from_persist_path(
@@ -74,8 +78,8 @@ class FaissVectorStore(VectorStore):
 
         # I don't think FAISS supports fsspec, it requires a path in the SWIG interface
         # TODO: copy to a temp file and load into memory from there
-        if fs is not None:
-            raise NotImplementedError("FAISS does not support fsspec")
+        if fs and not isinstance(fs, LocalFileSystem):
+            raise NotImplementedError(f"FAISS only supports local storage for now.")
 
         if not os.path.exists(persist_path):
             raise ValueError(f"No existing {__name__} found at {persist_path}.")
@@ -125,8 +129,8 @@ class FaissVectorStore(VectorStore):
         """
         # I don't think FAISS supports fsspec, it requires a path in the SWIG interface
         # TODO: write to a temporary file and then copy to the final destination
-        if fs is not None:
-            raise NotImplementedError("FAISS does not support fsspec")
+        if fs and not isinstance(fs, LocalFileSystem):
+            raise NotImplementedError(f"FAISS only supports local storage for now.")
         import faiss
 
         dirpath = os.path.dirname(persist_path)

--- a/llama_index/vector_stores/faiss.py
+++ b/llama_index/vector_stores/faiss.py
@@ -6,7 +6,8 @@ An index that that is built on top of an existing vector store.
 
 import logging
 import os
-from typing import Any, List, cast
+import fsspec
+from typing import Any, List, cast, Optional
 
 import numpy as np
 
@@ -58,16 +59,23 @@ class FaissVectorStore(VectorStore):
     def from_persist_dir(
         cls,
         persist_dir: str = DEFAULT_PERSIST_DIR,
+        fs: Optional[fsspec.AbstractFileSystem] = None,
     ) -> "FaissVectorStore":
         persist_path = os.path.join(persist_dir, DEFAULT_PERSIST_FNAME)
-        return cls.from_persist_path(persist_path=persist_path)
+        return cls.from_persist_path(persist_path=persist_path, fs=fs)
 
     @classmethod
     def from_persist_path(
         cls,
         persist_path: str,
+        fs: Optional[fsspec.AbstractFileSystem] = None,
     ) -> "FaissVectorStore":
         import faiss
+
+        # I don't think FAISS supports fsspec, it requires a path in the SWIG interface
+        # TODO: copy to a temp file and load into memory from there
+        if fs is not None:
+            raise NotImplementedError("FAISS does not support fsspec")
 
         if not os.path.exists(persist_path):
             raise ValueError(f"No existing {__name__} found at {persist_path}.")
@@ -105,6 +113,7 @@ class FaissVectorStore(VectorStore):
     def persist(
         self,
         persist_path: str = os.path.join(DEFAULT_PERSIST_DIR, DEFAULT_PERSIST_FNAME),
+        fs: Optional[fsspec.AbstractFileSystem] = None,
     ) -> None:
         """Save to file.
 
@@ -114,6 +123,10 @@ class FaissVectorStore(VectorStore):
             persist_path (str): The save_path of the file.
 
         """
+        # I don't think FAISS supports fsspec, it requires a path in the SWIG interface
+        # TODO: write to a temporary file and then copy to the final destination
+        if fs is not None:
+            raise NotImplementedError("FAISS does not support fsspec")
         import faiss
 
         dirpath = os.path.dirname(persist_path)

--- a/llama_index/vector_stores/faiss.py
+++ b/llama_index/vector_stores/faiss.py
@@ -65,7 +65,7 @@ class FaissVectorStore(VectorStore):
         persist_path = os.path.join(persist_dir, DEFAULT_PERSIST_FNAME)
         # only support local storage for now
         if fs and not isinstance(fs, LocalFileSystem):
-            raise NotImplementedError(f"FAISS only supports local storage for now.")
+            raise NotImplementedError("FAISS only supports local storage for now.")
         return cls.from_persist_path(persist_path=persist_path, fs=None)
 
     @classmethod
@@ -79,7 +79,7 @@ class FaissVectorStore(VectorStore):
         # I don't think FAISS supports fsspec, it requires a path in the SWIG interface
         # TODO: copy to a temp file and load into memory from there
         if fs and not isinstance(fs, LocalFileSystem):
-            raise NotImplementedError(f"FAISS only supports local storage for now.")
+            raise NotImplementedError("FAISS only supports local storage for now.")
 
         if not os.path.exists(persist_path):
             raise ValueError(f"No existing {__name__} found at {persist_path}.")
@@ -130,7 +130,7 @@ class FaissVectorStore(VectorStore):
         # I don't think FAISS supports fsspec, it requires a path in the SWIG interface
         # TODO: write to a temporary file and then copy to the final destination
         if fs and not isinstance(fs, LocalFileSystem):
-            raise NotImplementedError(f"FAISS only supports local storage for now.")
+            raise NotImplementedError("FAISS only supports local storage for now.")
         import faiss
 
         dirpath = os.path.dirname(persist_path)

--- a/llama_index/vector_stores/redis.py
+++ b/llama_index/vector_stores/redis.py
@@ -3,6 +3,7 @@
 An index that that is built on top of an existing vector store.
 """
 import logging
+import fsspec
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from llama_index.data_structs.node import DocumentRelationship, Node
@@ -251,12 +252,18 @@ class RedisVectorStore(VectorStore):
 
         return VectorStoreQueryResult(nodes=nodes, ids=ids, similarities=scores)
 
-    def persist(self, persist_path: str, in_background: bool = True) -> None:
+    def persist(
+        self,
+        persist_path: str,
+        fs: Optional[fsspec.AbstractFileSystem] = None,
+        in_background: bool = True,
+    ) -> None:
         """Persist the vector store to disk.
 
         Args:
             persist_path (str): Path to persist the vector store to. (doesn't apply)
             in_background (bool, optional): Persist in background. Defaults to True.
+            fs (fsspec.AbstractFileSystem, optional): Filesystem to persist to. (doesn't apply)
 
         Raises:
             redis.exceptions.RedisError: If there is an error

--- a/llama_index/vector_stores/redis.py
+++ b/llama_index/vector_stores/redis.py
@@ -263,7 +263,8 @@ class RedisVectorStore(VectorStore):
         Args:
             persist_path (str): Path to persist the vector store to. (doesn't apply)
             in_background (bool, optional): Persist in background. Defaults to True.
-            fs (fsspec.AbstractFileSystem, optional): Filesystem to persist to. (doesn't apply)
+            fs (fsspec.AbstractFileSystem, optional): Filesystem to persist to.
+                (doesn't apply)
 
         Raises:
             redis.exceptions.RedisError: If there is an error

--- a/llama_index/vector_stores/simple.py
+++ b/llama_index/vector_stores/simple.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import fsspec
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, cast
 
@@ -61,17 +62,22 @@ class SimpleVectorStore(VectorStore):
     def __init__(
         self,
         data: Optional[SimpleVectorStoreData] = None,
+        fs: Optional[fsspec.AbstractFileSystem] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize params."""
         self._data = data or SimpleVectorStoreData()
+        self._fs = fs or fsspec.filesystem("file")
 
     @classmethod
     def from_persist_dir(
-        cls, persist_dir: str = DEFAULT_PERSIST_DIR
+        cls,
+        persist_dir: str = DEFAULT_PERSIST_DIR,
+        fs: Optional[fsspec.AbstractFileSystem] = None,
     ) -> "SimpleVectorStore":
+        """Load from persist dir."""
         persist_path = os.path.join(persist_dir, DEFAULT_PERSIST_FNAME)
-        return cls.from_persist_path(persist_path)
+        return cls.from_persist_path(persist_path, fs=fs)
 
     @property
     def client(self) -> None:
@@ -143,25 +149,31 @@ class SimpleVectorStore(VectorStore):
     def persist(
         self,
         persist_path: str = os.path.join(DEFAULT_PERSIST_DIR, DEFAULT_PERSIST_FNAME),
+        fs: Optional[fsspec.AbstractFileSystem] = None,
     ) -> None:
         """Persist the SimpleVectorStore to a directory."""
+        fs = fs or self._fs
         dirpath = os.path.dirname(persist_path)
-        if not os.path.exists(dirpath):
-            os.makedirs(dirpath)
+        if not fs.exists(dirpath):
+            fs.makedirs(dirpath)
 
-        with open(persist_path, "w+") as f:
+        with fs.open(persist_path, "w") as f:
             json.dump(self._data.to_dict(), f)
 
     @classmethod
-    def from_persist_path(cls, persist_path: str) -> "SimpleVectorStore":
+    @classmethod
+    def from_persist_path(
+        cls, persist_path: str, fs: Optional[fsspec.AbstractFileSystem] = None
+    ) -> "SimpleVectorStore":
         """Create a SimpleKVStore from a persist directory."""
-        if not os.path.exists(persist_path):
+        fs = fs or fsspec.filesystem("file")
+        if not fs.exists(persist_path):
             raise ValueError(
                 f"No existing {__name__} found at {persist_path}, skipping load."
             )
 
         logger.debug(f"Loading {__name__} from {persist_path}.")
-        with open(persist_path, "r+") as f:
+        with fs.open(persist_path, "rb") as f:
             data_dict = json.load(f)
             data = SimpleVectorStoreData.from_dict(data_dict)
         return cls(data)

--- a/llama_index/vector_stores/simple.py
+++ b/llama_index/vector_stores/simple.py
@@ -161,7 +161,6 @@ class SimpleVectorStore(VectorStore):
             json.dump(self._data.to_dict(), f)
 
     @classmethod
-    @classmethod
     def from_persist_path(
         cls, persist_path: str, fs: Optional[fsspec.AbstractFileSystem] = None
     ) -> "SimpleVectorStore":

--- a/llama_index/vector_stores/types.py
+++ b/llama_index/vector_stores/types.py
@@ -1,5 +1,5 @@
 """Vector store index types."""
-
+import fsspec
 
 from dataclasses import dataclass
 from enum import Enum
@@ -152,5 +152,7 @@ class VectorStore(Protocol):
         """Query vector store."""
         ...
 
-    def persist(self, persist_path: str) -> None:
+    def persist(
+        self, persist_path: str, fs: Optional[fsspec.AbstractFileSystem]
+    ) -> None:
         return None

--- a/llama_index/vector_stores/types.py
+++ b/llama_index/vector_stores/types.py
@@ -1,10 +1,9 @@
 """Vector store index types."""
-import fsspec
-
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, List, Optional, Protocol, Union, runtime_checkable
 
+import fsspec
 from pydantic import BaseModel
 
 from llama_index.data_structs.node import Node
@@ -153,6 +152,6 @@ class VectorStore(Protocol):
         ...
 
     def persist(
-        self, persist_path: str, fs: Optional[fsspec.AbstractFileSystem]
+        self, persist_path: str, fs: Optional[fsspec.AbstractFileSystem] = None
     ) -> None:
         return None

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ install_requires = [
     "openai>=0.26.4",
     "pandas",
     "requests<2.30.0",
+    "fsspec>=2023.5.0",
 ]
 
 # NOTE: if python version >= 3.9, install tiktoken


### PR DESCRIPTION
The goal of the PR is to enable abstract filesystems, not just local, when dealing with storage files. As an example, this allows us to directly write to a S3 bucket, useful for serving the results in production. Tested working on Cloudflare R2 and local storage, but via fsspec, should support many more, including Azure / GCS / whatever.

To do so, we use [fsspec](https://filesystem-spec.readthedocs.io/en/latest/index.html), a popular and well-understood library for abstracting file protocols. This adds fsspec as a core dependency to the package. Note that in order to use S3, the user needs to install [s3fs](https://github.com/fsspec/s3fs) in their local environment. I suggest against requiring fsspec implementations, up to the user to find their own. 

The API is probably not the cleanest, open to feedback for how to structure it.