### PR TITLE
Add S3 KV store

### DIFF
--- a/data_requirements.txt
+++ b/data_requirements.txt
@@ -4,6 +4,8 @@ wikipedia
 pymongo
 slack_sdk
 discord.py
+boto3
+moto[s3]
 
 # google
 google-api-python-client

--- a/llama_index/storage/kvstore/s3_kvstore.py
+++ b/llama_index/storage/kvstore/s3_kvstore.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, Optional
 import json
 from pathlib import PurePath
 import os

--- a/llama_index/storage/kvstore/s3_kvstore.py
+++ b/llama_index/storage/kvstore/s3_kvstore.py
@@ -1,0 +1,131 @@
+from typing import Any, Dict, Optional, cast
+import json
+from pathlib import PurePath
+import os
+from llama_index.storage.kvstore.types import DEFAULT_COLLECTION, BaseKVStore
+
+IMPORT_ERROR_MSG = "`boto3` package not found, please run `pip install boto3`"
+
+
+class S3DBKVStore(BaseKVStore):
+    """S3 Key-Value store.
+    Stores key-value pairs in a S3 bucket. Can optionally specify a path to a folder where KV data is stored.
+    The KV data is further divided into collections, which are subfolders in the path.
+    Each key-value pair is stored as a JSON file.
+
+    Args:
+        s3_bucket (Any): boto3 S3 Bucket instance
+        path (str): path to folder in S3 bucket where KV data is stored
+    """
+
+    def __init__(
+        self,
+        bucket: Any,
+        path: str = "./",
+    ) -> None:
+        """Init a S3DBKVStore."""
+        try:
+            import boto3
+        except ImportError:
+            raise ImportError(IMPORT_ERROR_MSG)
+
+        s3 = boto3.resource("s3")
+        self._bucket = cast(s3.Bucket, bucket)
+
+        self._path = path or "./"
+
+    @classmethod
+    def from_s3_location(
+        cls,
+        bucket_name: str,
+        path: Optional[str] = None,
+    ) -> "S3DBKVStore":
+        """Load a S3DBKVStore from a S3 URI.
+
+        Args:
+            bucket_name (str): S3 bucket name
+            path (Optional[str]): path to folder in S3 bucket where KV data is stored
+        """
+        try:
+            import boto3
+        except ImportError:
+            raise ImportError(IMPORT_ERROR_MSG)
+
+        s3 = boto3.resource("s3")
+        bucket = s3.Bucket(bucket_name)
+        return cls(
+            bucket,
+            path=path,
+        )
+
+    def _get_object_key(self, collection: str, key: str) -> str:
+        return str(PurePath(f"{self._path}/{collection}/{key}.json"))
+
+    def put(
+        self,
+        key: str,
+        val: dict,
+        collection: str = DEFAULT_COLLECTION,
+    ) -> None:
+        """Put a key-value pair into the store.
+
+        Args:
+            key (str): key
+            val (dict): value
+            collection (str): collection name
+
+        """
+        obj_key = self._get_object_key(collection, key)
+        self._bucket.put_object(
+            Key=obj_key,
+            Body=json.dumps(val),
+        )
+
+    def get(self, key: str, collection: str = DEFAULT_COLLECTION) -> Optional[dict]:
+        """Get a value from the store.
+
+        Args:
+            key (str): key
+            collection (str): collection name
+
+        """
+        obj_key = self._get_object_key(collection, key)
+        try:
+            obj = list(self._bucket.objects.filter(Prefix=obj_key).limit(1))[0]
+        except IndexError:
+            return None
+        body = obj.get()["Body"].read()
+        return json.loads(body)
+
+    def get_all(self, collection: str = DEFAULT_COLLECTION) -> Dict[str, dict]:
+        """Get all values from the store.
+
+        Args:
+            collection (str): collection name
+
+        """
+        collection_path = str(PurePath(f"{self._path}/{collection}/"))
+        collection_kv_dict = {}
+        for obj in self._bucket.objects.filter(Prefix=collection_path):
+            body = obj.get()["Body"].read()
+            json_filename = os.path.split(obj.key)[-1]
+            key = os.path.splitext(json_filename)[0]
+            value = json.loads(body)
+            collection_kv_dict[key] = value
+        return collection_kv_dict
+
+    def delete(self, key: str, collection: str = DEFAULT_COLLECTION) -> bool:
+        """Delete a value from the store.
+
+        Args:
+            key (str): key
+            collection (str): collection name
+
+        """
+        obj_key = self._get_object_key(collection, key)
+        matched_objs = list(self._bucket.objects.filter(Prefix=obj_key).limit(1))
+        if len(matched_objs) == 0:
+            return False
+        obj = matched_objs[0]
+        obj.delete()
+        return True

