### PR TITLE
Save index summary

### DIFF
--- a/llama_index/indices/base.py
+++ b/llama_index/indices/base.py
@@ -147,7 +147,7 @@ class BaseGPTIndex(Generic[IS], ABC):
         return str(self._index_struct.summary)
 
     @summary.setter
-    def summary(self, new_summary) -> None:
+    def summary(self, new_summary: str) -> None:
         self._index_struct.summary = new_summary
         self._storage_context.index_store.add_index_struct(self._index_struct)
 

--- a/llama_index/indices/base.py
+++ b/llama_index/indices/base.py
@@ -144,7 +144,7 @@ class BaseGPTIndex(Generic[IS], ABC):
 
     @property
     def summary(self) -> str:
-        return self._index_struct.summary
+        return str(self._index_struct.summary)
 
     @summary.setter
     def summary(self, new_summary) -> None:

--- a/llama_index/indices/base.py
+++ b/llama_index/indices/base.py
@@ -141,11 +141,11 @@ class BaseGPTIndex(Generic[IS], ABC):
     @property
     def storage_context(self) -> StorageContext:
         return self._storage_context
-    
+
     @property
     def summary(self) -> str:
         return self._index_struct.summary
-    
+
     @summary.setter
     def summary(self, new_summary) -> None:
         self._index_struct.summary = new_summary

--- a/llama_index/indices/base.py
+++ b/llama_index/indices/base.py
@@ -141,6 +141,15 @@ class BaseGPTIndex(Generic[IS], ABC):
     @property
     def storage_context(self) -> StorageContext:
         return self._storage_context
+    
+    @property
+    def summary(self) -> str:
+        return self._index_struct.summary
+    
+    @summary.setter
+    def summary(self, new_summary) -> None:
+        self._index_struct.summary = new_summary
+        self._storage_context.index_store.add_index_struct(self._index_struct)
 
     @abstractmethod
     def _build_index_from_nodes(self, nodes: Sequence[Node]) -> IS:


### PR DESCRIPTION
The summary of the index struct was not being properly persisted. People had been using this to store various things (tool descriptions, graph summaries, etc.)

This PR fixes that py adding a dedicated property for the summary 