### PR TITLE
Skip loop intended for debug mode when it's not enabled.

### DIFF
--- a/llama_index/optimization/optimizer.py
+++ b/llama_index/optimization/optimizer.py
@@ -99,6 +99,7 @@ class SentenceEmbeddingOptimizer(BaseTokenUsageOptimizer):
         top_sentences = [split_text[i] for i in top_idxs]
 
         logger.debug(f"> Top {len(top_idxs)} sentences with scores:\n")
-        for i in range(len(top_idxs)):
-            logger.debug(f"{i}. {top_sentences[i]} ({top_similarities[i]})")
+        if logger.isEnabledFor(logging.DEBUG):
+            for i in range(len(top_idxs)):
+                logger.debug(f"{i}. {top_sentences[i]} ({top_similarities[i]})")
         return " ".join(top_sentences)


### PR DESCRIPTION
`logger.debug` will not print anything in debug mode, but the loop itself would still run and for each iteration overhead involved in checking whether logging is enabled will be performed, which is totally unnecessary.