### PR TITLE
Adjust OpenSearch document fields

### DIFF
--- a/llama_index/vector_stores/opensearch.py
+++ b/llama_index/vector_stores/opensearch.py
@@ -40,6 +40,7 @@ class OpensearchVectorClient:
         dim: int,
         embedding_field: str = "embedding",
         text_field: str = "content",
+        extra_info_field: str = "extra_info",
         method: Optional[dict] = None,
         auth: Optional[dict] = None,
     ):
@@ -72,13 +73,16 @@ class OpensearchVectorClient:
                 # docker image.
                 auth["basic_auth"] = ("admin", "admin")
             self._client = httpx.Client(
-                base_url=endpoint, verify=auth["verify"], auth=auth["basic_auth"]
+                base_url=endpoint,
+                verify=auth["verify"],
+                auth=auth["basic_auth"],
             )
 
         self._endpoint = endpoint
         self._dim = dim
         self._index = index
         self._text_field = text_field
+        self._extra_info_field = extra_info_field
         # initialize mapping
         idx_conf = {
             "settings": {"index": {"knn": True, "knn.algo_param.ef_search": 100}},
@@ -105,11 +109,16 @@ class OpensearchVectorClient:
                 {
                     self._text_field: result.node.get_text(),
                     self._embedding_field: result.embedding,
+                    self._extra_info_field: result.node.extra_info,
+                    "node_info": result.node.node_info,
+                    "relationships": result.node.relationships,
                 }
             )
         bulk = "\n".join([json.dumps(v) for v in bulk_req]) + "\n"
         res = self._client.post(
-            "/_bulk", headers={"Content-Type": "application/x-ndjson"}, content=bulk
+            "/_bulk",
+            headers={"Content-Type": "application/x-ndjson"},
+            content=bulk,
         )
         assert res.status_code == 200
         assert not res.json()["errors"], "expected no errors while indexing docs"
@@ -132,7 +141,12 @@ class OpensearchVectorClient:
             json={
                 "size": k,
                 "query": {
-                    "knn": {self._embedding_field: {"vector": query_embedding, "k": k}}
+                    "knn": {
+                        self._embedding_field: {
+                            "vector": query_embedding,
+                            "k": k,
+                        }
+                    }
                 },
             },
         )
@@ -142,8 +156,17 @@ class OpensearchVectorClient:
         for hit in res.json()["hits"]["hits"]:
             source = hit["_source"]
             text = source[self._text_field]
+            extra_info = source.get(self._extra_info_field)
             doc_id = hit["_id"]
-            node = Node(text=text, extra_info=source, doc_id=doc_id)
+            node_info = source.get("node_info")
+            relationships = source.get("relationships")
+            node = Node(
+                text=text,
+                extra_info=extra_info,
+                doc_id=doc_id,
+                node_info=node_info,
+                relationships=relationships,
+            )
             ids.append(doc_id)
             nodes.append(node)
             scores.append(hit["_score"])


### PR DESCRIPTION
### Added
* Store `extra_info`, `node_info`, and `relationships` as fields on the OpenSearch document.
  * There are [helper methods](https://github.com/jerryjliu/llama_index/blob/8c40ecbb74fc1d74e9ee278422e34fa4185904d8/llama_index/vector_stores/utils.py) to transform node metadata to and from a serialized string, but the expected usage pattern for OpenSearch is storing the nested JSON data directly. In case users would want to interact with the OpenSearch documents directly, it's best to avoid serialization here.

### Changed
* For `extra_info`, parse the retrieved OpenSearch document fields rather than dumping `_source`.
  * We will now insert `extra_info` into a dedicated field on the OpenSearch document, and will pull it back out directly during retrieval.
  * This should fix https://github.com/jerryjliu/llama_index/issues/3788. Before, we naively dumped `_source` which included the embedding, failing the validation for a flat metadata dict.