### PR TITLE
Remove duplicate graph synthesize events

### DIFF
--- a/llama_index/query_engine/graph_query_engine.py
+++ b/llama_index/query_engine/graph_query_engine.py
@@ -79,15 +79,7 @@ class ComposableGraphQueryEngine(BaseQueryEngine):
                 query_bundle, nodes_for_synthesis, additional_source_nodes
             )
         else:
-            synth_event_id = self.callback_manager.on_event_start(
-                CBEventType.SYNTHESIZE
-            )
             response = query_engine.synthesize(query_bundle, nodes)
-            self.callback_manager.on_event_end(
-                CBEventType.SYNTHESIZE,
-                payload={"response": response},
-                event_id=synth_event_id,
-            )
 
         self.callback_manager.on_event_end(CBEventType.QUERY, event_id=event_id)
         return response

--- a/llama_index/query_engine/graph_query_engine.py
+++ b/llama_index/query_engine/graph_query_engine.py
@@ -75,16 +75,8 @@ class ComposableGraphQueryEngine(BaseQueryEngine):
                 )
                 nodes_for_synthesis.append(node_with_score)
                 additional_source_nodes.extend(source_nodes)
-            synth_event_id = self.callback_manager.on_event_start(
-                CBEventType.SYNTHESIZE
-            )
             response = query_engine.synthesize(
                 query_bundle, nodes_for_synthesis, additional_source_nodes
-            )
-            self.callback_manager.on_event_end(
-                CBEventType.SYNTHESIZE,
-                payload={"response": response},
-                event_id=synth_event_id,
             )
         else:
             synth_event_id = self.callback_manager.on_event_start(


### PR DESCRIPTION
First observed in this PR: https://github.com/jerryjliu/llama_index/pull/3377

The synth event is in the response_synethsizer now, no need to duplicate it