### PR TITLE
readability: LangChain example AgentExecutor variable

### DIFF
--- a/examples/langchain_demo/LangchainDemo.ipynb
+++ b/examples/langchain_demo/LangchainDemo.ipynb
@@ -87,7 +87,7 @@
                 "# set Logging to DEBUG for more detailed outputs\n",
                 "memory = ConversationBufferMemory(memory_key=\"chat_history\")\n",
                 "llm = ChatOpenAI(temperature=0)\n",
-                "agent_chain = initialize_agent(tools, llm, agent=\"conversational-react-description\", memory=memory)"
+                "agent_executor = initialize_agent(tools, llm, agent=\"conversational-react-description\", memory=memory)"
             ]
         },
         {
@@ -122,7 +122,7 @@
                 }
             ],
             "source": [
-                "agent_chain.run(input=\"hi, i am bob\")"
+                "agent_executor.run(input=\"hi, i am bob\")"
             ]
         },
         {
@@ -164,7 +164,7 @@
                 }
             ],
             "source": [
-                "agent_chain.run(input=\"What did the author do growing up?\")"
+                "agent_executor.run(input=\"What did the author do growing up?\")"
             ]
         },
         {
@@ -231,7 +231,7 @@
                 ")\n",
                 "llm = OpenAIChat(temperature=0)\n",
                 "# llm=OpenAI(temperature=0)\n",
-                "agent_chain = initialize_agent([], llm, agent=\"conversational-react-description\", memory=memory)"
+                "agent_executor = initialize_agent([], llm, agent=\"conversational-react-description\", memory=memory)"
             ]
         },
         {
@@ -272,7 +272,7 @@
                 }
             ],
             "source": [
-                "agent_chain.run(input=\"hi, i am bob\")"
+                "agent_executor.run(input=\"hi, i am bob\")"
             ]
         },
         {
@@ -314,7 +314,7 @@
             ],
             "source": [
                 "# NOTE: the query now calls the GPTListIndex memory module. \n",
-                "agent_chain.run(input=\"what's my name?\")"
+                "agent_executor.run(input=\"what's my name?\")"
             ]
         },
         {


### PR DESCRIPTION
The function `initialize_agent` returns a class
`langchain.agents.agent.AgentExecutor`.
Calling the variable `agent_chain` suggests that the type is a class in `langchain.chains.*` and it is hard to understand the code. This commit changes the variable name to `agent_executor`.