### PR TITLE
add extra_info docs

### DIFF
--- a/docs/guides/primer/usage_pattern.md
+++ b/docs/guides/primer/usage_pattern.md
@@ -136,13 +136,7 @@ See the [Update Index How-To](/how_to/index_structs/update.md) for details and a
 
 ### Customizing Documents
 
-Documents also offer the chance to include useful metadata. Using the `extra_info` dictionary on each document, additional information can be included to help inform responses and track down sources for query responses. This information can be anything, such as filenames or categories, but the only requirement is that the keys must be strings, and the values must be either `str`, `float`, or `int`.
-
-Any information set in the `extra_info` dictionary of each document will show up in the `extra_info` of each source node created from the document.
-
-There are a few ways to set up this dictionary:
-
-1. In the document constructor:
+When creating documents, you can also attach useful metadata. Any metadata added to a document will be copied to the nodes that get created from their respective source document.
 
 ```python
 document = Document(
@@ -154,21 +148,7 @@ document = Document(
 )
 ```
 
-2. After the document is created:
-
-```python
-document.extra_info = {'filename', '<doc_file_name>'}
-```
-
-3. Set the filename automatically using the `SimpleDirectoryReader` and `file_metadata` hook. This will automatically run the hook on each document to set the `extra_info` field:
-
-```python
-from llama_index import SimpleDirectoryReader
-filename_fn = lambda filename: {'file_name': filename}
-
-# automatically sets the extra_info of each document according to filename_fn
-documents = SimpleDirectoryReader('./data', file_metadata=filename_fn)
-```
+More information and approaches to this are discussed in the section [Customizing Documents](/how_to/customization/custom_documents.md).
 
 ### Customizing LLM's
 

--- a/docs/guides/primer/usage_pattern.md
+++ b/docs/guides/primer/usage_pattern.md
@@ -16,7 +16,7 @@ through the `load_data` function, e.g.:
 ```python
 from llama_index import SimpleDirectoryReader
 
-documents = SimpleDirectoryReader('data').load_data()
+documents = SimpleDirectoryReader('./data').load_data()
 ```
 
 You can also choose to construct documents manually. LlamaIndex exposes the `Document` struct.
@@ -133,6 +133,42 @@ index.insert_nodes(nodes)
 ```
 
 See the [Update Index How-To](/how_to/index_structs/update.md) for details and an example notebook.
+
+### Customizing Documents
+
+Documents also offer the chance to include useful metadata. Using the `extra_info` dictionary on each document, additional information can be included to help inform responses and track down sources for query responses. This information can be anything, such as filename's or categories, but the only requirement is that the keys must be strings, and the values must be either `str`, `float`, or `int`.
+
+Any information set in the `extra_info` dictionary of each document will show up in the `extra_info` of each source node created from the document.
+
+There are a few ways to set up this dictionary:
+
+1. In the document constructor:
+
+```python
+document = Document(
+    'text', 
+    extra_info={
+        'filename', '<doc_file_name>', 
+        'category': '<category>'
+    }
+)
+```
+
+2. After the document is created:
+
+```python
+document.extra_info = {'filename', '<doc_file_name>'}
+```
+
+3. Set the filename automatically using the `SimpleDirectoryReader` and `file_metadata` hook. This will automatically run the hook on each document to set the `extra_info` field:
+
+```python
+from llama_index import SimpleDirectoryReader
+filename_fn = lambda filename: {'file_name': filename}
+
+# automatically sets the extra_info of each document according to filename_fn
+documents = SimpleDirectoryReader('./data', file_metadata=filename_fn)
+```
 
 ### Customizing LLM's
 

--- a/docs/guides/primer/usage_pattern.md
+++ b/docs/guides/primer/usage_pattern.md
@@ -136,7 +136,7 @@ See the [Update Index How-To](/how_to/index_structs/update.md) for details and a
 
 ### Customizing Documents
 
-Documents also offer the chance to include useful metadata. Using the `extra_info` dictionary on each document, additional information can be included to help inform responses and track down sources for query responses. This information can be anything, such as filename's or categories, but the only requirement is that the keys must be strings, and the values must be either `str`, `float`, or `int`.
+Documents also offer the chance to include useful metadata. Using the `extra_info` dictionary on each document, additional information can be included to help inform responses and track down sources for query responses. This information can be anything, such as filenames or categories, but the only requirement is that the keys must be strings, and the values must be either `str`, `float`, or `int`.
 
 Any information set in the `extra_info` dictionary of each document will show up in the `extra_info` of each source node created from the document.
 

--- a/docs/how_to/customization/custom_documents.md
+++ b/docs/how_to/customization/custom_documents.md
@@ -1,0 +1,35 @@
+### Customizing Documents
+
+Documents also offer the chance to include useful metadata. Using the `extra_info` dictionary on each document, additional information can be included to help inform responses and track down sources for query responses. This information can be anything, such as filenames or categories, but the only requirement is that the keys must be strings, and the values must be either `str`, `float`, or `int`.
+
+Any information set in the `extra_info` dictionary of each document will show up in the `extra_info` of each source node created from the document.
+
+There are a few ways to set up this dictionary:
+
+1. In the document constructor:
+
+```python
+document = Document(
+    'text', 
+    extra_info={
+        'filename', '<doc_file_name>', 
+        'category': '<category>'
+    }
+)
+```
+
+2. After the document is created:
+
+```python
+document.extra_info = {'filename', '<doc_file_name>'}
+```
+
+3. Set the filename automatically using the `SimpleDirectoryReader` and `file_metadata` hook. This will automatically run the hook on each document to set the `extra_info` field:
+
+```python
+from llama_index import SimpleDirectoryReader
+filename_fn = lambda filename: {'file_name': filename}
+
+# automatically sets the extra_info of each document according to filename_fn
+documents = SimpleDirectoryReader('./data', file_metadata=filename_fn)
+```


### PR DESCRIPTION
This adds some basic docs for extra_info in the usage pattern section.

![image](https://github.com/jerryjliu/llama_index/assets/22285038/60c51e57-5114-4120-963b-3512cd6cd8e4)
