### PR TITLE
fix typo namespace and format the code

### DIFF
--- a/llama_index/storage/docstore/simple_docstore.py
+++ b/llama_index/storage/docstore/simple_docstore.py
@@ -1,14 +1,16 @@
 import os
-import fsspec
 from typing import Optional
+
+import fsspec
+
 from llama_index.storage.docstore.keyval_docstore import KVDocumentStore
-from llama_index.storage.kvstore.simple_kvstore import SimpleKVStore
-from llama_index.storage.kvstore.types import BaseInMemoryKVStore
 from llama_index.storage.docstore.types import (
-    DEFAULT_PERSIST_PATH,
     DEFAULT_PERSIST_DIR,
     DEFAULT_PERSIST_FNAME,
+    DEFAULT_PERSIST_PATH,
 )
+from llama_index.storage.kvstore.simple_kvstore import SimpleKVStore
+from llama_index.storage.kvstore.types import BaseInMemoryKVStore
 
 
 class SimpleDocumentStore(KVDocumentStore):
@@ -18,18 +20,18 @@ class SimpleDocumentStore(KVDocumentStore):
 
     Args:
         simple_kvstore (SimpleKVStore): simple key-value store
-        name_space (str): namespace for the docstore
+        namespace (str): namespace for the docstore
 
     """
 
     def __init__(
         self,
         simple_kvstore: Optional[SimpleKVStore] = None,
-        name_space: Optional[str] = None,
+        namespace: Optional[str] = None,
     ) -> None:
         """Init a SimpleDocumentStore."""
         simple_kvstore = simple_kvstore or SimpleKVStore()
-        super().__init__(simple_kvstore, name_space)
+        super().__init__(simple_kvstore, namespace)
 
     @classmethod
     def from_persist_dir(


### PR DESCRIPTION
### Changes
* Change `name_space` to `namespace` in `SimpleDocumentStore`.