### PR TITLE
add name of author

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ else:
     install_requires.extend(["transformers"])
 
 setup(
+    author="Jerry Liu",
     name=PACKAGE_NAME,
     version=__version__,
     packages=find_packages(),


### PR DESCRIPTION
I saw on the [PyDigger](https://pydigger.com/pypi/gpt-index) site that there is no author name