### PR TITLE
Updated Azure OpenAI Example

### DIFF
--- a/docs/examples/customization/llms/AzureOpenAI.ipynb
+++ b/docs/examples/customization/llms/AzureOpenAI.ipynb
@@ -10,6 +10,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "id": "ef3d26db",
             "metadata": {},
@@ -47,6 +48,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "id": "80a962f8",
             "metadata": {},
@@ -69,6 +71,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "id": "fcaaafdf",
             "metadata": {},
@@ -91,10 +94,11 @@
                 "})\n",
                 "llm_predictor = LLMPredictor(llm=llm)\n",
                 "\n",
+                "# You need to deploy your own embedding model as well as your own chat completion model\n",
                 "embedding_llm = LangchainEmbedding(\n",
                 "    OpenAIEmbeddings(\n",
                 "        model=\"text-embedding-ada-002\",\n",
-                "        deployment=\"text-embedding-ada-002\",\n",
+                "        deployment=\"<insert EMBEDDING model deployment name from azure>\",\n",
                 "        openai_api_key= openai.api_key,\n",
                 "        openai_api_base=openai.api_base,\n",
                 "        openai_api_type=openai.api_type,\n",


### PR DESCRIPTION
I was unable to get the Azure OpenAI example in the your [example notebook](https://github.com/jerryjliu/llama_index/blob/main/docs/examples/customization/llms/AzureOpenAI.ipynb) to work. Perhaps I'm missing a way to use the public OpenAI encoder instead of a private instance of it, but, two observations:

1) I think you *have* to deploy your own and then reference the deployment when you create the OpenAIEmbeddings instance (see my changes). 
2) Even if you it's possible to use the public embedding with a private model instance, I'd suggest we at least modify the docs to show someone how to call their own embeddings model. 

I've updated the example to show how to use an Azure-hosted embeddings deployment. FWIW, this is the same solution [suggested in the langchain repo](https://github.com/hwchase17/langchain/issues/1560#issuecomment-1541703342).