--- a/llama_index/storage/kvstore/s3_kvstore.py
+++ b/llama_index/storage/kvstore/s3_kvstore.py
@@ -15,13 +15,13 @@ class S3DBKVStore(BaseKVStore):
 
     Args:
         s3_bucket (Any): boto3 S3 Bucket instance
-        path (str): path to folder in S3 bucket where KV data is stored
+        path (Optional[str]): path to folder in S3 bucket where KV data is stored
     """
 
     def __init__(
         self,
         bucket: Any,
-        path: str = "./",
+        path: Optional[str] = "./",
     ) -> None:
         """Init a S3DBKVStore."""
         try:
@@ -29,9 +29,7 @@ class S3DBKVStore(BaseKVStore):
         except ImportError:
             raise ImportError(IMPORT_ERROR_MSG)
 
-        s3 = boto3.resource("s3")
-        self._bucket = cast(s3.Bucket, bucket)
-
+        self._bucket = bucket
         self._path = path or "./"
 
     @classmethod

--- a/llama_index/storage/kvstore/s3_kvstore.py
+++ b/llama_index/storage/kvstore/s3_kvstore.py
@@ -1,7 +1,8 @@
-from typing import Any, Dict, Optional
 import json
-from pathlib import PurePath
 import os
+from pathlib import PurePath
+from typing import Any, Dict, Optional
+
 from llama_index.storage.kvstore.types import DEFAULT_COLLECTION, BaseKVStore
 
 IMPORT_ERROR_MSG = "`boto3` package not found, please run `pip install boto3`"
@@ -9,7 +10,8 @@ IMPORT_ERROR_MSG = "`boto3` package not found, please run `pip install boto3`"
 
 class S3DBKVStore(BaseKVStore):
     """S3 Key-Value store.
-    Stores key-value pairs in a S3 bucket. Can optionally specify a path to a folder where KV data is stored.
+    Stores key-value pairs in a S3 bucket. Can optionally specify a path to a folder
+        where KV data is stored.
     The KV data is further divided into collections, which are subfolders in the path.
     Each key-value pair is stored as a JSON file.
 
@@ -25,7 +27,7 @@ class S3DBKVStore(BaseKVStore):
     ) -> None:
         """Init a S3DBKVStore."""
         try:
-            import boto3
+            pass
         except ImportError:
             raise ImportError(IMPORT_ERROR_MSG)
 

--- a/tests/storage/kvstore/test_s3_kvstore.py
+++ b/tests/storage/kvstore/test_s3_kvstore.py
@@ -1,3 +1,4 @@
+from typing import Generator
 import pytest
 from llama_index.storage.kvstore.s3_kvstore import S3DBKVStore
 
@@ -11,7 +12,7 @@ except ImportError:
 
 
 @pytest.fixture()
-def kvstore_from_mocked_bucket() -> S3DBKVStore:
+def kvstore_from_mocked_bucket() -> Generator[S3DBKVStore, None, None]:
     with mock_s3():
         s3 = boto3.resource("s3")
         bucket = s3.Bucket("test_bucket")
@@ -20,7 +21,7 @@ def kvstore_from_mocked_bucket() -> S3DBKVStore:
 
 
 @pytest.mark.skipif(not has_boto_libs, reason="boto3 and/or moto not installed")
-def test_put_get(kvstore_from_mocked_bucket: S3DBKVStore):
+def test_put_get(kvstore_from_mocked_bucket: S3DBKVStore) -> None:
     test_key = "test_key"
     test_blob = {"test_obj_key": "test_obj_val"}
     kvstore_from_mocked_bucket.put(test_key, test_blob)
@@ -29,14 +30,14 @@ def test_put_get(kvstore_from_mocked_bucket: S3DBKVStore):
 
 
 @pytest.mark.skipif(not has_boto_libs, reason="boto3 and/or moto not installed")
-def test_get_non_existent(kvstore_from_mocked_bucket: S3DBKVStore):
+def test_get_non_existent(kvstore_from_mocked_bucket: S3DBKVStore) -> None:
     test_key = "test_key"
     blob = kvstore_from_mocked_bucket.get(test_key)
     assert blob is None
 
 
 @pytest.mark.skipif(not has_boto_libs, reason="boto3 and/or moto not installed")
