### PR TITLE
Add DynamoDB Store

### DIFF
--- a/data_requirements.txt
+++ b/data_requirements.txt
@@ -5,7 +5,7 @@ pymongo
 slack_sdk
 discord.py
 boto3
-moto[s3]
+moto[s3,dynamodb]
 
 # google
 google-api-python-client

--- a/examples/docstore/DynamoDBDocstoreDemo.ipynb
+++ b/examples/docstore/DynamoDBDocstoreDemo.ipynb
@@ -2,10 +2,9 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "a54d1c43-4b7f-4917-939f-a964f6f3dafc",
    "metadata": {
-    "scrolled": true,
     "tags": []
    },
    "outputs": [],
@@ -16,10 +15,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "fa67fa07-1395-4aab-a356-72bdb302f6b2",
    "metadata": {
-    "scrolled": true,
     "tags": []
    },
    "outputs": [],
@@ -34,10 +32,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "1d12d766-3ca8-4012-9da2-248be80bb6ab",
    "metadata": {
-    "scrolled": true,
     "tags": []
    },
    "outputs": [],
@@ -59,10 +56,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "e7cdaf9d-cfbd-4ced-8d4e-6eef8508224d",
    "metadata": {
-    "scrolled": true,
     "tags": []
    },
    "outputs": [],
@@ -81,10 +77,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "f97e558a-c29f-44ec-ab33-1f481da1a6ef",
    "metadata": {
-    "scrolled": true,
     "tags": []
    },
    "outputs": [],
