### PR TITLE
Constrain search of simple vector index

### DIFF
--- a/llama_index/indices/vector_store/base.py
+++ b/llama_index/indices/vector_store/base.py
@@ -57,7 +57,9 @@ class GPTVectorStoreIndex(BaseGPTIndex[IndexDict]):
         # NOTE: lazy import
         from llama_index.indices.vector_store.retrievers import VectorIndexRetriever
 
-        return VectorIndexRetriever(self, **kwargs)
+        return VectorIndexRetriever(
+            self, doc_ids=list(self.index_struct.doc_id_dict.keys()), **kwargs
+        )
 
     def _get_node_embedding_results(
         self, nodes: Sequence[Node]

--- a/llama_index/indices/vector_store/base.py
+++ b/llama_index/indices/vector_store/base.py
@@ -58,7 +58,7 @@ class GPTVectorStoreIndex(BaseGPTIndex[IndexDict]):
         from llama_index.indices.vector_store.retrievers import VectorIndexRetriever
 
         return VectorIndexRetriever(
-            self, doc_ids=list(self.index_struct.doc_id_dict.keys()), **kwargs
+            self, doc_ids=list(self.index_struct.nodes_dict.values()), **kwargs
         )
 
     def _get_node_embedding_results(

--- a/llama_index/vector_stores/simple.py
+++ b/llama_index/vector_stores/simple.py
@@ -122,8 +122,15 @@ class SimpleVectorStore(VectorStore):
 
         # TODO: consolidate with get_query_text_embedding_similarities
         items = self._data.embedding_dict.items()
-        node_ids = [t[0] for t in items]
-        embeddings = [t[1] for t in items]
+
+        if query.doc_ids:
+            available_ids = set(query.doc_ids)
+
+            node_ids = [t[0] for t in items if t[0] in available_ids]
+            embeddings = [t[1] for t in items if t[0] in available_ids]
+        else:
+            node_ids = [t[0] for t in items]
+            embeddings = [t[1] for t in items]
 
         query_embedding = cast(List[float], query.query_embedding)
 

--- a/tests/indices/test_loading_graph.py
+++ b/tests/indices/test_loading_graph.py
@@ -19,7 +19,14 @@ def test_load_graph_from_storage_simple(
     storage_context = StorageContext.from_defaults()
 
     # construct index
-    vector_index = GPTVectorStoreIndex.from_documents(
+    vector_index_1 = GPTVectorStoreIndex.from_documents(
+        documents=documents,
+        storage_context=storage_context,
+        service_context=mock_service_context,
+    )
+
+    # construct second index, testing vector store overlap
+    vector_index_2 = GPTVectorStoreIndex.from_documents(
         documents=documents,
         storage_context=storage_context,
         service_context=mock_service_context,
@@ -35,8 +42,8 @@ def test_load_graph_from_storage_simple(
     # construct graph
     graph = ComposableGraph.from_indices(
         GPTListIndex,
-        children_indices=[vector_index, list_index],
-        index_summaries=["vector index", "list index"],
+        children_indices=[vector_index_1, vector_index_2, list_index],
+        index_summaries=["vector index 1", "vector index 2", "list index"],
         storage_context=storage_context,
         service_context=mock_service_context,
     )


### PR DESCRIPTION
This PR fixes saving multiple SimpleVectorStore objects to the same index.

This solves two use cases:
1. Saving/loading graphs with multiple vector indexes
2. Persisting multiple vector indexes to the same directory

Having a dependency between the vector store and index struct is not great, but this was the cleanest implementation I've had so far. The index struct already keeps of the "namespace" of each simple vector index, so we can leverage that here.