-def test_put_get_multiple_collections(kvstore_from_mocked_bucket: S3DBKVStore):
+def test_put_get_multiple_collections(kvstore_from_mocked_bucket: S3DBKVStore) -> None:
     test_key = "test_key"
     test_blob_collection_a = {"test_obj_key": "a"}
     test_blob_collection_b = {"test_obj_key": "b"}
@@ -57,7 +58,7 @@ def test_put_get_multiple_collections(kvstore_from_mocked_bucket: S3DBKVStore):
 
 
 @pytest.mark.skipif(not has_boto_libs, reason="boto3 and/or moto not installed")
-def test_delete(kvstore_from_mocked_bucket: S3DBKVStore):
+def test_delete(kvstore_from_mocked_bucket: S3DBKVStore) -> None:
     test_key = "test_key"
     test_blob = {"test_obj_key": "test_obj_val"}
     kvstore_from_mocked_bucket.put(test_key, test_blob)
@@ -67,7 +68,7 @@ def test_delete(kvstore_from_mocked_bucket: S3DBKVStore):
 
 
 @pytest.mark.skipif(not has_boto_libs, reason="boto3 and/or moto not installed")
-def test_delete_non_existent(kvstore_from_mocked_bucket: S3DBKVStore):
+def test_delete_non_existent(kvstore_from_mocked_bucket: S3DBKVStore) -> None:
     test_key = "test_key"
     test_blob = {"test_obj_key": "test_obj_val"}
     kvstore_from_mocked_bucket.put(test_key, test_blob)
@@ -75,7 +76,7 @@ def test_delete_non_existent(kvstore_from_mocked_bucket: S3DBKVStore):
 
 
 @pytest.mark.skipif(not has_boto_libs, reason="boto3 and/or moto not installed")
-def test_get_all(kvstore_from_mocked_bucket: S3DBKVStore):
+def test_get_all(kvstore_from_mocked_bucket: S3DBKVStore) -> None:
     test_key_a = "test_key_a"
     test_blob_a = {"test_obj_key": "test_obj_val_a"}
 

--- a/tests/storage/kvstore/test_s3_kvstore.py
+++ b/tests/storage/kvstore/test_s3_kvstore.py
@@ -1,0 +1,81 @@
+import pytest
+from llama_index.storage.kvstore.s3_kvstore import S3DBKVStore
+
+try:
+    import boto3
+    from moto import mock_s3
+
+    has_boto_libs = True
+except ImportError:
+    has_boto_libs = False
+
+
+@pytest.fixture()
+def kvstore_from_mocked_bucket() -> S3DBKVStore:
+    with mock_s3():
+        s3 = boto3.resource("s3")
+        bucket = s3.Bucket("test_bucket")
+        bucket.create()
+        yield S3DBKVStore(bucket)
+
+
+@pytest.mark.skipif(not has_boto_libs, reason="boto3 and/or moto not installed")
+def test_put_get(kvstore_from_mocked_bucket: S3DBKVStore):
+    test_key = "test_key"
+    test_blob = {"test_obj_key": "test_obj_val"}
+    kvstore_from_mocked_bucket.put(test_key, test_blob)
+    blob = kvstore_from_mocked_bucket.get(test_key)
+    assert blob == test_blob
+
+
+@pytest.mark.skipif(not has_boto_libs, reason="boto3 and/or moto not installed")
+def test_get_non_existent(kvstore_from_mocked_bucket: S3DBKVStore):
+    test_key = "test_key"
+    blob = kvstore_from_mocked_bucket.get(test_key)
+    assert blob is None
+
+
+@pytest.mark.skipif(not has_boto_libs, reason="boto3 and/or moto not installed")
+def test_put_get_multiple_collections(kvstore_from_mocked_bucket: S3DBKVStore):
+    test_key = "test_key"
+    test_blob_collection_a = {"test_obj_key": "a"}
+    test_blob_collection_b = {"test_obj_key": "b"}
+    kvstore_from_mocked_bucket.put(
+        test_key, test_blob_collection_a, collection="test_collection_a"
+    )
+    kvstore_from_mocked_bucket.put(
+        test_key, test_blob_collection_b, collection="test_collection_b"
+    )
+    blob_collection_a = kvstore_from_mocked_bucket.get(
+        test_key, collection="test_collection_a"
+    )
+    blob_collection_b = kvstore_from_mocked_bucket.get(
+        test_key, collection="test_collection_b"
+    )
+    assert test_blob_collection_a == blob_collection_a
+    assert test_blob_collection_b == blob_collection_b
+
+
+@pytest.mark.skipif(not has_boto_libs, reason="boto3 and/or moto not installed")
+def test_delete(kvstore_from_mocked_bucket: S3DBKVStore):
+    test_key = "test_key"
+    test_blob = {"test_obj_key": "test_obj_val"}
+    assert kvstore_from_mocked_bucket.delete(test_key) == False
+    kvstore_from_mocked_bucket.put(test_key, test_blob)
+    blob = kvstore_from_mocked_bucket.get(test_key)
+    assert blob == test_blob
+    assert kvstore_from_mocked_bucket.delete(test_key)
+
+
+@pytest.mark.skipif(not has_boto_libs, reason="boto3 and/or moto not installed")
+def test_get_all(kvstore_from_mocked_bucket: S3DBKVStore):
+    test_key_a = "test_key_a"
+    test_blob_a = {"test_obj_key": "test_obj_val_a"}
+
+    test_key_b = "test_key_b"
+    test_blob_b = {"test_obj_key": "test_obj_val_b"}
+    kvstore_from_mocked_bucket.put(test_key_a, test_blob_a)
+    kvstore_from_mocked_bucket.put(test_key_b, test_blob_b)
+    blobs = kvstore_from_mocked_bucket.get_all()
+
+    assert blobs == {test_key_a: test_blob_a, test_key_b: test_blob_b}

