### PR TITLE
Add global service context

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -7,3 +7,7 @@ textarea{
   border: 0;
   padding: 0;
 }
+
+article p {
+  margin-bottom: 10px !important;
+}

--- a/docs/guides/primer/usage_pattern.md
+++ b/docs/guides/primer/usage_pattern.md
@@ -166,6 +166,7 @@ index = GPTVectorStoreIndex.from_documents(
 
 See the [Custom LLM's How-To](/how_to/customization/custom_llms.md) for more details.
 
+For more details on the service context, including how to create a global service context, see the page [Customizing the ServiceContext](/how_to/customization/service_context.md).
 
 ### Customizing Prompts
 

--- a/docs/guides/primer/usage_pattern.md
+++ b/docs/guides/primer/usage_pattern.md
@@ -166,6 +166,17 @@ index = GPTVectorStoreIndex.from_documents(
 
 See the [Custom LLM's How-To](/how_to/customization/custom_llms.md) for more details.
 
+### Global ServiceContext
+
+If you wanted the service context from the last section to always be the default, you can configure one like so
+
+```python
+import llama_index
+llama_index.global_serivce_context = service_context
+```
+
+This service context will always be used as the default if not specified as a keyword argument in LlamaIndex functions.
+
 For more details on the service context, including how to create a global service context, see the page [Customizing the ServiceContext](/how_to/customization/service_context.md).
 
 ### Customizing Prompts

--- a/docs/guides/primer/usage_pattern.md
+++ b/docs/guides/primer/usage_pattern.md
@@ -171,8 +171,8 @@ See the [Custom LLM's How-To](/how_to/customization/custom_llms.md) for more det
 If you wanted the service context from the last section to always be the default, you can configure one like so:
 
 ```python
-import llama_index
-llama_index.global_serivce_context = service_context
+from llama_index import set_global_service_context
+set_global_service_context(service_context)
 ```
 
 This service context will always be used as the default if not specified as a keyword argument in LlamaIndex functions.

--- a/docs/guides/primer/usage_pattern.md
+++ b/docs/guides/primer/usage_pattern.md
@@ -168,7 +168,7 @@ See the [Custom LLM's How-To](/how_to/customization/custom_llms.md) for more det
 
 ### Global ServiceContext
 
-If you wanted the service context from the last section to always be the default, you can configure one like so
+If you wanted the service context from the last section to always be the default, you can configure one like so:
 
 ```python
 import llama_index

--- a/docs/how_to/customization.rst
+++ b/docs/how_to/customization.rst
@@ -16,6 +16,7 @@ These are described in their respective guides below.
    customization/custom_llms.md
    customization/custom_prompts.md
    customization/embeddings.md
+   customization/service_context.md
    storage/customization.md
    customization/streaming.md
 

--- a/docs/how_to/customization/service_context.md
+++ b/docs/how_to/customization/service_context.md
@@ -1,0 +1,75 @@
+# ServiceContext
+
+The ServiceContext object encapsulates the resources used to create indexes and run queries.
+
+The following optional items can be set in the service context:
+
+- llm_predictor: The LLM used to generate natural language responses to queries.
+- embed_model: The embedding model used to generate vector representations of text.
+- prompt_helper: The PromptHelper object that defines settings for text sent to the LLM.
+- node_parser: The parser that converts documents into nodes.
+- chunk_size_limit: The maximum size of a node. Is used for the prompt helper and node parser when they aren't provided.
+- callback_managaer: The callback manager object that calls it's handlers on events. Provides basic logging and tracing capabilities.
+- is_global: A boolean that should be set when you are defining a global service context
+
+Here's a complete example that sets up all objects using their default settings:
+
+```python
+from langchain.llms import OpenAI
+from llama_index import ServiceContext, LLMPredictor, OpenAIEmbedding, PromptHelper
+from llama_index.langchain_helpers.text_splitter import TokenTextSplitter
+from llama_index.node_parser import SimpleNodeParser
+
+llm_predictor = LLMPredictor(llm=OpenAI(model_name='text-davinci-003', temperature=0))
+embed_model = OpenAIEmbedding()
+node_parser = SimpleNodeParser(text_splitter=TokenTextSplitter(chunk_size=1024, chunk_overlap=200))
+prompt_helper = PromptHelper(max_input_size=4096, num_output=256, max_chunk_overlap=20, chunk_size_limit=1024)
+service_context = ServiceContext.from_defaults(
+  llm_predictor=llm_predictor,
+  embed_model=embed_model,
+  node_parser=node_parser,
+  prompt_helper=prompt_helper
+)
+```
+
+## Global ServiceContext
+
+You can specify a different set of defaults for the ServiceContext by setting up a global service context.
+
+With a global service context, any attributes not provided when calling `ServiceContext.from_defaults()` will be pulled from your global service context. If you never define a service context anywhere else, then the global service context will always be used.
+
+You can define a global service context by following these steps:
+
+1. Create a standalone python file that defines a variable called `service_context` that is the `ServiceContext` object containing your desired global settings. The `ServiceContext` defined in this file should include the `is_global=True` keyword argument.
+2. Set an env varialbe called `LLAMA_SERVICE_CONTEXT` that points to a .py file. This can be set using `export LLAMA_SERVICE_CONTEXT="path/to/file.py"` or by setting in python directly using `os.environ['LLAMA_SERVICE_CONTEXT'] = "path/to/file.py"`. 
+3. Use LlamaIndex - the default settings will be automatically pulled from your default service context file!
+
+Here's a quick example of what a global service context file might look like. This service context changes the LLM to `gpt-3.5-turbo`, changes the `chunk_size_limit`, and sets up a `callback_manager` to trace events using the `LlamaDebugHandler`.
+
+The `ServiceContext` defined in this file should include the `is_global=True` keyword argument.
+
+```python
+from langchain.chat_models import ChatOpenAI
+from llama_index import ServiceContext, LLMPredictor
+from llama_index.callbacks import CallbackManager, LlamaDebugHandler
+
+llama_debug = LlamaDebugHandler(print_trace_on_end=True)
+callback_manager = CallbackManager([llama_debug])
+
+llm = ChatOpenAI(model_name='gpt-3.5-turbo', temperature=0)
+llm_predictor = LLMPredictor(llm=llm)
+service_context = ServiceContext.from_defaults(llm_predictor=llm_predictor, chunk_size_limit=512, callback_manager=callback_manager, is_global=True)
+```
+
+Then, to use the global service context, set the variable in your terminal:
+
+```bash
+export LLAMA_SERVICE_CONTEXT="path/to/default_service_context.py"
+```
+
+Or set the environment variable directly in code:
+
+```python
+import os
+os.environ['LLAMA_SERVICE_CONTEXT'] = "path/to/default_service_context.py"
+```

--- a/docs/how_to/customization/service_context.md
+++ b/docs/how_to/customization/service_context.md
@@ -10,7 +10,6 @@ The following optional items can be set in the service context:
 - node_parser: The parser that converts documents into nodes.
 - chunk_size_limit: The maximum size of a node. Is used for the prompt helper and node parser when they aren't provided.
 - callback_managaer: The callback manager object that calls it's handlers on events. Provides basic logging and tracing capabilities.
-- is_global: A boolean that should be set when you are defining a global service context
 
 Here's a complete example that sets up all objects using their default settings:
 
@@ -38,15 +37,9 @@ You can specify a different set of defaults for the ServiceContext by setting up
 
 With a global service context, any attributes not provided when calling `ServiceContext.from_defaults()` will be pulled from your global service context. If you never define a service context anywhere else, then the global service context will always be used.
 
-You can define a global service context by following these steps:
+Here's a quick example of what a global service context might look like. This service context changes the LLM to `gpt-3.5-turbo`, changes the `chunk_size_limit`, and sets up a `callback_manager` to trace events using the `LlamaDebugHandler`.
 
-1. Create a standalone python file that defines a variable called `service_context` that is the `ServiceContext` object containing your desired global settings. The `ServiceContext` defined in this file should include the `is_global=True` keyword argument.
-2. Set an env varialbe called `LLAMA_SERVICE_CONTEXT` that points to a .py file. This can be set using `export LLAMA_SERVICE_CONTEXT="path/to/file.py"` or by setting in python directly using `os.environ['LLAMA_SERVICE_CONTEXT'] = "path/to/file.py"`. 
-3. Use LlamaIndex - the default settings will be automatically pulled from your default service context file!
-
-Here's a quick example of what a global service context file might look like. This service context changes the LLM to `gpt-3.5-turbo`, changes the `chunk_size_limit`, and sets up a `callback_manager` to trace events using the `LlamaDebugHandler`.
-
-The `ServiceContext` defined in this file should include the `is_global=True` keyword argument.
+First, define the service context:
 
 ```python
 from langchain.chat_models import ChatOpenAI
@@ -61,15 +54,9 @@ llm_predictor = LLMPredictor(llm=llm)
 service_context = ServiceContext.from_defaults(llm_predictor=llm_predictor, chunk_size_limit=512, callback_manager=callback_manager, is_global=True)
 ```
 
-Then, to use the global service context, set the variable in your terminal:
-
-```bash
-export LLAMA_SERVICE_CONTEXT="path/to/default_service_context.py"
-```
-
-Or set the environment variable directly in code:
+Then, set the global service context object
 
 ```python
-import os
-os.environ['LLAMA_SERVICE_CONTEXT'] = "path/to/default_service_context.py"
+import llama_index
+llama_index.global_service_context = service_context
 ```

--- a/docs/how_to/customization/service_context.md
+++ b/docs/how_to/customization/service_context.md
@@ -57,6 +57,6 @@ service_context = ServiceContext.from_defaults(llm_predictor=llm_predictor, chun
 Then, set the global service context object
 
 ```python
-import llama_index
-llama_index.global_service_context = service_context
+from llama_index import set_global_service_context
+set_global_service_context(service_context)
 ```

--- a/llama_index/__init__.py
+++ b/llama_index/__init__.py
@@ -7,6 +7,7 @@ with open(Path(__file__).absolute().parents[0] / "VERSION") as _f:
 
 import logging
 from logging import NullHandler
+from typing import Optional
 
 from llama_index.data_structs.struct_type import IndexStructType
 
@@ -185,3 +186,6 @@ __all__ = [
 
 # NOTE: keep for backwards compatibility
 SQLContextBuilder = SQLDocumentContextBuilder
+
+# global service context for ServiceContext.from_defaults()
+global_service_context: Optional[ServiceContext] = None

--- a/llama_index/__init__.py
+++ b/llama_index/__init__.py
@@ -45,7 +45,10 @@ from llama_index.indices.query.response_synthesis import ResponseSynthesizer
 from llama_index.indices.query.schema import QueryBundle
 
 # for composability
-from llama_index.indices.service_context import ServiceContext, set_global_service_context
+from llama_index.indices.service_context import (
+    ServiceContext,
+    set_global_service_context,
+)
 from llama_index.indices.struct_store.sql import GPTSQLStructStoreIndex
 from llama_index.indices.tree import GPTTreeIndex
 from llama_index.indices.vector_store import GPTVectorStoreIndex
@@ -182,7 +185,7 @@ __all__ = [
     "load_indices_from_storage",
     "QueryBundle",
     "ResponseSynthesizer",
-    "set_global_service_context"
+    "set_global_service_context",
 ]
 
 # NOTE: keep for backwards compatibility

--- a/llama_index/__init__.py
+++ b/llama_index/__init__.py
@@ -45,7 +45,7 @@ from llama_index.indices.query.response_synthesis import ResponseSynthesizer
 from llama_index.indices.query.schema import QueryBundle
 
 # for composability
-from llama_index.indices.service_context import ServiceContext
+from llama_index.indices.service_context import ServiceContext, set_global_service_context
 from llama_index.indices.struct_store.sql import GPTSQLStructStoreIndex
 from llama_index.indices.tree import GPTTreeIndex
 from llama_index.indices.vector_store import GPTVectorStoreIndex
@@ -182,6 +182,7 @@ __all__ = [
     "load_indices_from_storage",
     "QueryBundle",
     "ResponseSynthesizer",
+    "set_global_service_context"
 ]
 
 # NOTE: keep for backwards compatibility

--- a/llama_index/indices/service_context.py
+++ b/llama_index/indices/service_context.py
@@ -1,3 +1,7 @@
+import importlib
+import logging
+import os
+from pathlib import Path
 from dataclasses import dataclass
 from typing import Optional
 
@@ -11,6 +15,10 @@ from llama_index.llm_predictor.base import BaseLLMPredictor
 from llama_index.logger import LlamaLogger
 from llama_index.node_parser.interface import NodeParser
 from llama_index.node_parser.simple import SimpleNodeParser
+
+
+logger = logging.getLogger(__name__)
+global_service_context = None
 
 
 def _get_default_node_parser(
@@ -66,10 +74,16 @@ class ServiceContext:
         llama_logger: Optional[LlamaLogger] = None,
         callback_manager: Optional[CallbackManager] = None,
         chunk_size_limit: Optional[int] = None,
+        is_global: Optional[bool] = False,
     ) -> "ServiceContext":
         """Create a ServiceContext from defaults.
         If an argument is specified, then use the argument value provided for that
         parameter. If an argument is not specified, then use the default value.
+
+        is_global is used to specify if the from_defaults call should set the global
+        service context. If a global service context is set, then the values set on
+        the global service context will be used for the attributes not provided in
+        the from_defaults call.
 
         Args:
             llm_predictor (Optional[BaseLLMPredictor]): LLMPredictor
@@ -78,8 +92,56 @@ class ServiceContext:
             node_parser (Optional[NodeParser]): NodeParser
             llama_logger (Optional[LlamaLogger]): LlamaLogger (deprecated)
             chunk_size_limit (Optional[int]): chunk_size_limit
+            callback_manager (Optional[CallbackManager]): CallbackManager
+            is_global: Optional[bool]:
+                Specifies if the arguments should create a global service context
 
         """
+        global global_service_context
+
+        service_context_file = os.environ.get("LLAMA_SERVICE_CONTEXT", "")
+        if (
+            not is_global
+            and global_service_context is None
+            and service_context_file
+            and os.path.exists(service_context_file)
+        ):
+            # dynamically load module from string path
+            module_name = Path(service_context_file).stem
+            spec = importlib.util.spec_from_file_location(
+                module_name, service_context_file
+            )
+
+            if spec and spec.loader:
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+
+                if hasattr(module, "service_context"):
+                    global_service_context = module.service_context
+                    # return global_service_context
+                else:
+                    logger.warning(
+                        "LLAMA_SERVICE_CONTEXT does not point to a valid python file "
+                        "that defines a service_context object. Continuing without it."
+                    )
+            else:
+                logger.warning(
+                    "LLAMA_SERVICE_CONTEXT does not point to a valid python file. "
+                    "Continuing without it."
+                )
+
+        if global_service_context is not None:
+            return cls.from_service_context(
+                global_service_context,
+                llm_predictor=llm_predictor,
+                prompt_helper=prompt_helper,
+                embed_model=embed_model,
+                node_parser=node_parser,
+                llama_logger=llama_logger,
+                callback_manager=callback_manager,
+                chunk_size_limit=chunk_size_limit,
+            )
+
         callback_manager = callback_manager or CallbackManager([])
         llm_predictor = llm_predictor or LLMPredictor()
         llm_predictor.callback_manager = callback_manager
@@ -97,6 +159,53 @@ class ServiceContext:
         )
 
         llama_logger = llama_logger or LlamaLogger()
+
+        return cls(
+            llm_predictor=llm_predictor,
+            embed_model=embed_model,
+            prompt_helper=prompt_helper,
+            node_parser=node_parser,
+            llama_logger=llama_logger,  # deprecated
+            callback_manager=callback_manager,
+            chunk_size_limit=chunk_size_limit,
+        )
+
+    @classmethod
+    def from_service_context(
+        cls,
+        service_context: "ServiceContext",
+        llm_predictor: Optional[BaseLLMPredictor] = None,
+        prompt_helper: Optional[PromptHelper] = None,
+        embed_model: Optional[BaseEmbedding] = None,
+        node_parser: Optional[NodeParser] = None,
+        llama_logger: Optional[LlamaLogger] = None,
+        callback_manager: Optional[CallbackManager] = None,
+        chunk_size_limit: Optional[int] = None,
+    ) -> "ServiceContext":
+        """Instaniate a new serivce context using a previous as the defaults."""
+
+        callback_manager = callback_manager or service_context.callback_manager
+        llm_predictor = llm_predictor or service_context.llm_predictor
+        llm_predictor.callback_manager = callback_manager
+
+        # NOTE: the embed_model isn't used in all indices
+        embed_model = embed_model or service_context.embed_model
+        embed_model.callback_manager = callback_manager
+
+        # need to ensure chunk_size_limit can still be overwritten from the global
+        prompt_helper = prompt_helper or service_context.prompt_helper
+        if chunk_size_limit:
+            prompt_helper = PromptHelper.from_llm_predictor(
+                llm_predictor, chunk_size_limit=chunk_size_limit
+            )
+
+        node_parser = node_parser or service_context.node_parser
+        if chunk_size_limit:
+            node_parser = _get_default_node_parser(
+                chunk_size_limit=chunk_size_limit, callback_manager=callback_manager
+            )
+
+        llama_logger = llama_logger or service_context.llama_logger
 
         return cls(
             llm_predictor=llm_predictor,

--- a/llama_index/indices/service_context.py
+++ b/llama_index/indices/service_context.py
@@ -175,3 +175,8 @@ class ServiceContext:
             callback_manager=callback_manager,
             chunk_size_limit=chunk_size_limit,
         )
+
+
+def set_global_service_context(service_context: Optional[ServiceContext]) -> None:
+    """Helper function to set the global service context."""
+    llama_index.global_service_context = service_context

--- a/llama_index/indices/service_context.py
+++ b/llama_index/indices/service_context.py
@@ -1,10 +1,8 @@
-import importlib
 import logging
-import os
-from pathlib import Path
 from dataclasses import dataclass
 from typing import Optional
 
+import llama_index
 from llama_index.callbacks.base import CallbackManager
 from llama_index.embeddings.base import BaseEmbedding
 from llama_index.embeddings.openai import OpenAIEmbedding
@@ -18,7 +16,6 @@ from llama_index.node_parser.simple import SimpleNodeParser
 
 
 logger = logging.getLogger(__name__)
-global_service_context = None
 
 
 def _get_default_node_parser(
@@ -74,16 +71,13 @@ class ServiceContext:
         llama_logger: Optional[LlamaLogger] = None,
         callback_manager: Optional[CallbackManager] = None,
         chunk_size_limit: Optional[int] = None,
-        is_global: Optional[bool] = False,
     ) -> "ServiceContext":
         """Create a ServiceContext from defaults.
         If an argument is specified, then use the argument value provided for that
         parameter. If an argument is not specified, then use the default value.
 
-        is_global is used to specify if the from_defaults call should set the global
-        service context. If a global service context is set, then the values set on
-        the global service context will be used for the attributes not provided in
-        the from_defaults call.
+        You can change the base defaults by setting llama_index.global_service_context
+        to a ServiceContext object with your desired settings.
 
         Args:
             llm_predictor (Optional[BaseLLMPredictor]): LLMPredictor
@@ -93,46 +87,11 @@ class ServiceContext:
             llama_logger (Optional[LlamaLogger]): LlamaLogger (deprecated)
             chunk_size_limit (Optional[int]): chunk_size_limit
             callback_manager (Optional[CallbackManager]): CallbackManager
-            is_global: Optional[bool]:
-                Specifies if the arguments should create a global service context
 
         """
-        global global_service_context
-
-        service_context_file = os.environ.get("LLAMA_SERVICE_CONTEXT", "")
-        if (
-            not is_global
-            and global_service_context is None
-            and service_context_file
-            and os.path.exists(service_context_file)
-        ):
-            # dynamically load module from string path
-            module_name = Path(service_context_file).stem
-            spec = importlib.util.spec_from_file_location(
-                module_name, service_context_file
-            )
-
-            if spec and spec.loader:
-                module = importlib.util.module_from_spec(spec)
-                spec.loader.exec_module(module)
-
-                if hasattr(module, "service_context"):
-                    global_service_context = module.service_context
-                    # return global_service_context
-                else:
-                    logger.warning(
-                        "LLAMA_SERVICE_CONTEXT does not point to a valid python file "
-                        "that defines a service_context object. Continuing without it."
-                    )
-            else:
-                logger.warning(
-                    "LLAMA_SERVICE_CONTEXT does not point to a valid python file. "
-                    "Continuing without it."
-                )
-
-        if global_service_context is not None:
+        if llama_index.global_service_context is not None:
             return cls.from_service_context(
-                global_service_context,
+                llama_index.global_service_context,
                 llm_predictor=llm_predictor,
                 prompt_helper=prompt_helper,
                 embed_model=embed_model,


### PR DESCRIPTION
This PR adds an initial implementation for a global service context. The new and improved service context will dynamically import `service_context` from the `.py` file defined under the `LLAMA_SERVICE_CONTEXT` env variable.

This design also allows users to config on top of their existing global defaults.

This implementation might be divisive, but here's my justification for two main components of the design

1. Define the global service context existing API's
Rather than trying to decompose complex settings into a `yaml` format or similar, just let the user configure everything in python using the API they are already familiar with. This means we don't have to maintain a separate config file format, and also any LLMPredictor (including huggingface!) and embed model can be easily set the in global config 

2. Singleton pattern
I don't see a way to do this without using a singleton pattern. While OpenAI/ChatOpenAI are quick to initialize, if the user configures a HuggingfaceLLMPredictor, we don't want to reload this every time `from_defaults()` is called, because that would be a major performance hit.