### PR TITLE
[feature] Accumulator response builder

### DIFF
--- a/docs/guides/primer/usage_pattern.md
+++ b/docs/guides/primer/usage_pattern.md
@@ -330,13 +330,17 @@ query_engine = RetrieverQueryEngine.from_args(retriever, response_mode=<response
 
 Right now, we support the following options:
 - `default`: "create and refine" an answer by sequentially going through each retrieved `Node`; 
-    This make a separate LLM call per Node. Good for more detailed answers.
+    This makes a separate LLM call per Node. Good for more detailed answers.
 - `compact`: "compact" the prompt during each LLM call by stuffing as 
     many `Node` text chunks that can fit within the maximum prompt size. If there are 
     too many chunks to stuff in one prompt, "create and refine" an answer by going through
     multiple prompts.
 - `tree_summarize`: Given a set of `Node` objects and the query, recursively construct a tree 
     and return the root node as the response. Good for summarization purposes.
+- `accumulate`: Given a set of `Node` objects and the query, apply the query to each `Node` text
+    chunk while accumulating the responses into an array. Returns a concatenated string of all
+    responses. Good for when you need to run the same query separately against each text
+    chunk.
 
 ```python
 index = GPTListIndex.from_documents(documents)

--- a/llama_index/indices/response/type.py
+++ b/llama_index/indices/response/type.py
@@ -10,3 +10,4 @@ class ResponseMode(str, Enum):
     TREE_SUMMARIZE = "tree_summarize"
     GENERATION = "generation"
     NO_TEXT = "no_text"
+    ACCUMULATE = "accumulate"

--- a/tests/indices/response/test_response_builder.py
+++ b/tests/indices/response/test_response_builder.py
@@ -184,3 +184,57 @@ def test_accumulate_response(
         "Response 6: What is?:foo"
     )
     assert str(response) == expected
+
+
+def test_accumulate_response2(
+    mock_service_context: ServiceContext,
+    documents: List[Document],
+) -> None:
+    """Test accumulate response."""
+    # test response with ResponseMode.ACCUMULATE
+    # NOTE: here we want to guarante that prompts have 0 extra tokens
+    mock_qa_prompt_tmpl = "{context_str}{query_str}"
+    mock_qa_prompt = QuestionAnswerPrompt(mock_qa_prompt_tmpl)
+
+    # max input size is 11, prompt is two tokens (the query) --> 9 tokens
+    # --> padding is 1 --> 8 tokens
+    prompt_helper = PromptHelper(
+        11, 0, 0, tokenizer=mock_tokenizer, separator="\n\n", chunk_size_limit=4
+    )
+    service_context = mock_service_context
+    service_context.prompt_helper = prompt_helper
+    cur_chunk_size = prompt_helper.get_chunk_size_given_prompt("", 1, padding=1)
+    # outside of compact, assert that chunk size is 4
+    assert cur_chunk_size == 4
+
+    # within compact, make sure that chunk size is 8
+    query_str = "What is?"
+    texts = [
+        "This\nis\nbar",
+        "This\nis\nfoo",
+    ]
+    builder = get_response_builder(
+        service_context=service_context,
+        text_qa_template=mock_qa_prompt,
+        mode=ResponseMode.ACCUMULATE,
+    )
+
+    response = builder.get_response(
+        text_chunks=texts,
+        query_str=query_str,
+        separator="\nWHATEVER~~~~~~",
+    )
+    expected = (
+        "Response 1: What is?:This\n"
+        "WHATEVER~~~~~~"
+        "Response 2: What is?:is\n"
+        "WHATEVER~~~~~~"
+        "Response 3: What is?:bar\n"
+        "WHATEVER~~~~~~"
+        "Response 4: What is?:This\n"
+        "WHATEVER~~~~~~"
+        "Response 5: What is?:is\n"
+        "WHATEVER~~~~~~"
+        "Response 6: What is?:foo"
+    )
+    assert str(response) == expected

--- a/tests/indices/response/test_response_builder.py
+++ b/tests/indices/response/test_response_builder.py
@@ -1,5 +1,6 @@
 """Test response utils."""
 
+import asyncio
 from typing import List
 
 from llama_index.constants import MAX_CHUNK_OVERLAP, MAX_CHUNK_SIZE, NUM_OUTPUTS
@@ -186,7 +187,58 @@ def test_accumulate_response(
     assert str(response) == expected
 
 
-def test_accumulate_response2(
+def test_accumulate_response_async(
+    mock_service_context: ServiceContext,
+    documents: List[Document],
+) -> None:
+    """Test accumulate response."""
+    # test response with ResponseMode.ACCUMULATE
+    # NOTE: here we want to guarante that prompts have 0 extra tokens
+    mock_qa_prompt_tmpl = "{context_str}{query_str}"
+    mock_qa_prompt = QuestionAnswerPrompt(mock_qa_prompt_tmpl)
+
+    # max input size is 11, prompt is two tokens (the query) --> 9 tokens
+    # --> padding is 1 --> 8 tokens
+    prompt_helper = PromptHelper(
+        11, 0, 0, tokenizer=mock_tokenizer, separator="\n\n", chunk_size_limit=4
+    )
+    service_context = mock_service_context
+    service_context.prompt_helper = prompt_helper
+    cur_chunk_size = prompt_helper.get_chunk_size_given_prompt("", 1, padding=1)
+    # outside of compact, assert that chunk size is 4
+    assert cur_chunk_size == 4
+
+    # within compact, make sure that chunk size is 8
+    query_str = "What is?"
+    texts = [
+        "This\nis\nbar",
+        "This\nis\nfoo",
+    ]
+    builder = get_response_builder(
+        service_context=service_context,
+        text_qa_template=mock_qa_prompt,
+        mode=ResponseMode.ACCUMULATE,
+        use_async=True,
+    )
+
+    response = builder.get_response(text_chunks=texts, query_str=query_str)
+    expected = (
+        "Response 1: What is?:This\n"
+        "---------------------\n"
+        "Response 2: What is?:is\n"
+        "---------------------\n"
+        "Response 3: What is?:bar\n"
+        "---------------------\n"
+        "Response 4: What is?:This\n"
+        "---------------------\n"
+        "Response 5: What is?:is\n"
+        "---------------------\n"
+        "Response 6: What is?:foo"
+    )
+    assert str(response) == expected
+
+
+def test_accumulate_response_aget(
     mock_service_context: ServiceContext,
     documents: List[Document],
 ) -> None:
@@ -219,22 +271,24 @@ def test_accumulate_response2(
         mode=ResponseMode.ACCUMULATE,
     )
 
-    response = builder.get_response(
-        text_chunks=texts,
-        query_str=query_str,
-        separator="\nWHATEVER~~~~~~",
+    response = asyncio.run(
+        builder.aget_response(
+            text_chunks=texts,
+            query_str=query_str,
+            separator="\nWHATEVER~~~~~~\n",
+        )
     )
     expected = (
         "Response 1: What is?:This\n"
-        "WHATEVER~~~~~~"
+        "WHATEVER~~~~~~\n"
         "Response 2: What is?:is\n"
-        "WHATEVER~~~~~~"
+        "WHATEVER~~~~~~\n"
         "Response 3: What is?:bar\n"
-        "WHATEVER~~~~~~"
+        "WHATEVER~~~~~~\n"
         "Response 4: What is?:This\n"
-        "WHATEVER~~~~~~"
+        "WHATEVER~~~~~~\n"
         "Response 5: What is?:is\n"
-        "WHATEVER~~~~~~"
+        "WHATEVER~~~~~~\n"
         "Response 6: What is?:foo"
     )
     assert str(response) == expected

--- a/tests/indices/response/test_response_builder.py
+++ b/tests/indices/response/test_response_builder.py
@@ -134,3 +134,53 @@ def test_tree_summarize_response(mock_service_context: ServiceContext) -> None:
     )
     # TODO: fix this output, the \n join appends unnecessary results at the end
     assert str(response) == "What is?:This:is:a:bar:This:is:another:test"
+
+
+def test_accumulate_response(
+    mock_service_context: ServiceContext,
+    documents: List[Document],
+) -> None:
+    """Test accumulate response."""
+    # test response with ResponseMode.ACCUMULATE
+    # NOTE: here we want to guarante that prompts have 0 extra tokens
+    mock_qa_prompt_tmpl = "{context_str}{query_str}"
+    mock_qa_prompt = QuestionAnswerPrompt(mock_qa_prompt_tmpl)
+
+    # max input size is 11, prompt is two tokens (the query) --> 9 tokens
+    # --> padding is 1 --> 8 tokens
+    prompt_helper = PromptHelper(
+        11, 0, 0, tokenizer=mock_tokenizer, separator="\n\n", chunk_size_limit=4
+    )
+    service_context = mock_service_context
+    service_context.prompt_helper = prompt_helper
+    cur_chunk_size = prompt_helper.get_chunk_size_given_prompt("", 1, padding=1)
+    # outside of compact, assert that chunk size is 4
+    assert cur_chunk_size == 4
+
+    # within compact, make sure that chunk size is 8
+    query_str = "What is?"
+    texts = [
+        "This\nis\nbar",
+        "This\nis\nfoo",
+    ]
+    builder = get_response_builder(
+        service_context=service_context,
+        text_qa_template=mock_qa_prompt,
+        mode=ResponseMode.ACCUMULATE,
+    )
+
+    response = builder.get_response(text_chunks=texts, query_str=query_str)
+    expected = (
+        "Response 1: What is?:This\n"
+        "---------------------\n"
+        "Response 2: What is?:is\n"
+        "---------------------\n"
+        "Response 3: What is?:bar\n"
+        "---------------------\n"
+        "Response 4: What is?:This\n"
+        "---------------------\n"
+        "Response 5: What is?:is\n"
+        "---------------------\n"
+        "Response 6: What is?:foo"
+    )
+    assert str(response) == expected


### PR DESCRIPTION
The current response builders don't offer a way to accumulate new responses from each chunk of text. Refine, for example, is meant for iterating over chunks and modifying the answer with each iteration until you end up with 1 answer. Being able to accumulate responses allows people (like me) to use a prompt like "Summarize this text" and generate multiple summaries, 1 for each chunk.

Example:
```
query_engine = RetrieverQueryEngine.from_args(
    retriever=retriever,
    service_context=service_context,
    node_postprocessors=[
        SimilarityPostprocessor(similarity_cutoff=0.7)
    ],
    text_qa_template=QA_PROMPT,
    response_mode='accumulate'
)
```

**NOTE:** This response builder does not work for streaming (and will fail with an error saying so if you try). In order to get streaming working, I think we'd have to make it possible for `get_response` to return an array of generators which would probably break other consumers? Happy to discuss solutions though.