--- a/tests/storage/kvstore/test_s3_kvstore.py
+++ b/tests/storage/kvstore/test_s3_kvstore.py
@@ -60,11 +60,18 @@ def test_put_get_multiple_collections(kvstore_from_mocked_bucket: S3DBKVStore):
 def test_delete(kvstore_from_mocked_bucket: S3DBKVStore):
     test_key = "test_key"
     test_blob = {"test_obj_key": "test_obj_val"}
-    assert kvstore_from_mocked_bucket.delete(test_key) == False
     kvstore_from_mocked_bucket.put(test_key, test_blob)
     blob = kvstore_from_mocked_bucket.get(test_key)
     assert blob == test_blob
     assert kvstore_from_mocked_bucket.delete(test_key)
+
+
+@pytest.mark.skipif(not has_boto_libs, reason="boto3 and/or moto not installed")
+def test_delete_non_existent(kvstore_from_mocked_bucket: S3DBKVStore):
+    test_key = "test_key"
+    test_blob = {"test_obj_key": "test_obj_val"}
+    kvstore_from_mocked_bucket.put(test_key, test_blob)
+    assert kvstore_from_mocked_bucket.delete("wrong_key") == False
 
 
 @pytest.mark.skipif(not has_boto_libs, reason="boto3 and/or moto not installed")

--- a/tests/storage/kvstore/test_s3_kvstore.py
+++ b/tests/storage/kvstore/test_s3_kvstore.py
@@ -72,7 +72,7 @@ def test_delete_non_existent(kvstore_from_mocked_bucket: S3DBKVStore) -> None:
     test_key = "test_key"
     test_blob = {"test_obj_key": "test_obj_val"}
     kvstore_from_mocked_bucket.put(test_key, test_blob)
-    assert kvstore_from_mocked_bucket.delete("wrong_key") == False
+    assert kvstore_from_mocked_bucket.delete("wrong_key") is False
 
 
 @pytest.mark.skipif(not has_boto_libs, reason="boto3 and/or moto not installed")


### PR DESCRIPTION
Implementation of a S3-backed KV store for document/index persistence. Since S3 is a commonly used and easy-to-setup data storage layer, I thought this may be a useful addition the project.

I used [boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html) for the S3 interactions & am using [moto](https://docs.getmoto.org/en/latest/index.html) to mock those interactions in unit tests.

The current storage scheme is geared towards optimizing for `get()` of an individual key-value pair rather than `get_all()` for retrieving all key-value pairs within a collection.

The storage scheme stores all KV pairs within a specified S3 bucket and an optionally supplied subdirectory path within that bucket.

The KV pair data is separated into subfolders by `collection` name where each subfolder's name is the `collection` name.
Within a given `collection`s subfolder, you would find one JSON file for each individual KV pair. The `key` is stored as JSON files filename i.e. `{key}.json`. The contents of the JSON file is the serialized value dict.