### PR TITLE
[nit][perf] Replace list comprehension with list.

### DIFF
--- a/llama_index/optimization/optimizer.py
+++ b/llama_index/optimization/optimizer.py
@@ -87,7 +87,7 @@ class SentenceEmbeddingOptimizer(BaseTokenUsageOptimizer):
             embeddings=text_embeddings,
             similarity_fn=self.embed_model.similarity,
             similarity_top_k=num_top_k,
-            embedding_ids=[i for i in range(len(text_embeddings))],
+            embedding_ids=list(range(len(text_embeddings))),
             similarity_cutoff=threshold,
         )
         net_embed_tokens = self.embed_model.total_tokens_used - start_embed_token_ct


### PR DESCRIPTION
It's shorter and more efficient.
In [colab](https://colab.research.google.com/gist/ttsugriy/1a34380f6d9c5e78307c2b263cb3f61d/cache-member-function.ipynb) you can see that `list` is more than 2X faster than corresponding list comprehension. Not that it's a huge deal, but still.