### PR TITLE
Query Index with SVM causes value error when similarity_top_k > 1

### DIFF
--- a/llama_index/indices/utils.py
+++ b/llama_index/indices/utils.py
@@ -49,7 +49,11 @@ def log_vector_store_query_result(
 
     assert result.ids is not None
     assert result.nodes is not None
-    similarities = result.similarities or [1.0 for _ in result.ids]
+    similarities = (
+        result.similarities
+        if result.similarities is not None and len(result.similarities) > 0
+        else [1.0 for _ in result.ids]
+    )
 
     fmt_txts = []
     for node_idx, node_similarity, node in zip(result.ids, similarities, result.nodes):


### PR DESCRIPTION
Since the similarities is a numpy array when using svm, rather than an Optional[list(float)], we need to be a bit more careful when looking at whether or not we have similarities in the result.

This attempts to address #1288 - in the simplest way I could.  
