### PR TITLE
fixed continue statement if parser can't be used

### DIFF
--- a/llama_index/readers/github_readers/github_repository_reader.py
+++ b/llama_index/readers/github_readers/github_repository_reader.py
@@ -293,7 +293,6 @@ class GithubRepositoryReader(BaseReader):
                 )
                 if document is not None:
                     documents.append(document)
-                else:
                     continue
 
             try:


### PR DESCRIPTION
What is meant to happen is that if parser can't be used, the function will return the document as None. When it does this, it should skip to the next method to generate the document but, instead, it continues when document is None, breaking the loop. [Here on llama_hub](https://github.com/emptycrown/llama-hub/blob/main/loader_hub/github_repo/base.py#L383) it is written correctly but not on llama_index. This PR aligns with llama_hub.