@@ -104,46 +99,46 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1514211c",
+   "id": "f9998976",
    "metadata": {},
    "outputs": [],
    "source": [
-    "MONGO_URI = os.environ['MONGO_URI']"
+    "TABLE_NAME = os.environ[\"DYNAMODB_TABLE_NAME\"]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "54b9bd36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.storage.docstore.dynamodb_docstore import DynamoDBDocumentStore\n",
+    "from llama_index.storage.index_store.dynamodb_index_store import DynamoDBIndexStore"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
    "id": "1ba8b0da-67a8-4653-8cdb-09e39583a2d8",
    "metadata": {
-    "scrolled": true,
     "tags": []
    },
    "outputs": [],
    "source": [
-    "from llama_index.storage.docstore import MongoDocumentStore\n",
-    "from llama_index.storage.index_store.mongo_index_store import MongoIndexStore"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "60e781d1",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n",
     "storage_context = StorageContext.from_defaults(\n",
-    "    docstore=MongoDocumentStore.from_uri(uri=MONGO_URI),\n",
-    "    index_store=MongoIndexStore.from_uri(uri=MONGO_URI),\n",
+    "    docstore=DynamoDBDocumentStore.from_table_name(table_name=TABLE_NAME),\n",
+    "    index_store=DynamoDBIndexStore.from_table_name(table_name=TABLE_NAME)\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e0b18789",
-   "metadata": {},
+   "id": "e88378b2",
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "storage_context.docstore.add_documents(nodes)"
@@ -164,7 +159,6 @@
    "execution_count": null,
    "id": "316fb6ac-2031-4d17-9999-ffdb827f46d1",
    "metadata": {
-    "scrolled": true,
     "tags": []
    },
    "outputs": [],
@@ -175,9 +169,8 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9440f405-fa75-4788-bc7c-11d021a0a17b",
+   "id": "5c6b2141-fc77-4dec-891b-d4dad0633b35",
    "metadata": {
-    "scrolled": true,
     "tags": []
    },
    "outputs": [],
@@ -188,10 +181,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "364ef89f-4ba2-4b1a-b5e5-619e0e8420ef",
+   "id": "144bc7eb",
    "metadata": {
-    "scrolled": true,
-    "tags": []
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -201,10 +193,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5c6b2141-fc77-4dec-891b-d4dad0633b35",
+   "id": "4ccbe86c",
    "metadata": {
-    "scrolled": true,
-    "tags": []
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -214,8 +205,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "365a025b",
-   "metadata": {},
+   "id": "1059ec3c",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "#### Test out saving and loading"
    ]
@@ -223,20 +216,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1b359a08",
-   "metadata": {},
+   "id": "d0f258d6",
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
-    "# NOTE: docstore and index_store is persisted in MongoDB by default\n",
-    "# NOTE: here only need to persist simple vector store to disk\n",
+    "# NOTE: docstore and index_store is persisted in DynamoDB by default\n",
+    "# NOTE: here only need to persist simple vector store to dick\n",
     "storage_context.persist()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84b3d2f4",
-   "metadata": {},
+   "id": "9155c1a9",
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# note down index IDs\n",
@@ -248,28 +245,31 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1593ca1d",
-   "metadata": {},
+   "id": "555de7fa",
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "from llama_index.indices.loading import load_index_from_storage\n",
     "\n",
     "# re-create storage context\n",
     "storage_context = StorageContext.from_defaults(\n",
-    "    docstore=MongoDocumentStore.from_uri(uri=MONGO_URI),\n",
-    "    index_store=MongoIndexStore.from_uri(uri=MONGO_URI),\n",
+    "    docstore=DynamoDBDocumentStore.from_table_name(table_name=TABLE_NAME),\n",
+    "    index_store=DynamoDBIndexStore.from_table_name(table_name=TABLE_NAME),\n",
     ")\n",
     "\n",
-    "# load indices\n",
     "list_index = load_index_from_storage(storage_context=storage_context, index_id=list_id)\n",
-    "vector_index = load_index_from_storage(storage_context=storage_context, vector_id=vector_id)\n",
-    "keyword_table_index = load_index_from_storage(storage_context=storage_context, keyword_id=keyword_id)"
+    "vector_index = load_index_from_storage(storage_context=storage_context, index_id=vector_id)\n",
+    "keyword_table_index = load_index_from_storage(storage_context=storage_context, index_id=keyword_id)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "d3bf6aaf-3375-4212-8323-777969a918f7",
-   "metadata": {},
+   "id": "c5bc40a7",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "#### Test out some Queries"
    ]
@@ -277,10 +277,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9bba68f3-2743-437e-93b6-ce9ba92e40c3",
+   "id": "8db82de3",
    "metadata": {
-    "scrolled": true,
-    "tags": []
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -291,9 +290,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "544c0565-72a0-434b-98e5-83138ebdaa2b",
+   "id": "244bc6ae",
    "metadata": {
-    "scrolled": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -304,9 +303,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39d250be",
+   "id": "6cbe77ef",
    "metadata": {
-    "scrolled": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -316,9 +315,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "036077b7-108e-4026-9628-44c694343460",
+   "id": "02b800ab",
    "metadata": {
-    "scrolled": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -329,8 +328,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42229e09",
-   "metadata": {},
+   "id": "70b63767",
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "display_response(vector_response)"
@@ -339,10 +340,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ecd7719c-f663-4edb-a239-d2a8f0a5c091",
+   "id": "b93478b6",
    "metadata": {
-    "scrolled": true,
-    "tags": []
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -353,32 +353,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37524641-2632-4a76-8ae6-00f1285256d9",
+   "id": "8044da9c",
    "metadata": {
-    "scrolled": true,
-    "tags": []
+    "collapsed": false
    },
    "outputs": [],
    "source": [
     "display_response(keyword_response)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ff58018c-3117-4d50-abff-16a1873eda9c",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "llama_index",
    "language": "python",
-   "name": "python3"
+   "name": "llama_index"
   },
   "language_info": {
    "codemirror_mode": {
@@ -390,7 +379,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,

--- a/examples/docstore/DynamoDBDocstoreDemo.ipynb
+++ b/examples/docstore/DynamoDBDocstoreDemo.ipynb
@@ -1,387 +1,387 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "a54d1c43-4b7f-4917-939f-a964f6f3dafc",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "import nest_asyncio\n",
-    "nest_asyncio.apply()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "fa67fa07-1395-4aab-a356-72bdb302f6b2",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "import logging\n",
-    "import sys\n",
-    "import os\n",
-    "\n",
-    "logging.basicConfig(stream=sys.stdout, level=logging.INFO)\n",
-    "logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "1d12d766-3ca8-4012-9da2-248be80bb6ab",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "from llama_index import SimpleDirectoryReader, ServiceContext, LLMPredictor, StorageContext\n",
-    "from llama_index import GPTVectorStoreIndex, GPTListIndex, GPTSimpleKeywordTableIndex\n",
-    "from llama_index.composability import ComposableGraph\n",
-    "from langchain.chat_models import ChatOpenAI\n",
-    "from llama_index.response.notebook_utils import display_response"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f6dd9d5f-a601-4097-894e-fe98a0c35a5b",
-   "metadata": {},
-   "source": [
-    "#### Load Documents"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "e7cdaf9d-cfbd-4ced-8d4e-6eef8508224d",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "reader = SimpleDirectoryReader('../paul_graham_essay/data')\n",
-    "documents = reader.load_data()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "bae82b55-5c9f-432a-9e06-1fccb6f9fc7f",
-   "metadata": {},
-   "source": [
-    "#### Parse into Nodes"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "f97e558a-c29f-44ec-ab33-1f481da1a6ef",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "from llama_index.node_parser import SimpleNodeParser\n",
-    "nodes = SimpleNodeParser().get_nodes_from_documents(documents)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "aff4c8e1-b2ba-4ea6-a8df-978c2788fedc",
-   "metadata": {},
-   "source": [
-    "#### Add to Docstore"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f9998976",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "TABLE_NAME = os.environ[\"DYNAMODB_TABLE_NAME\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "54b9bd36",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from llama_index.storage.docstore.dynamodb_docstore import DynamoDBDocumentStore\n",
-    "from llama_index.storage.index_store.dynamodb_index_store import DynamoDBIndexStore"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "1ba8b0da-67a8-4653-8cdb-09e39583a2d8",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "storage_context = StorageContext.from_defaults(\n",
-    "    docstore=DynamoDBDocumentStore.from_table_name(table_name=TABLE_NAME),\n",
-    "    index_store=DynamoDBIndexStore.from_table_name(table_name=TABLE_NAME)\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e88378b2",
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "storage_context.docstore.add_documents(nodes)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "528149c1-5bde-4eba-b75a-e8fa1da17d7c",
-   "metadata": {},
-   "source": [
-    "#### Define Multiple Indexes\n",
-    "\n",
-    "Each index uses the same underlying Node."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "316fb6ac-2031-4d17-9999-ffdb827f46d1",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "list_index = GPTListIndex(nodes, storage_context=storage_context)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5c6b2141-fc77-4dec-891b-d4dad0633b35",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "vector_index = GPTVectorStoreIndex(nodes, storage_context=storage_context)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "144bc7eb",
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "keyword_table_index = GPTSimpleKeywordTableIndex(nodes, storage_context=storage_context)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4ccbe86c",
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "# NOTE: the docstore still has the same nodes\n",
-    "len(storage_context.docstore.docs)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1059ec3c",
-   "metadata": {
-    "collapsed": false
-   },
-   "source": [
-    "#### Test out saving and loading"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d0f258d6",
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "# NOTE: docstore and index_store is persisted in DynamoDB by default\n",
-    "# NOTE: here only need to persist simple vector store to dick\n",
-    "storage_context.persist()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9155c1a9",
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "# note down index IDs\n",
-    "list_id = list_index.index_id\n",
-    "vector_id = vector_index.index_id\n",
-    "keyword_id = keyword_table_index.index_id"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "555de7fa",
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "from llama_index.indices.loading import load_index_from_storage\n",
-    "\n",
-    "# re-create storage context\n",
-    "storage_context = StorageContext.from_defaults(\n",
-    "    docstore=DynamoDBDocumentStore.from_table_name(table_name=TABLE_NAME),\n",
-    "    index_store=DynamoDBIndexStore.from_table_name(table_name=TABLE_NAME),\n",
-    ")\n",
-    "\n",
-    "list_index = load_index_from_storage(storage_context=storage_context, index_id=list_id)\n",
-    "vector_index = load_index_from_storage(storage_context=storage_context, index_id=vector_id)\n",
-    "keyword_table_index = load_index_from_storage(storage_context=storage_context, index_id=keyword_id)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c5bc40a7",
-   "metadata": {
-    "collapsed": false
-   },
-   "source": [
-    "#### Test out some Queries"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8db82de3",
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "llm_predictor_chatgpt = LLMPredictor(llm=ChatOpenAI(temperature=0, model_name=\"gpt-3.5-turbo\"))\n",
-    "service_context_chatgpt = ServiceContext.from_defaults(llm_predictor=llm_predictor_chatgpt, chunk_size_limit=1024)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "244bc6ae",
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "query_engine = list_index.as_query_engine()\n",
-    "list_response = query_engine.query(\"What is a summary of this document?\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6cbe77ef",
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "display_response(list_response)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "02b800ab",
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "query_engine = vector_index.as_query_engine()\n",
-    "vector_response = query_engine.query(\"What did the author do growing up?\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "70b63767",
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "display_response(vector_response)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b93478b6",
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "query_engine = keyword_table_index.as_query_engine()\n",
-    "keyword_response = query_engine.query(\"What did the author do after his time at YC?\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8044da9c",
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "display_response(keyword_response)"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "llama_index",
-   "language": "python",
-   "name": "llama_index"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.10"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+    "cells": [
+        {
+            "cell_type": "code",
+            "execution_count": 1,
+            "id": "a54d1c43-4b7f-4917-939f-a964f6f3dafc",
+            "metadata": {
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "import nest_asyncio\n",
+                "nest_asyncio.apply()"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 2,
+            "id": "fa67fa07-1395-4aab-a356-72bdb302f6b2",
+            "metadata": {
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "import logging\n",
+                "import sys\n",
+                "import os\n",
+                "\n",
+                "logging.basicConfig(stream=sys.stdout, level=logging.INFO)\n",
+                "logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 4,
+            "id": "1d12d766-3ca8-4012-9da2-248be80bb6ab",
+            "metadata": {
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "from llama_index import SimpleDirectoryReader, ServiceContext, LLMPredictor, StorageContext\n",
+                "from llama_index import GPTVectorStoreIndex, GPTListIndex, GPTSimpleKeywordTableIndex\n",
+                "from llama_index.composability import ComposableGraph\n",
+                "from langchain.chat_models import ChatOpenAI\n",
+                "from llama_index.response.notebook_utils import display_response"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "f6dd9d5f-a601-4097-894e-fe98a0c35a5b",
+            "metadata": {},
+            "source": [
+                "#### Load Documents"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 5,
+            "id": "e7cdaf9d-cfbd-4ced-8d4e-6eef8508224d",
+            "metadata": {
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "reader = SimpleDirectoryReader('../paul_graham_essay/data')\n",
+                "documents = reader.load_data()"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "bae82b55-5c9f-432a-9e06-1fccb6f9fc7f",
+            "metadata": {},
+            "source": [
+                "#### Parse into Nodes"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 6,
+            "id": "f97e558a-c29f-44ec-ab33-1f481da1a6ef",
+            "metadata": {
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "from llama_index.node_parser import SimpleNodeParser\n",
+                "nodes = SimpleNodeParser().get_nodes_from_documents(documents)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "aff4c8e1-b2ba-4ea6-a8df-978c2788fedc",
+            "metadata": {},
+            "source": [
+                "#### Add to Docstore"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "f9998976",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "TABLE_NAME = os.environ[\"DYNAMODB_TABLE_NAME\"]"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "54b9bd36",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "from llama_index.storage.docstore.dynamodb_docstore import DynamoDBDocumentStore\n",
+                "from llama_index.storage.index_store.dynamodb_index_store import DynamoDBIndexStore"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 7,
+            "id": "1ba8b0da-67a8-4653-8cdb-09e39583a2d8",
+            "metadata": {
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "storage_context = StorageContext.from_defaults(\n",
+                "    docstore=DynamoDBDocumentStore.from_table_name(table_name=TABLE_NAME),\n",
+                "    index_store=DynamoDBIndexStore.from_table_name(table_name=TABLE_NAME)\n",
+                ")"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "e88378b2",
+            "metadata": {
+                "collapsed": false
+            },
+            "outputs": [],
+            "source": [
+                "storage_context.docstore.add_documents(nodes)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "528149c1-5bde-4eba-b75a-e8fa1da17d7c",
+            "metadata": {},
+            "source": [
+                "#### Define Multiple Indexes\n",
+                "\n",
+                "Each index uses the same underlying Node."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "316fb6ac-2031-4d17-9999-ffdb827f46d1",
+            "metadata": {
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "list_index = GPTListIndex(nodes, storage_context=storage_context)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "5c6b2141-fc77-4dec-891b-d4dad0633b35",
+            "metadata": {
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "vector_index = GPTVectorStoreIndex(nodes, storage_context=storage_context)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "144bc7eb",
+            "metadata": {
+                "collapsed": false
+            },
+            "outputs": [],
+            "source": [
+                "keyword_table_index = GPTSimpleKeywordTableIndex(nodes, storage_context=storage_context)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "4ccbe86c",
+            "metadata": {
+                "collapsed": false
+            },
+            "outputs": [],
+            "source": [
+                "# NOTE: the docstore still has the same nodes\n",
+                "len(storage_context.docstore.docs)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "1059ec3c",
+            "metadata": {
+                "collapsed": false
+            },
+            "source": [
+                "#### Test out saving and loading"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "d0f258d6",
+            "metadata": {
+                "collapsed": false
+            },
+            "outputs": [],
+            "source": [
+                "# NOTE: docstore and index_store is persisted in DynamoDB by default\n",
+                "# NOTE: here only need to persist simple vector store to dick\n",
+                "storage_context.persist()"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "9155c1a9",
+            "metadata": {
+                "collapsed": false
+            },
+            "outputs": [],
+            "source": [
+                "# note down index IDs\n",
+                "list_id = list_index.index_id\n",
+                "vector_id = vector_index.index_id\n",
+                "keyword_id = keyword_table_index.index_id"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "555de7fa",
+            "metadata": {
+                "collapsed": false
+            },
+            "outputs": [],
+            "source": [
+                "from llama_index.indices.loading import load_index_from_storage\n",
+                "\n",
+                "# re-create storage context\n",
+                "storage_context = StorageContext.from_defaults(\n",
+                "    docstore=DynamoDBDocumentStore.from_table_name(table_name=TABLE_NAME),\n",
+                "    index_store=DynamoDBIndexStore.from_table_name(table_name=TABLE_NAME),\n",
+                ")\n",
+                "\n",
+                "list_index = load_index_from_storage(storage_context=storage_context, index_id=list_id)\n",
+                "vector_index = load_index_from_storage(storage_context=storage_context, index_id=vector_id)\n",
+                "keyword_table_index = load_index_from_storage(storage_context=storage_context, index_id=keyword_id)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "c5bc40a7",
+            "metadata": {
+                "collapsed": false
+            },
+            "source": [
+                "#### Test out some Queries"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "8db82de3",
+            "metadata": {
+                "collapsed": false
+            },
+            "outputs": [],
+            "source": [
+                "llm_predictor_chatgpt = LLMPredictor(llm=ChatOpenAI(temperature=0, model_name=\"gpt-3.5-turbo\"))\n",
+                "service_context_chatgpt = ServiceContext.from_defaults(llm_predictor=llm_predictor_chatgpt, chunk_size_limit=1024)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "244bc6ae",
+            "metadata": {
+                "collapsed": false
+            },
+            "outputs": [],
+            "source": [
+                "query_engine = list_index.as_query_engine()\n",
+                "list_response = query_engine.query(\"What is a summary of this document?\")"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "6cbe77ef",
+            "metadata": {
+                "collapsed": false
+            },
+            "outputs": [],
+            "source": [
+                "display_response(list_response)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "02b800ab",
+            "metadata": {
+                "collapsed": false
+            },
+            "outputs": [],
+            "source": [
+                "query_engine = vector_index.as_query_engine()\n",
+                "vector_response = query_engine.query(\"What did the author do growing up?\")"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "70b63767",
+            "metadata": {
+                "collapsed": false
+            },
+            "outputs": [],
+            "source": [
+                "display_response(vector_response)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "b93478b6",
+            "metadata": {
+                "collapsed": false
+            },
+            "outputs": [],
+            "source": [
+                "query_engine = keyword_table_index.as_query_engine()\n",
+                "keyword_response = query_engine.query(\"What did the author do after his time at YC?\")"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "8044da9c",
+            "metadata": {
+                "collapsed": false
+            },
+            "outputs": [],
+            "source": [
+                "display_response(keyword_response)"
+            ]
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "llama_index",
+            "language": "python",
+            "name": "llama_index"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.10.10"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 5
 }

--- a/examples/docstore/MongoDocstoreDemo.ipynb
+++ b/examples/docstore/MongoDocstoreDemo.ipynb
@@ -1,398 +1,398 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a54d1c43-4b7f-4917-939f-a964f6f3dafc",
-   "metadata": {
-    "scrolled": true,
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "import nest_asyncio\n",
-    "nest_asyncio.apply()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fa67fa07-1395-4aab-a356-72bdb302f6b2",
-   "metadata": {
-    "scrolled": true,
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "import logging\n",
-    "import sys\n",
-    "import os\n",
-    "\n",
-    "logging.basicConfig(stream=sys.stdout, level=logging.INFO)\n",
-    "logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1d12d766-3ca8-4012-9da2-248be80bb6ab",
-   "metadata": {
-    "scrolled": true,
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "from llama_index import SimpleDirectoryReader, ServiceContext, LLMPredictor, StorageContext\n",
-    "from llama_index import GPTVectorStoreIndex, GPTListIndex, GPTSimpleKeywordTableIndex\n",
-    "from llama_index.composability import ComposableGraph\n",
-    "from langchain.chat_models import ChatOpenAI\n",
-    "from llama_index.response.notebook_utils import display_response"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f6dd9d5f-a601-4097-894e-fe98a0c35a5b",
-   "metadata": {},
-   "source": [
-    "#### Load Documents"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e7cdaf9d-cfbd-4ced-8d4e-6eef8508224d",
-   "metadata": {
-    "scrolled": true,
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "reader = SimpleDirectoryReader('../paul_graham_essay/data')\n",
-    "documents = reader.load_data()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "bae82b55-5c9f-432a-9e06-1fccb6f9fc7f",
-   "metadata": {},
-   "source": [
-    "#### Parse into Nodes"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f97e558a-c29f-44ec-ab33-1f481da1a6ef",
-   "metadata": {
-    "scrolled": true,
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "from llama_index.node_parser import SimpleNodeParser\n",
-    "nodes = SimpleNodeParser().get_nodes_from_documents(documents)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "aff4c8e1-b2ba-4ea6-a8df-978c2788fedc",
-   "metadata": {},
-   "source": [
-    "#### Add to Docstore"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1514211c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "MONGO_URI = os.environ['MONGO_URI']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1ba8b0da-67a8-4653-8cdb-09e39583a2d8",
-   "metadata": {
-    "scrolled": true,
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "from llama_index.storage.docstore import MongoDocumentStore\n",
-    "from llama_index.storage.index_store.mongo_index_store import MongoIndexStore"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "60e781d1",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n",
-    "storage_context = StorageContext.from_defaults(\n",
-    "    docstore=MongoDocumentStore.from_uri(uri=MONGO_URI),\n",
-    "    index_store=MongoIndexStore.from_uri(uri=MONGO_URI),\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e0b18789",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "storage_context.docstore.add_documents(nodes)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "528149c1-5bde-4eba-b75a-e8fa1da17d7c",
-   "metadata": {},
-   "source": [
-    "#### Define Multiple Indexes\n",
-    "\n",
-    "Each index uses the same underlying Node."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "316fb6ac-2031-4d17-9999-ffdb827f46d1",
-   "metadata": {
-    "scrolled": true,
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "list_index = GPTListIndex(nodes, storage_context=storage_context)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9440f405-fa75-4788-bc7c-11d021a0a17b",
-   "metadata": {
-    "scrolled": true,
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "vector_index = GPTVectorStoreIndex(nodes, storage_context=storage_context)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "364ef89f-4ba2-4b1a-b5e5-619e0e8420ef",
-   "metadata": {
-    "scrolled": true,
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "keyword_table_index = GPTSimpleKeywordTableIndex(nodes, storage_context=storage_context)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5c6b2141-fc77-4dec-891b-d4dad0633b35",
-   "metadata": {
-    "scrolled": true,
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# NOTE: the docstore still has the same nodes\n",
-    "len(storage_context.docstore.docs)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "365a025b",
-   "metadata": {},
-   "source": [
-    "#### Test out saving and loading"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1b359a08",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# NOTE: docstore and index_store is persisted in MongoDB by default\n",
-    "# NOTE: here only need to persist simple vector store to disk\n",
-    "storage_context.persist()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "84b3d2f4",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# note down index IDs\n",
-    "list_id = list_index.index_id\n",
-    "vector_id = vector_index.index_id\n",
-    "keyword_id = keyword_table_index.index_id"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1593ca1d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from llama_index.indices.loading import load_index_from_storage\n",
-    "\n",
-    "# re-create storage context\n",
-    "storage_context = StorageContext.from_defaults(\n",
-    "    docstore=MongoDocumentStore.from_uri(uri=MONGO_URI),\n",
-    "    index_store=MongoIndexStore.from_uri(uri=MONGO_URI),\n",
-    ")\n",
-    "\n",
-    "# load indices\n",
-    "list_index = load_index_from_storage(storage_context=storage_context, index_id=list_id)\n",
-    "vector_index = load_index_from_storage(storage_context=storage_context, vector_id=vector_id)\n",
-    "keyword_table_index = load_index_from_storage(storage_context=storage_context, keyword_id=keyword_id)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d3bf6aaf-3375-4212-8323-777969a918f7",
-   "metadata": {},
-   "source": [
-    "#### Test out some Queries"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9bba68f3-2743-437e-93b6-ce9ba92e40c3",
-   "metadata": {
-    "scrolled": true,
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "llm_predictor_chatgpt = LLMPredictor(llm=ChatOpenAI(temperature=0, model_name=\"gpt-3.5-turbo\"))\n",
-    "service_context_chatgpt = ServiceContext.from_defaults(llm_predictor=llm_predictor_chatgpt, chunk_size_limit=1024)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "544c0565-72a0-434b-98e5-83138ebdaa2b",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "query_engine = list_index.as_query_engine()\n",
-    "list_response = query_engine.query(\"What is a summary of this document?\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "39d250be",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "display_response(list_response)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "036077b7-108e-4026-9628-44c694343460",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "query_engine = vector_index.as_query_engine()\n",
-    "vector_response = query_engine.query(\"What did the author do growing up?\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "42229e09",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "display_response(vector_response)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ecd7719c-f663-4edb-a239-d2a8f0a5c091",
-   "metadata": {
-    "scrolled": true,
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "query_engine = keyword_table_index.as_query_engine()\n",
-    "keyword_response = query_engine.query(\"What did the author do after his time at YC?\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "37524641-2632-4a76-8ae6-00f1285256d9",
-   "metadata": {
-    "scrolled": true,
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "display_response(keyword_response)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ff58018c-3117-4d50-abff-16a1873eda9c",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": []
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.16"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+    "cells": [
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "a54d1c43-4b7f-4917-939f-a964f6f3dafc",
+            "metadata": {
+                "scrolled": true,
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "import nest_asyncio\n",
+                "nest_asyncio.apply()"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "fa67fa07-1395-4aab-a356-72bdb302f6b2",
+            "metadata": {
+                "scrolled": true,
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "import logging\n",
+                "import sys\n",
+                "import os\n",
+                "\n",
+                "logging.basicConfig(stream=sys.stdout, level=logging.INFO)\n",
+                "logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "1d12d766-3ca8-4012-9da2-248be80bb6ab",
+            "metadata": {
+                "scrolled": true,
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "from llama_index import SimpleDirectoryReader, ServiceContext, LLMPredictor, StorageContext\n",
+                "from llama_index import GPTVectorStoreIndex, GPTListIndex, GPTSimpleKeywordTableIndex\n",
+                "from llama_index.composability import ComposableGraph\n",
+                "from langchain.chat_models import ChatOpenAI\n",
+                "from llama_index.response.notebook_utils import display_response"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "f6dd9d5f-a601-4097-894e-fe98a0c35a5b",
+            "metadata": {},
+            "source": [
+                "#### Load Documents"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "e7cdaf9d-cfbd-4ced-8d4e-6eef8508224d",
+            "metadata": {
+                "scrolled": true,
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "reader = SimpleDirectoryReader('../paul_graham_essay/data')\n",
+                "documents = reader.load_data()"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "bae82b55-5c9f-432a-9e06-1fccb6f9fc7f",
+            "metadata": {},
+            "source": [
+                "#### Parse into Nodes"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "f97e558a-c29f-44ec-ab33-1f481da1a6ef",
+            "metadata": {
+                "scrolled": true,
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "from llama_index.node_parser import SimpleNodeParser\n",
+                "nodes = SimpleNodeParser().get_nodes_from_documents(documents)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "aff4c8e1-b2ba-4ea6-a8df-978c2788fedc",
+            "metadata": {},
+            "source": [
+                "#### Add to Docstore"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "1514211c",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "MONGO_URI = os.environ['MONGO_URI']"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "1ba8b0da-67a8-4653-8cdb-09e39583a2d8",
+            "metadata": {
+                "scrolled": true,
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "from llama_index.storage.docstore import MongoDocumentStore\n",
+                "from llama_index.storage.index_store.mongo_index_store import MongoIndexStore"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "60e781d1",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "\n",
+                "storage_context = StorageContext.from_defaults(\n",
+                "    docstore=MongoDocumentStore.from_uri(uri=MONGO_URI),\n",
+                "    index_store=MongoIndexStore.from_uri(uri=MONGO_URI),\n",
+                ")"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "e0b18789",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "storage_context.docstore.add_documents(nodes)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "528149c1-5bde-4eba-b75a-e8fa1da17d7c",
+            "metadata": {},
+            "source": [
+                "#### Define Multiple Indexes\n",
+                "\n",
+                "Each index uses the same underlying Node."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "316fb6ac-2031-4d17-9999-ffdb827f46d1",
+            "metadata": {
+                "scrolled": true,
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "list_index = GPTListIndex(nodes, storage_context=storage_context)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "9440f405-fa75-4788-bc7c-11d021a0a17b",
+            "metadata": {
+                "scrolled": true,
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "vector_index = GPTVectorStoreIndex(nodes, storage_context=storage_context)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "364ef89f-4ba2-4b1a-b5e5-619e0e8420ef",
+            "metadata": {
+                "scrolled": true,
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "keyword_table_index = GPTSimpleKeywordTableIndex(nodes, storage_context=storage_context)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "5c6b2141-fc77-4dec-891b-d4dad0633b35",
+            "metadata": {
+                "scrolled": true,
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "# NOTE: the docstore still has the same nodes\n",
+                "len(storage_context.docstore.docs)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "365a025b",
+            "metadata": {},
+            "source": [
+                "#### Test out saving and loading"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "1b359a08",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# NOTE: docstore and index_store is persisted in MongoDB by default\n",
+                "# NOTE: here only need to persist simple vector store to disk\n",
+                "storage_context.persist()"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "84b3d2f4",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# note down index IDs\n",
+                "list_id = list_index.index_id\n",
+                "vector_id = vector_index.index_id\n",
+                "keyword_id = keyword_table_index.index_id"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "1593ca1d",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "from llama_index.indices.loading import load_index_from_storage\n",
+                "\n",
+                "# re-create storage context\n",
+                "storage_context = StorageContext.from_defaults(\n",
+                "    docstore=MongoDocumentStore.from_uri(uri=MONGO_URI),\n",
+                "    index_store=MongoIndexStore.from_uri(uri=MONGO_URI),\n",
+                ")\n",
+                "\n",
+                "# load indices\n",
+                "list_index = load_index_from_storage(storage_context=storage_context, index_id=list_id)\n",
+                "vector_index = load_index_from_storage(storage_context=storage_context, vector_id=vector_id)\n",
+                "keyword_table_index = load_index_from_storage(storage_context=storage_context, keyword_id=keyword_id)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "d3bf6aaf-3375-4212-8323-777969a918f7",
+            "metadata": {},
+            "source": [
+                "#### Test out some Queries"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "9bba68f3-2743-437e-93b6-ce9ba92e40c3",
+            "metadata": {
+                "scrolled": true,
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "llm_predictor_chatgpt = LLMPredictor(llm=ChatOpenAI(temperature=0, model_name=\"gpt-3.5-turbo\"))\n",
+                "service_context_chatgpt = ServiceContext.from_defaults(llm_predictor=llm_predictor_chatgpt, chunk_size_limit=1024)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "544c0565-72a0-434b-98e5-83138ebdaa2b",
+            "metadata": {
+                "scrolled": true
+            },
+            "outputs": [],
+            "source": [
+                "query_engine = list_index.as_query_engine()\n",
+                "list_response = query_engine.query(\"What is a summary of this document?\")"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "39d250be",
+            "metadata": {
+                "scrolled": true
+            },
+            "outputs": [],
+            "source": [
+                "display_response(list_response)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "036077b7-108e-4026-9628-44c694343460",
+            "metadata": {
+                "scrolled": true
+            },
+            "outputs": [],
+            "source": [
+                "query_engine = vector_index.as_query_engine()\n",
+                "vector_response = query_engine.query(\"What did the author do growing up?\")"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "42229e09",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "display_response(vector_response)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "ecd7719c-f663-4edb-a239-d2a8f0a5c091",
+            "metadata": {
+                "scrolled": true,
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "query_engine = keyword_table_index.as_query_engine()\n",
+                "keyword_response = query_engine.query(\"What did the author do after his time at YC?\")"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "37524641-2632-4a76-8ae6-00f1285256d9",
+            "metadata": {
+                "scrolled": true,
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "display_response(keyword_response)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "ff58018c-3117-4d50-abff-16a1873eda9c",
+            "metadata": {
+                "scrolled": true
+            },
+            "outputs": [],
+            "source": []
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 3 (ipykernel)",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.9.16"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 5
 }

--- a/llama_index/storage/docstore/dynamodb_docstore.py
+++ b/llama_index/storage/docstore/dynamodb_docstore.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Optional
+from llama_index.storage.docstore.keyval_docstore import KVDocumentStore
+from llama_index.storage.kvstore.dynamodb_kvstore import DynamoDBKVStore
+
+
+class DynamoDBDocumentStore(KVDocumentStore):
+    def __init__(
+        self, dynamodb_kvstore: DynamoDBKVStore, namespace: Optional[str] = None
+    ) -> None:
+        super().__init__(kvstore=dynamodb_kvstore, namespace=namespace)
+
+    @classmethod
+    def from_table_name(
+        cls, table_name: str, namespace: Optional[str] = None
+    ) -> DynamoDBDocumentStore:
+        dynamodb_kvstore = DynamoDBKVStore.from_table_name(table_name=table_name)
+        return cls(dynamodb_kvstore=dynamodb_kvstore, namespace=namespace)

--- a/llama_index/storage/index_store/dynamodb_index_store.py
+++ b/llama_index/storage/index_store/dynamodb_index_store.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from llama_index.storage.index_store.keyval_index_store import KVIndexStore
+from llama_index.storage.kvstore.dynamodb_kvstore import DynamoDBKVStore
+
+
+class DynamoDBIndexStore(KVIndexStore):
+    def __init__(
+        self, dynamodb_kvstore: DynamoDBKVStore, namespace: Optional[str] = None
+    ):
+        """Init a DynamoDBIndexStore."""
+        super().__init__(kvstore=dynamodb_kvstore, namespace=namespace)
+
+    @classmethod
+    def from_table_name(
+        cls, table_name: str, namespace: Optional[str] = None
+    ) -> DynamoDBIndexStore:
+        """Load DynamoDBIndexStore from a DynamoDB table name."""
+        ddb_kvstore = DynamoDBKVStore.from_table_name(table_name=table_name)
+        return cls(dynamodb_kvstore=ddb_kvstore, namespace=namespace)

--- a/llama_index/storage/kvstore/dynamodb_kvstore.py
+++ b/llama_index/storage/kvstore/dynamodb_kvstore.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from llama_index.storage.kvstore.types import DEFAULT_COLLECTION, BaseKVStore
+
+IMPORT_ERROR_MSG = "`boto3` package not found, please run `pip install boto3`"
+
+
+def parse_schema(table: Any) -> Tuple[str, str]:
+    key_hash: Optional[str] = None
+    key_range: Optional[str] = None
+
+    for key in table.key_schema:
+        if key["KeyType"] == "HASH":
+            key_hash = key["AttributeName"]
+        elif key["KeyType"] == "RANGE":
+            key_range = key["AttributeName"]
+
+    if key_hash is not None and key_range is not None:
+        return key_hash, key_range
+    else:
+        raise ValueError("Must be a DynamoDB table with a hash key and sort key.")
+
+
+def convert_float_to_decimal(obj: Any) -> Any:
+    if isinstance(obj, List):
+        return [convert_float_to_decimal(x) for x in obj]
+    elif isinstance(obj, Set):
+        return {convert_float_to_decimal(x) for x in obj}
+    elif isinstance(obj, Dict):
+        return {k: convert_float_to_decimal(v) for k, v in obj.items()}
+    elif isinstance(obj, float):
+        return Decimal(str(obj))
+    else:
+        return obj
+
+
+def convert_decimal_to_int_or_float(obj: Any) -> Any:
+    if isinstance(obj, List):
+        return [convert_decimal_to_int_or_float(x) for x in obj]
+    elif isinstance(obj, Set):
+        return {convert_decimal_to_int_or_float(x) for x in obj}
+    elif isinstance(obj, Dict):
+        return {k: convert_decimal_to_int_or_float(v) for k, v in obj.items()}
+    elif isinstance(obj, Decimal):
+        return num if (num := int(obj)) == obj else float(obj)
+    else:
+        return obj
+
+
+class DynamoDBKVStore(BaseKVStore):
+    def __init__(self, table: Any):
+        """Init a DynamoDBKVStore."""
+        try:
+            from boto3.dynamodb.conditions import Key
+        except ImportError:
+            raise ImportError(IMPORT_ERROR_MSG)
+
+        self._table = table
+        self._boto3_key = Key
+        self._key_hash, self._key_range = parse_schema(table)
+
+    @classmethod
+    def from_table_name(cls, table_name: str) -> DynamoDBKVStore:
+        """Load a DynamoDBKVStore from a DynamoDB table name.
+
+        Args:
+            table_name (str): DynamoDB table name
+        """
+        try:
+            import boto3
+        except ImportError:
+            raise ImportError(IMPORT_ERROR_MSG)
+
+        ddb = boto3.resource("dynamodb")
+        return cls(table=ddb.Table(table_name))
+
+    def put(self, key: str, val: dict, collection: str = DEFAULT_COLLECTION) -> None:
+        """Put a key-value pair into the store.
+
+        Args:
+            key (str): key
+            val (dict): value
+            collection (str): collection name
+        """
+        item = {k: convert_float_to_decimal(v) for k, v in val.items()}
+        item[self._key_hash] = collection
+        item[self._key_range] = key
+        self._table.put_item(Item=item)
+
+    def get(self, key: str, collection: str = DEFAULT_COLLECTION) -> Optional[dict]:
+        """Get a value from the store.
+
+        Args:
+            key (str): key
+            collection (str): collection name
+        """
+        resp = self._table.get_item(
+            Key={self._key_hash: collection, self._key_range: key}
+        )
+        if (item := resp.get("Item")) is None:
+            return None
+        else:
+            return {
+                k: convert_decimal_to_int_or_float(v)
+                for k, v in item.items()
+                if k not in {self._key_hash, self._key_range}
+            }
+
+    def get_all(self, collection: str = DEFAULT_COLLECTION) -> Dict[str, dict]:
+        """Get all values from the store.
+
+        Args:
+            collection (str): collection name
+        """
+        result = {}
+        last_evaluated_key = None
+        is_first = True
+        while last_evaluated_key is not None or is_first:
+            if is_first:
+                is_first = False
+            option = {
+                "KeyConditionExpression": self._boto3_key(self._key_hash).eq(collection)
+            }
+            if last_evaluated_key is not None:
+                option["ExclusiveStartKey"] = last_evaluated_key
+            resp = self._table.query(**option)
+            for item in resp.get("Items", []):
+                item.pop(self._key_hash)
+                key = item.pop(self._key_range)
+                result[key] = {
+                    k: convert_decimal_to_int_or_float(v) for k, v in item.items()
+                }
+            last_evaluated_key = resp.get("LastEvaluatedKey")
+        return result
+
+    def delete(self, key: str, collection: str = DEFAULT_COLLECTION) -> bool:
+        """Delete a value from the store.
+
+        Args:
+            key (str): key
+            collection (str): collection name
+        """
+        resp = self._table.delete_item(
+            Key={self._key_hash: collection, self._key_range: key},
+            ReturnValues="ALL_OLD",
+        )
+        return "Attributes" in resp

--- a/llama_index/storage/kvstore/dynamodb_kvstore.py
+++ b/llama_index/storage/kvstore/dynamodb_kvstore.py
@@ -147,4 +147,8 @@ class DynamoDBKVStore(BaseKVStore):
             Key={self._key_hash: collection, self._key_range: key},
             ReturnValues="ALL_OLD",
         )
-        return "Attributes" in resp
+
+        if (item := resp.get("Attributes")) is None:
+            return False
+        else:
+            return len(item) > 0

--- a/llama_index/storage/kvstore/dynamodb_kvstore.py
+++ b/llama_index/storage/kvstore/dynamodb_kvstore.py
@@ -51,6 +51,15 @@ def convert_decimal_to_int_or_float(obj: Any) -> Any:
 
 
 class DynamoDBKVStore(BaseKVStore):
+    """DynamoDB Key-Value store.
+    Stores key-value pairs in a DynamoDB Table.
+    The DynamoDB Table must have both a hash key and a range key,
+        and their types must be string.
+
+    Args:
+        table (Any): DynamoDB Table Service Resource
+    """
+
     def __init__(self, table: Any):
         """Init a DynamoDBKVStore."""
         try:

--- a/llama_index/vector_stores/dynamodb.py
+++ b/llama_index/vector_stores/dynamodb.py
@@ -41,6 +41,8 @@ class DynamoDBVectorStore(VectorStore):
         namespace (Optional[str]): namespace
     """
 
+    stores_text: bool = False
+
     def __init__(
         self, dynamodb_kvstore: DynamoDBKVStore, namespace: Optional[str] = None
     ) -> None:

--- a/llama_index/vector_stores/dynamodb.py
+++ b/llama_index/vector_stores/dynamodb.py
@@ -1,0 +1,148 @@
+"""DynamoDB vector store index."""
+from __future__ import annotations
+from typing import Optional, List, Any, cast, Dict
+
+from llama_index.storage.kvstore.dynamodb_kvstore import DynamoDBKVStore
+
+from llama_index.indices.query.embedding_utils import (
+    get_top_k_embeddings,
+    get_top_k_embeddings_learner,
+)
+
+from llama_index.vector_stores.types import (
+    NodeWithEmbedding,
+    VectorStore,
+    VectorStoreQuery,
+    VectorStoreQueryMode,
+    VectorStoreQueryResult,
+)
+
+from logging import getLogger
+
+logger = getLogger(__name__)
+
+DEFAULT_NAMESPACE = "vector_store"
+
+LEARNER_MODES = {
+    VectorStoreQueryMode.SVM,
+    VectorStoreQueryMode.LINEAR_REGRESSION,
+    VectorStoreQueryMode.LOGISTIC_REGRESSION,
+}
+
+
+class DynamoDBVectorStore(VectorStore):
+    """DynamoDB Vector Store.
+
+    In this vector store, embeddings are stored within dynamodb table.
+    This class was implemented with reference to SimpleVectorStore.
+
+    Args:
+        dynamodb_kvstore (DynamoDBKVStore): data store
+        namespace (Optional[str]): namespace
+    """
+
+    def __init__(
+        self, dynamodb_kvstore: DynamoDBKVStore, namespace: Optional[str] = None
+    ) -> None:
+        """Initialize params."""
+        self._kvstore = dynamodb_kvstore
+        namespace = namespace or DEFAULT_NAMESPACE
+        self._collection_embedding = f"{namespace}/embedding"
+        self._collection_text_id_to_doc_id = f"{namespace}/text_id_to_doc_id"
+        self._key_value = "value"
+
+    @classmethod
+    def from_table_name(
+        cls, table_name: str, namespace: Optional[str] = None
+    ) -> DynamoDBVectorStore:
+        """Load from DynamoDB table name."""
+        dynamodb_kvstore = DynamoDBKVStore.from_table_name(table_name=table_name)
+        return cls(dynamodb_kvstore=dynamodb_kvstore, namespace=namespace)
+
+    @property
+    def client(self) -> None:
+        """Get client."""
+        return None
+
+    def get(self, text_id: str) -> List[float]:
+        """Get embedding."""
+        item = self._kvstore.get(key=text_id, collection=self._collection_embedding)
+        item = cast(Dict[str, List[float]], item)
+        return item[self._key_value]
+
+    def add(self, embedding_results: List[NodeWithEmbedding]) -> List[str]:
+        """Add embedding_results to index."""
+        response = []
+        for result in embedding_results:
+            self._kvstore.put(
+                key=result.id,
+                val={self._key_value: result.embedding},
+                collection=self._collection_embedding,
+            )
+            self._kvstore.put(
+                key=result.id,
+                val={self._key_value: result.ref_doc_id},
+                collection=self._collection_text_id_to_doc_id,
+            )
+            response.append(result.id)
+        return response
+
+    def delete(self, doc_id: str, **delete_kwargs: Any) -> None:
+        """Delete a document."""
+        text_ids_to_delete = set()
+        for text_id, item in self._kvstore.get_all(
+            collection=self._collection_text_id_to_doc_id
+        ).items():
+            if doc_id == item[self._key_value]:
+                text_ids_to_delete.add(text_id)
+
+        for text_id in text_ids_to_delete:
+            self._kvstore.delete(key=text_id, collection=self._collection_embedding)
+            self._kvstore.delete(
+                key=text_id, collection=self._collection_text_id_to_doc_id
+            )
+
+    def query(self, query: VectorStoreQuery, **kwargs: Any) -> VectorStoreQueryResult:
+        """Get nodes for response"""
+        if query.filters is not None:
+            raise ValueError(
+                "Metadata filters not implemented for SimpleVectorStore yet."
+            )
+
+        if query.doc_ids:
+            available_ids = set(query.doc_ids)
+        else:
+            available_ids = set()
+
+        is_nothing_available_ids = len(available_ids) == 0
+
+        # TODO: consolidate with get_query_text_embedding_similarities
+        items = self._kvstore.get_all(collection=self._collection_embedding).items()
+
+        node_ids = []
+        embeddings = []
+
+        for node_id, data in items:
+            if is_nothing_available_ids or node_id in available_ids:
+                node_ids.append(node_id)
+                embeddings.append(data[self._key_value])
+
+        query_embedding = cast(List[float], query.query_embedding)
+        if query.mode in LEARNER_MODES:
+            top_similarities, top_ids = get_top_k_embeddings_learner(
+                query_embedding=query_embedding,
+                embeddings=embeddings,
+                similarity_top_k=query.similarity_top_k,
+                embedding_ids=node_ids,
+            )
+        elif query.mode == VectorStoreQueryMode.DEFAULT:
+            top_similarities, top_ids = get_top_k_embeddings(
+                query_embedding=query_embedding,
+                embeddings=embeddings,
+                similarity_top_k=query.similarity_top_k,
+                embedding_ids=node_ids,
+            )
+        else:
+            raise ValueError(f"Invalid query mode: {query.mode}")
+
+        return VectorStoreQueryResult(similarities=top_similarities, ids=node_ids)

--- a/tests/storage/docstore/test_dynamodb_docstore.py
+++ b/tests/storage/docstore/test_dynamodb_docstore.py
@@ -6,8 +6,7 @@ from pytest import MonkeyPatch
 from llama_index.data_structs.node import Node
 from llama_index.readers.schema.base import Document
 from llama_index.schema import BaseDocument
-from llama_index.storage.docstore.dynamodb_docstore import \
-    DynamoDBDocumentStore
+from llama_index.storage.docstore.dynamodb_docstore import DynamoDBDocumentStore
 from llama_index.storage.kvstore.dynamodb_kvstore import DynamoDBKVStore
 
 try:

--- a/tests/storage/docstore/test_dynamodb_docstore.py
+++ b/tests/storage/docstore/test_dynamodb_docstore.py
@@ -1,0 +1,117 @@
+from typing import Generator, List
+
+import pytest
+from pytest import MonkeyPatch
+
+from llama_index.data_structs.node import Node
+from llama_index.readers.schema.base import Document
+from llama_index.schema import BaseDocument
+from llama_index.storage.docstore.dynamodb_docstore import \
+    DynamoDBDocumentStore
+from llama_index.storage.kvstore.dynamodb_kvstore import DynamoDBKVStore
+
+try:
+    import boto3
+    from moto import mock_dynamodb
+
+    has_boto_libs = True
+except ImportError:
+    has_boto_libs = False
+
+
+@pytest.fixture()
+def documents() -> List[Document]:
+    return [Document("doc_1"), Document("doc_2")]
+
+
+@pytest.fixture()
+def kvstore_from_mocked_table(
+    monkeypatch: MonkeyPatch,
+) -> Generator[DynamoDBKVStore, None, None]:
+    monkeypatch.setenv("MOTO_ALLOW_NONEXISTENT_REGION", "True")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "Andes")
+
+    table_name = "test_table"
+    with mock_dynamodb():
+        client = boto3.client("dynamodb")
+        client.create_table(
+            TableName=table_name,
+            AttributeDefinitions=[
+                {"AttributeName": "collection", "AttributeType": "S"},
+                {"AttributeName": "key", "AttributeType": "S"},
+            ],
+            KeySchema=[
+                {"AttributeName": "collection", "KeyType": "HASH"},
+                {"AttributeName": "key", "KeyType": "RANGE"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield DynamoDBKVStore.from_table_name(table_name)
+
+
+@pytest.fixture()
+def ddb_docstore(kvstore_from_mocked_table: DynamoDBKVStore) -> DynamoDBDocumentStore:
+    return DynamoDBDocumentStore(dynamodb_kvstore=kvstore_from_mocked_table)
+
+
+@pytest.mark.skipif(not has_boto_libs, reason="boto3 and/or moto not installed")
+def test_docstore(ddb_docstore: DynamoDBDocumentStore) -> None:
+    """Test docstore."""
+    doc = Document("hello world", doc_id="d1", extra_info={"foo": "bar"})
+    node = Node("my node", doc_id="d2", node_info={"node": "info"})
+
+    # test get document
+    docstore = ddb_docstore
+    docstore.add_documents([doc, node])
+    gd1 = docstore.get_document("d1")
+    assert gd1 == doc
+    gd2 = docstore.get_document("d2")
+    assert gd2 == node
+
+
+@pytest.mark.skipif(not has_boto_libs, reason="boto3 and/or moto not installed")
+def test_dynamodb_docstore(
+    ddb_docstore: DynamoDBDocumentStore, documents: List[Document]
+) -> None:
+    ds = ddb_docstore
+    assert len(ds.docs) == 0
+
+    # test adding documents
+    ds.add_documents(documents)
+    assert len(ds.docs) == 2
+    assert all(isinstance(doc, BaseDocument) for doc in ds.docs.values())
+
+    # test updating documents
+    ds.add_documents(documents)
+    print(ds.docs)
+    assert len(ds.docs) == 2
+
+    # test getting documents
+    doc0 = ds.get_document(documents[0].get_doc_id())
+    assert doc0 is not None
+    assert documents[0].text == doc0.text
+
+    # test deleting documents
+    ds.delete_document(documents[0].get_doc_id())
+    assert len(ds.docs) == 1
+
+
+@pytest.mark.skipif(not has_boto_libs, reason="boto3 and/or moto not installed")
+def test_dynamodb_docstore_hash(
+    ddb_docstore: DynamoDBDocumentStore, documents: List[Document]
+) -> None:
+    ds = ddb_docstore
+
+    # Test setting hash
+    ds.set_document_hash("test_doc_id", "test_doc_hash")
+    doc_hash = ds.get_document_hash("test_doc_id")
+    assert doc_hash == "test_doc_hash"
+
+    # Test updating hash
+    ds.set_document_hash("test_doc_id", "test_doc_hash_new")
+    doc_hash = ds.get_document_hash("test_doc_id")
+    assert doc_hash == "test_doc_hash_new"
+
+    # Test getting non-existent
+    doc_hash = ds.get_document_hash("test_not_exist")
+    assert doc_hash is None

--- a/tests/storage/index_store/test_dynamodb_index_store.py
+++ b/tests/storage/index_store/test_dynamodb_index_store.py
@@ -1,0 +1,56 @@
+from typing import Generator
+
+import pytest
+from pytest import MonkeyPatch
+
+from llama_index.data_structs.data_structs import IndexGraph
+from llama_index.storage.index_store.dynamodb_index_store import DynamoDBIndexStore
+from llama_index.storage.kvstore.dynamodb_kvstore import DynamoDBKVStore
+
+try:
+    import boto3
+    from moto import mock_dynamodb
+
+    has_boto_libs = True
+except ImportError:
+    has_boto_libs = False
+
+
+@pytest.fixture()
+def kvstore_from_mocked_table(
+    monkeypatch: MonkeyPatch,
+) -> Generator[DynamoDBKVStore, None, None]:
+    monkeypatch.setenv("MOTO_ALLOW_NONEXISTENT_REGION", "True")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "Andes")
+
+    table_name = "test_table"
+    with mock_dynamodb():
+        client = boto3.client("dynamodb")
+        client.create_table(
+            TableName=table_name,
+            AttributeDefinitions=[
+                {"AttributeName": "collection", "AttributeType": "S"},
+                {"AttributeName": "key", "AttributeType": "S"},
+            ],
+            KeySchema=[
+                {"AttributeName": "collection", "KeyType": "HASH"},
+                {"AttributeName": "key", "KeyType": "RANGE"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield DynamoDBKVStore.from_table_name(table_name)
+
+
+@pytest.fixture()
+def ddb_index_store(kvstore_from_mocked_table: DynamoDBKVStore) -> DynamoDBIndexStore:
+    return DynamoDBIndexStore(dynamodb_kvstore=kvstore_from_mocked_table)
+
+
+@pytest.mark.skipif(not has_boto_libs, reason="boto3 and/or moto not installed")
+def test_dynamodb_index_store(ddb_index_store: DynamoDBIndexStore) -> None:
+    index_store = ddb_index_store
+
+    index_struct = IndexGraph()
+    index_store.add_index_struct(index_struct=index_struct)
+
+    assert index_store.get_index_struct(struct_id=index_struct.index_id) == index_struct

--- a/tests/storage/kvstore/test_dynamodb_kvstore.py
+++ b/tests/storage/kvstore/test_dynamodb_kvstore.py
@@ -1,0 +1,110 @@
+from typing import Generator
+import pytest
+from pytest import MonkeyPatch
+from llama_index.storage.kvstore.dynamodb_kvstore import DynamoDBKVStore
+from mypy_boto3_dynamodb import DynamoDBClient  # todo: 後で消す
+
+try:
+    import boto3
+    from moto import mock_dynamodb
+
+    has_boto_libs = True
+except ImportError:
+    has_boto_libs = False
+
+
+@pytest.fixture()
+def kvstore_from_mocked_table(
+    monkeypatch: MonkeyPatch,
+) -> Generator[DynamoDBKVStore, None, None]:
+    monkeypatch.setenv("MOTO_ALLOW_NONEXISTENT_REGION", "True")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "Andes")
+
+    table_name = "test_table"
+    with mock_dynamodb():
+        client: DynamoDBClient = boto3.client("dynamodb")
+        client.create_table(
+            TableName=table_name,
+            AttributeDefinitions=[
+                {"AttributeName": "collection", "AttributeType": "S"},
+                {"AttributeName": "key", "AttributeType": "S"},
+            ],
+            KeySchema=[
+                {"AttributeName": "collection", "KeyType": "HASH"},
+                {"AttributeName": "key", "KeyType": "RANGE"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield DynamoDBKVStore.from_table_name(table_name)
+
+
+@pytest.mark.skipif(not has_boto_libs, reason="boto3 and/or moto not installed")
+def test_put_get(kvstore_from_mocked_table: DynamoDBKVStore) -> None:
+    test_key = "test_key"
+    test_value = {"test_str": "test_str", "test_float": 3.14}
+    kvstore_from_mocked_table.put(key=test_key, val=test_value)
+    item = kvstore_from_mocked_table.get(key=test_key)
+    assert item == test_value
+
+
+@pytest.mark.skipif(not has_boto_libs, reason="boto3 and/or moto not installed")
+def test_get_non_existent(kvstore_from_mocked_table: DynamoDBKVStore) -> None:
+    test_key = "test_key"
+    item = kvstore_from_mocked_table.get(key=test_key)
+    assert item is None
+
+
+@pytest.mark.skipif(not has_boto_libs, reason="boto3 and/or moto not installed")
+def test_put_get_multiple_collections(
+    kvstore_from_mocked_table: DynamoDBKVStore,
+) -> None:
+    test_key = "test_key"
+    test_item_collection_a = {"test_obj_key": "a"}
+    test_item_collection_b = {"test_obj_key": "b"}
+    kvstore_from_mocked_table.put(
+        key=test_key, val=test_item_collection_a, collection="test_collection_a"
+    )
+    kvstore_from_mocked_table.put(
+        key=test_key, val=test_item_collection_b, collection="test_collection_b"
+    )
+    item_collection_a = kvstore_from_mocked_table.get(
+        key=test_key, collection="test_collection_a"
+    )
+    item_collection_b = kvstore_from_mocked_table.get(
+        key=test_key, collection="test_collection_b"
+    )
+    assert test_item_collection_a == item_collection_a
+    assert test_item_collection_b == item_collection_b
+
+
+@pytest.mark.skipif(not has_boto_libs, reason="boto3 and/or moto not installed")
+def test_delete(kvstore_from_mocked_table: DynamoDBKVStore) -> None:
+    test_key = "test_key"
+    test_item = {"test_item": "test_item_val"}
+    kvstore_from_mocked_table.put(key=test_key, val=test_item)
+    item = kvstore_from_mocked_table.get(key=test_key)
+    assert item == test_item
+    assert kvstore_from_mocked_table.delete(key=test_key)
+
+
+@pytest.mark.skipif(not has_boto_libs, reason="boto3 and/or moto not installed")
+def test_delete_non_existent(kvstore_from_mocked_table: DynamoDBKVStore) -> None:
+    test_key = "test_key"
+    test_item = {"test_item_key": "test_item_val"}
+    kvstore_from_mocked_table.put(key=test_key, val=test_item)
+    assert kvstore_from_mocked_table.delete(key="wrong_key") is False
+
+
+@pytest.mark.skipif(not has_boto_libs, reason="boto3 and/or moto not installed")
+def test_get_all(kvstore_from_mocked_table: DynamoDBKVStore) -> None:
+    test_key_a = "test_key_a"
+    test_item_a = {"test_item_key": "test_item_val_a"}
+
+    test_key_b = "test_key_b"
+    test_item_b = {"test_item_key": "test_item_val_b"}
+
+    kvstore_from_mocked_table.put(key=test_key_a, val=test_item_a)
+    kvstore_from_mocked_table.put(key=test_key_b, val=test_item_b)
+
+    items = kvstore_from_mocked_table.get_all()
+    assert items == {test_key_a: test_item_a, test_key_b: test_item_b}

--- a/tests/storage/kvstore/test_dynamodb_kvstore.py
+++ b/tests/storage/kvstore/test_dynamodb_kvstore.py
@@ -2,7 +2,6 @@ from typing import Generator
 import pytest
 from pytest import MonkeyPatch
 from llama_index.storage.kvstore.dynamodb_kvstore import DynamoDBKVStore
-from mypy_boto3_dynamodb import DynamoDBClient  # todo: 後で消す
 
 try:
     import boto3
@@ -22,7 +21,7 @@ def kvstore_from_mocked_table(
 
     table_name = "test_table"
     with mock_dynamodb():
-        client: DynamoDBClient = boto3.client("dynamodb")
+        client = boto3.client("dynamodb")
         client.create_table(
             TableName=table_name,
             AttributeDefinitions=[


### PR DESCRIPTION
Implementation of a DynamoDB-backed KV store, Document Store, Index Store, and Vector Store. Since DynamoDB is a commonly used and easy-to-setup data storage layer, I thought this may be a useful addition the project.

I used boto3 for the DynamoDB interactions & am using moto to mock those interactions in unit tests. Vector store testing was not implemented because there were not many samples.

The storage scheme stores all KV pairs within a specified DynamoDB Table.

The KV pair data is separated in partitions by collection name where each hash key is the collection name. If the value contains a float, it is converted to Decimal before being put into the table.

The Vector Store was implemented using DynamoDBKVStore, based on the SimpleVectorStore implementation.