### PR TITLE
Improve storage docs + other goodies

### DIFF
--- a/docs/how_to/customization/custom_llms.md
+++ b/docs/how_to/customization/custom_llms.md
@@ -205,21 +205,22 @@ num_output = 256
 max_chunk_overlap = 20
 prompt_helper = PromptHelper(max_input_size, num_output, max_chunk_overlap)
 
+# store the pipeline/model outisde of the LLM class to avoid memory issues
+model_name = "facebook/opt-iml-max-30b"
+pipeline = pipeline("text-generation", model=model_name, device="cuda:0", model_kwargs={"torch_dtype":torch.bfloat16})
 
 class CustomLLM(LLM):
-    model_name = "facebook/opt-iml-max-30b"
-    pipeline = pipeline("text-generation", model=model_name, device="cuda:0", model_kwargs={"torch_dtype":torch.bfloat16})
-
+    
     def _call(self, prompt: str, stop: Optional[List[str]] = None) -> str:
         prompt_length = len(prompt)
-        response = self.pipeline(prompt, max_new_tokens=num_output)[0]["generated_text"]
+        response = pipeline(prompt, max_new_tokens=num_output)[0]["generated_text"]
 
         # only return newly generated tokens
         return response[prompt_length:]
 
     @property
     def _identifying_params(self) -> Mapping[str, Any]:
-        return {"name_of_model": self.model_name}
+        return {"name_of_model": model_name}
 
     @property
     def _llm_type(self) -> str:

--- a/docs/how_to/integrations/vector_stores.md
+++ b/docs/how_to/integrations/vector_stores.md
@@ -2,12 +2,15 @@
 
 LlamaIndex offers multiple integration points with vector stores / vector databases:
 
-1. LlamaIndex can load data from vector stores, similar to any other data connector. This data can then be used within LlamaIndex data structures.
-2. LlamaIndex can use a vector store itself as an index. Like any other index, this index can store documents and be used to answer queries.
+1. LlamaIndex can use a vector store itself as an index. Like any other index, this index can store documents and be used to answer queries.
+2. LlamaIndex can load data from vector stores, similar to any other data connector. This data can then be used within LlamaIndex data structures.
 
-## Loading Data from Vector Stores using Data Connector
+(vector-store-index)=
 
