### PR TITLE
feat: vector store - use a heap vs naive sort

### DIFF
--- a/llama_index/indices/query/embedding_utils.py
+++ b/llama_index/indices/query/embedding_utils.py
@@ -28,7 +28,6 @@ def get_top_k_embeddings(
             heapq.heappush(similarity_heap, (similarity, embedding_ids[i]))
             if similarity_top_k and len(similarity_heap) > similarity_top_k:
                 heapq.heappop(similarity_heap)
-    # sorted_results = sorted(similarity_heap, key=lambda x: x[0], reverse=True)
     result_tups = [
         (s, id) for s, id in sorted(similarity_heap, key=lambda x: x[0], reverse=True)
     ]

--- a/llama_index/indices/query/embedding_utils.py
+++ b/llama_index/indices/query/embedding_utils.py
@@ -24,11 +24,11 @@ def get_top_k_embeddings(
     similarity_heap: List[Tuple[float, Any]] = []
     for i, emb in enumerate(embeddings):
         similarity = similarity_fn(query_embedding, emb)
-        print(similarity)
         if similarity_cutoff is None or similarity > similarity_cutoff:
             heapq.heappush(similarity_heap, (similarity, embedding_ids[i]))
             if similarity_top_k and len(similarity_heap) > similarity_top_k:
                 heapq.heappop(similarity_heap)
+    # sorted_results = sorted(similarity_heap, key=lambda x: x[0], reverse=True)
     result_tups = [
         (s, id) for s, id in sorted(similarity_heap, key=lambda x: x[0], reverse=True)
     ]

--- a/llama_index/indices/query/embedding_utils.py
+++ b/llama_index/indices/query/embedding_utils.py
@@ -1,5 +1,5 @@
 """Embedding utils for queries."""
-
+import heapq
 from typing import Callable, List, Optional, Tuple
 
 from llama_index.embeddings.base import similarity as default_similarity_fn
@@ -21,22 +21,19 @@ def get_top_k_embeddings(
 
     similarity_fn = similarity_fn or default_similarity_fn
 
-    similarities = []
-    for emb in embeddings:
+    similarity_heap = []
+    for i, emb in enumerate(embeddings):
         similarity = similarity_fn(query_embedding, emb)
-        similarities.append(similarity)
+        if similarity_cutoff is None or similarity > similarity_cutoff:
+            # use negative similarity to get a max heap
+            heapq.heappush(similarity_heap, (-similarity, embedding_ids[i]))
+            if similarity_top_k and len(similarity_heap) > similarity_top_k:
+                heapq.heappop(similarity_heap)
 
-    sorted_tups = sorted(
-        zip(similarities, embedding_ids), key=lambda x: x[0], reverse=True
-    )
+    result_tups = [(s, id) for s, id in sorted(similarity_heap, key=lambda x: x[0])]
 
-    if similarity_cutoff is not None:
-        sorted_tups = [tup for tup in sorted_tups if tup[0] > similarity_cutoff]
-
-    similarity_top_k = similarity_top_k or len(sorted_tups)
-    result_tups = sorted_tups[:similarity_top_k]
-
-    result_similarities = [s for s, _ in result_tups]
+    # convert back to positive similarities
+    result_similarities = [-s for s, _ in result_tups]
     result_ids = [n for _, n in result_tups]
 
     return result_similarities, result_ids

--- a/llama_index/indices/query/embedding_utils.py
+++ b/llama_index/indices/query/embedding_utils.py
@@ -1,6 +1,6 @@
 """Embedding utils for queries."""
 import heapq
-from typing import Callable, List, Optional, Tuple
+from typing import Any, Callable, List, Optional, Tuple
 
 from llama_index.embeddings.base import similarity as default_similarity_fn
 import numpy as np
@@ -21,7 +21,7 @@ def get_top_k_embeddings(
 
     similarity_fn = similarity_fn or default_similarity_fn
 
-    similarity_heap = []
+    similarity_heap: List[Tuple[float, Any]] = []
     for i, emb in enumerate(embeddings):
         similarity = similarity_fn(query_embedding, emb)
         print(similarity)

--- a/llama_index/indices/query/embedding_utils.py
+++ b/llama_index/indices/query/embedding_utils.py
@@ -24,16 +24,16 @@ def get_top_k_embeddings(
     similarity_heap = []
     for i, emb in enumerate(embeddings):
         similarity = similarity_fn(query_embedding, emb)
+        print(similarity)
         if similarity_cutoff is None or similarity > similarity_cutoff:
-            # use negative similarity to get a max heap
-            heapq.heappush(similarity_heap, (-similarity, embedding_ids[i]))
+            heapq.heappush(similarity_heap, (similarity, embedding_ids[i]))
             if similarity_top_k and len(similarity_heap) > similarity_top_k:
                 heapq.heappop(similarity_heap)
+    result_tups = [
+        (s, id) for s, id in sorted(similarity_heap, key=lambda x: x[0], reverse=True)
+    ]
 
-    result_tups = [(s, id) for s, id in sorted(similarity_heap, key=lambda x: x[0])]
-
-    # convert back to positive similarities
-    result_similarities = [-s for s, _ in result_tups]
+    result_similarities = [s for s, _ in result_tups]
     result_ids = [n for _, n in result_tups]
 
     return result_similarities, result_ids


### PR DESCRIPTION
where `k` = top k to return, `n` = total number of vectors

before vs after
- space: `O(n)` vs  `O(k)` 
- time: `O(n * log n)` vs  `O(n * logk)` 

should be sizable improvement assuming `k << n`, true for all reasonable use cases.