### PR TITLE
add tokenizer outputs to remove, fix device

### DIFF
--- a/docs/how_to/customization/custom_llms.md
+++ b/docs/how_to/customization/custom_llms.md
@@ -174,7 +174,16 @@ service_context = ServiceContext.from_defaults(
 )
 ```
 
-An API reference can be found [here](../../reference/llm_predictor.rst).
+Some models will raise errors if all the keys from the tokenizer are passed to the model. A common tokenizer output that causes issues is `token_type_ids`. Below is an example of configuring the predictor to remove this before passing the inputs to the model:
+
+```python
+HuggingFaceLLMPredictor(
+    ...
+    tokenizer_outputs_to_remove=["token_type_ids"]
+) 
+```
+
+A full API reference can be found [here](../../reference/llm_predictor.rst).
 
 Several example notebooks are also listed below:
 

--- a/docs/how_to/customization/custom_llms.md
+++ b/docs/how_to/customization/custom_llms.md
@@ -156,8 +156,7 @@ from llama_index.llm_predictor import HuggingFaceLLMPredictor
 stablelm_predictor = HuggingFaceLLMPredictor(
     max_input_size=4096, 
     max_new_tokens=256,
-    temperature=0.7,
-    do_sample=False,
+    generate_kwargs={"temperature": 0.7, "do_sample": False}
     system_prompt=system_prompt,
     query_wrapper_prompt=query_wrapper_prompt,
     tokenizer_name="StabilityAI/stablelm-tuned-alpha-3b",

--- a/llama_index/llm_predictor/huggingface.py
+++ b/llama_index/llm_predictor/huggingface.py
@@ -46,6 +46,7 @@ class HuggingFaceLLMPredictor(BaseLLMPredictor):
         device_map: str = "auto",
         stopping_ids: Optional[List[int]] = None,
         tokenizer_kwargs: Optional[dict] = None,
+        tokenizer_outputs_to_remove: Optional[list] = None,
         model_kwargs: Optional[dict] = None,
         callback_manager: Optional[CallbackManager] = None,
     ) -> None:
@@ -91,7 +92,7 @@ class HuggingFaceLLMPredictor(BaseLLMPredictor):
         self._temperature = temperature
         self._do_sample = do_sample
         self._device_map = device_map
-
+        self._tokenizer_outputs_to_remove = tokenizer_outputs_to_remove or []
         self._system_prompt = system_prompt
         self._query_wrapper_prompt = query_wrapper_prompt
         self._total_tokens_used = 0
@@ -133,7 +134,6 @@ class HuggingFaceLLMPredictor(BaseLLMPredictor):
             str: The predicted answer.
 
         """
-        import torch
         from transformers import TextIteratorStreamer
 
         formatted_prompt = prompt.format(**prompt_args)
@@ -142,10 +142,12 @@ class HuggingFaceLLMPredictor(BaseLLMPredictor):
             full_prompt = f"{self._system_prompt} {full_prompt}"
 
         inputs = self.tokenizer(full_prompt, return_tensors="pt")
-        if "cuda" == self._device_map or (
-            "auto" == self._device_map and torch.cuda.is_available()
-        ):
-            inputs = inputs.to("cuda")
+        inputs = inputs.to(self.model.device)
+
+        # remove keys from the tokenizer if needed, to avoid HF errors
+        for key in self._tokenizer_outputs_to_remove:
+            if key in inputs:
+                inputs.pop(key, None)
 
         streamer = TextIteratorStreamer(
             self.tokenizer,


### PR DESCRIPTION
Huggingface raises a value error now if a model is passed unused kwargs (very annoying tbh)

This fixes that, as well as fixes the device that the inputs move to.

This also removes temperature and do_sample in favor of more general generate_kwargs