-LlamaIndex supports loading data from the following sources. See [Data Connectors](/how_to/data_connectors.md) for more details and API documentation.
+## Using a Vector Store as an Index
+
+LlamaIndex also supports different vector stores
+as the storage backend for `GPTVectorStoreIndex`.
 
 - Chroma (`ChromaReader`) [Installation](https://docs.trychroma.com/getting-started)
 - DeepLake (`DeepLakeReader`) [Installation](https://docs.deeplake.ai/en/latest/Installation.html)
@@ -19,116 +22,10 @@ LlamaIndex supports loading data from the following sources. See [Data Connector
 - Zilliz (`MilvusReader`). [Quickstart](https://zilliz.com/doc/quick_start)
 - MyScale (`MyScaleReader`). [Quickstart](https://docs.myscale.com/en/quickstart/). [Installation/Python Client](https://docs.myscale.com/en/python-client/).
 
-Chroma stores both documents and vectors. This is an example of how to use Chroma:
-
-```python
-
-from llama_index.readers.chroma import ChromaReader
-from llama_index.indices import GPTListIndex
-
-# The chroma reader loads data from a persisted Chroma collection.
-# This requires a collection name and a persist directory.
-reader = ChromaReader(
-    collection_name="chroma_collection",
-    persist_directory="examples/data_connectors/chroma_collection"
-)
-
-query_vector=[n1, n2, n3, ...]
-
-documents = reader.load_data(collection_name="demo", query_vector=query_vector, limit=5)
-index = GPTListIndex.from_documents(documents)
-
-query_engine = index.as_query_engine()
-response = query_engine.query("<query_text>")
-display(Markdown(f"<b>{response}</b>"))
-```
-
-Qdrant also stores both documents and vectors. This is an example of how to use Qdrant:
-
-```python
-
-from llama_index.readers.qdrant import QdrantReader
-
-reader = QdrantReader(host="localhost")
-
-# the query_vector is an embedding representation of your query_vector
-# Example query_vector
-# query_vector = [0.3, 0.3, 0.3, 0.3, ...]
-
-query_vector = [n1, n2, n3, ...]
-
-# NOTE: Required args are collection_name, query_vector.
-# See the Python client: https;//github.com/qdrant/qdrant_client
-# for more details
-
-documents = reader.load_data(collection_name="demo", query_vector=query_vector, limit=5)
-
-```
-
-NOTE: Since Weaviate can store a hybrid of document and vector objects, the user may either choose to explicitly specify `class_name` and `properties` in order to query documents, or they may choose to specify a raw GraphQL query. See below for usage.
-
-```python
-# option 1: specify class_name and properties
-
-# 1) load data using class_name and properties
-documents = reader.load_data(
-    class_name="<class_name>",
-    properties=["property1", "property2", "..."],
-    separate_documents=True
-)
-
-# 2) example GraphQL query
-query = """
-{
-    Get {
-        <class_name> {
-            <property1>
-            <property2>
-        }
-    }
-}
-"""
-
-documents = reader.load_data(graphql_query=query, separate_documents=True)
-```
-
-NOTE: Both Pinecone and Faiss data loaders assume that the respective data sources only store vectors; text content is stored elsewhere. Therefore, both data loaders require that the user specifies an `id_to_text_map` in the load_data call.
-
-For instance, this is an example usage of the Pinecone data loader `PineconeReader`:
-
-```python
-
-from llama_index.readers.pinecone import PineconeReader
-
-reader = PineconeReader(api_key=api_key, environment="us-west1-gcp")
-
-id_to_text_map = {
-    "id1": "text blob 1",
-    "id2": "text blob 2",
-}
-
-query_vector=[n1, n2, n3, ..]
-
-documents = reader.load_data(
-    index_name="quickstart", id_to_text_map=id_to_text_map, top_k=3, vector=query_vector, separate_documents=True
-)
-
-```
-
-[Example notebooks can be found here](https://github.com/jerryjliu/llama_index/tree/main/examples/data_connectors).
-
-(vector-store-index)=
-
-## Using a Vector Store as an Index
-
-LlamaIndex also supports different vector stores
-as the storage backend for `GPTVectorStoreIndex`.
-
 A detailed API reference is [found here](/reference/indices/vector_store.rst).
 
 Similar to any other index within LlamaIndex (tree, keyword table, list), `GPTVectorStoreIndex` can be constructed upon any collection
-of documents.
-We use the vector store within the index to store embeddings for the input text chunks.
+of documents. We use the vector store within the index to store embeddings for the input text chunks.
 
 Once constructed, the index can be used for querying.
 
@@ -386,6 +283,109 @@ vector_store = MyScaleVectorStore(
 ```
 
 [Example notebooks can be found here](https://github.com/jerryjliu/llama_index/tree/main/docs/examples/vector_stores).
+
+## Loading Data from Vector Stores using Data Connector
+
+LlamaIndex supports oading data from the following sources. See [Data Connectors](/how_to/data_connectors.md) for more details and API documentation.
+
+Chroma stores both documents and vectors. This is an example of how to use Chroma:
+
+```python
+
+from llama_index.readers.chroma import ChromaReader
+from llama_index.indices import GPTListIndex
+
+# The chroma reader loads data from a persisted Chroma collection.
+# This requires a collection name and a persist directory.
+reader = ChromaReader(
+    collection_name="chroma_collection",
+    persist_directory="examples/data_connectors/chroma_collection"
+)
+
+query_vector=[n1, n2, n3, ...]
+
+documents = reader.load_data(collection_name="demo", query_vector=query_vector, limit=5)
+index = GPTListIndex.from_documents(documents)
+
+query_engine = index.as_query_engine()
+response = query_engine.query("<query_text>")
+display(Markdown(f"<b>{response}</b>"))
+```
+
+Qdrant also stores both documents and vectors. This is an example of how to use Qdrant:
+
+```python
+
+from llama_index.readers.qdrant import QdrantReader
+
+reader = QdrantReader(host="localhost")
+
+# the query_vector is an embedding representation of your query_vector
+# Example query_vector
+# query_vector = [0.3, 0.3, 0.3, 0.3, ...]
+
+query_vector = [n1, n2, n3, ...]
+
+# NOTE: Required args are collection_name, query_vector.
+# See the Python client: https;//github.com/qdrant/qdrant_client
+# for more details
+
+documents = reader.load_data(collection_name="demo", query_vector=query_vector, limit=5)
+
+```
+
+NOTE: Since Weaviate can store a hybrid of document and vector objects, the user may either choose to explicitly specify `class_name` and `properties` in order to query documents, or they may choose to specify a raw GraphQL query. See below for usage.
+
+```python
+# option 1: specify class_name and properties
+
+# 1) load data using class_name and properties
+documents = reader.load_data(
+    class_name="<class_name>",
+    properties=["property1", "property2", "..."],
+    separate_documents=True
+)
+
+# 2) example GraphQL query
+query = """
+{
+    Get {
+        <class_name> {
+            <property1>
+            <property2>
+        }
+    }
+}
+"""
+
+documents = reader.load_data(graphql_query=query, separate_documents=True)
+```
+
+NOTE: Both Pinecone and Faiss data loaders assume that the respective data sources only store vectors; text content is stored elsewhere. Therefore, both data loaders require that the user specifies an `id_to_text_map` in the load_data call.
+
+For instance, this is an example usage of the Pinecone data loader `PineconeReader`:
+
+```python
+
+from llama_index.readers.pinecone import PineconeReader
+
+reader = PineconeReader(api_key=api_key, environment="us-west1-gcp")
+
+id_to_text_map = {
+    "id1": "text blob 1",
+    "id2": "text blob 2",
+}
+
+query_vector=[n1, n2, n3, ..]
+
+documents = reader.load_data(
+    index_name="quickstart", id_to_text_map=id_to_text_map, top_k=3, vector=query_vector, separate_documents=True
+)
+
+```
+
+[Example notebooks can be found here](https://github.com/jerryjliu/llama_index/tree/main/examples/data_connectors).
+
 
 ```{toctree}
 ---

--- a/docs/how_to/storage/customization.md
+++ b/docs/how_to/storage/customization.md
@@ -31,7 +31,7 @@ from llama_index.node_parser import SimpleNodeParser
 parser = SimpleNodeParser()
 nodes = parser.get_nodes_from_documents(documents)
 
-# create storage context
+# create storage context using default stores
 storage_context = StorageContext.from_defaults(
     docstore=SimpleDocumentStore(),
     vector_store=SimpleVectorStore(),
@@ -43,6 +43,91 @@ storage_context.docstore.add_documents(nodes)
 
 # build index
 index = GPTVectorStoreIndex(nodes, storage_context=storage_context)
+
+# save index
+index.storage_context.persist(persist_dir="<persist_dir>")
+
+# can also set index_id to save multiple indexes to the same folder
+index.set_index_id = "<index_id>"
+index.storage_context.persist(persist_dir="<persist_dir>")
+
+# to load index later, make sure you setup the storage context
+# this will loaded the persisted stores from persist_dir
+storage_context = StorageContext.from_defaults(
+    persist_dir="<persist_dir>"
+)
+
+# then load the index object
+from llama_index import load_index_from_storage
+loaded_index = load_index_from_storage(storage_context)
+
+# if loading an index from a persist_dir containing multiple indexes
+loaded_index = load_index_from_storage(storage_context, index_id="<index_id>")
+
+# if loading multiple indexes from a persist dir
+loaded_indicies = load_index_from_storage(storage_context, index_ids=["<index_id>", ...])
 ```
+
 You can customize the underlying storage with a one-line change to instantiate different document stores, index stores, and vector stores.
 See [Document Stores](/how_to/storage/docstores.md), [Vector Stores](/how_to/storage/vector_stores.md), [Index Stores](/how_to/storage/index_stores.md) guides for more details.
+
+For saving and loading a graph/composable index, see the [full guide here](/how_to/index_structs/composability.md).
+
+### Vector Store Integrations and Storage
+
+Most of our vector store integrations store the entire index (vectors + text) in the vector store itself. This comes with the major benefit of not having to exlicitly persist the index as shown above, since the vector store is already hosted and persisting the data in our index.
+
+The vector stores that support this practice are:
+
+- ChatGPTRetrievalPluginClient
+- ChromaVectorStore
+- LanceDBVectorStore
+- MetalVectorStore
+- MilvusVectorStore
+- MyScaleVectorStore
+- OpensearchVectorStore
+- PineconeVectorStore
+- QdrantVectorStore
+- RedisVectorStore
+- WeaviateVectorStore
+
+A small example using Pinecone is below:
+
+```python
+import pinecone
+from llama_index import GPTVectorStoreIndex, SimpleDirectoryReader
+from llama_index.vector_stores import PineconeVectorStore
+
+# Creating a Pinecone index
+api_key = "api_key"
+pinecone.init(api_key=api_key, environment="us-west1-gcp")
+pinecone.create_index(
+    "quickstart",
+    dimension=1536,
+    metric="euclidean",
+    pod_type="p1"
+)
+index = pinecone.Index("quickstart")
+
+# can define filters specific to this vector index (so you can
+# reuse pinecone indexes)
+metadata_filters = {"title": "paul_graham_essay"}
+
+# construct vector store
+vector_store = PineconeVectorStore(
+    pinecone_index=index,
+    metadata_filters=metadata_filters
+)
+
+# create storage context
+storage_context = StorageContext.from_defaults(vector_store=vector_store)
+
+# load documents
+documents = SimpleDirectoryReader("./data").load_data()
+
+# create index, which will insert documents/vectors to pinecone
+index = GPTVectorStoreIndex.from_documents(documents, storage_context=storage_context)
+
+# re-build/load the index by conntect to the same vector store
+loaded_index = GPTVectorStoreIndex([], storage_context=storage_context)
+```


### PR DESCRIPTION
This PR does three things
1. Improves docs around the storage context, adding more examples, links, and explanations
2. Re-orders the vector store integrations page. The actual vector stores should come before the loaders (since people are probably more interested in integrating the actual vector store vs. loading data)
3. Small nit change to the `CustomLLM` example to avoid memory issues due to pydantic 