### PR TITLE
Added content arg to MarkdownReader

### DIFF
--- a/llama_index/readers/file/markdown_reader.py
+++ b/llama_index/readers/file/markdown_reader.py
@@ -87,11 +87,16 @@ class MarkdownReader(BaseReader):
         return {}
 
     def parse_tups(
-        self, filepath: Path, errors: str = "ignore"
+        self,
+        filepath: Path,
+        content: Optional[str] = None,
+        errors: str = "ignore",
     ) -> List[Tuple[Optional[str], str]]:
-        """Parse file into tuples."""
-        with open(filepath, "r", encoding="utf-8") as f:
-            content = f.read()
+        """Parse file into tuples.
+        If content is provided, use that instead of reading from file."""
+        if content is None:
+            with open(filepath, "r", encoding="utf-8") as f:
+                content = f.read()
         if self._remove_hyperlinks:
             content = self.remove_hyperlinks(content)
         if self._remove_images:
@@ -100,10 +105,14 @@ class MarkdownReader(BaseReader):
         return markdown_tups
 
     def load_data(
-        self, file: Path, extra_info: Optional[Dict] = None
+        self,
+        file: Path,
+        extra_info: Optional[Dict] = None,
+        content: Optional[str] = None,
     ) -> List[Document]:
-        """Parse file into string."""
-        tups = self.parse_tups(file)
+        """Parse file into string.
+        If content is provided, use that instead of reading from file."""
+        tups = self.parse_tups(file, content=content)
         results = []
         # TODO: don't include headers right now
         for header, value in tups:


### PR DESCRIPTION
The aim of this PR is to make `MarkdownReader` available to other readers that are Markdown-based, even if their content is not stored in plain text files.

For backward compatibility, the `file` arg was left as is (positional), but when `content` is provided it is ignored and the given content is parsed instead.

Unrelated: I'm not sure why parse_tups() has the errors kwarg.
