### PR TITLE
Resolve CVE-2023-32681 by accepting requests>=2.31.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ install_requires = [
     "tenacity>=8.2.0,<9.0.0",
     "openai>=0.26.4",
     "pandas",
-    "requests<2.30.0",
+    "urllib3<2",
     "fsspec>=2023.5.0",
     "typing-inspect==0.8.0",
     "typing_extensions==4.5.0",


### PR DESCRIPTION
Accepting `requests>=2.31.0` to resolve [CVE-2023-32681 (Unintended leak of Proxy-Authorization header)](https://github.com/psf/requests/security/advisories/GHSA-j8r2-6x86-q33q).

`requests` was previously pinned to `<2.30.0` by #2099 because requests version (2.30.0) breaks download_loader in llama_hub. I think the root cause of the breaks is that `requests 2.30.0` starts to support `urllib3 2.0`, which may contain minor breaking changes. As per [Release History of `requests`](https://github.com/psf/requests/blob/main/HISTORY.md), we can stay on `urllib3 1.x` with `requests>=2.30.0`.

Hence the better solution is to pin `urllib3<2` instead of pinning `requests<2.30.0`.
 