### PR TITLE
doc: Fix Storing Table Context within an Index

### DIFF
--- a/docs/guides/tutorials/sql_guide.md
+++ b/docs/guides/tutorials/sql_guide.md
@@ -245,15 +245,23 @@ query_str = "Which city has the highest population?"
 
 # query the table schema index using the helper method
 # to retrieve table context
-SQLContextContainerBuilder.query_index_for_context(
+context_builder.query_index_for_context(
     table_schema_index,
     query_str,
     store_context_str=True
 )
 
+context_container = context_builder.build_context_container()
+
+index = GPTSQLStructStoreIndex(
+    [],
+    sql_database=sql_database,
+    sql_context_container=context_container
+)
+
 # query the SQL index with the table context
 query_engine = index.as_query_engine()
-response = query_engine.query(query_str, sql_context_container=context_container)
+response = query_engine.query(query_str)
 print(response)
 
 ```


### PR DESCRIPTION
Hello, 

While attempting to follow the example in the [Storing Table Context within an Index](https://gpt-index.readthedocs.io/en/latest/guides/tutorials/sql_guide.html#storing-table-context-within-an-index) section of the documentation, I encountered some errors. To help others avoid similar issues, I have proposed some amendments to the documentation. This amended implementation seems likely to correspond with the intent as described in the documentation.
