### PR TITLE
Broken link fix in custom_llms documentation

### DIFF
--- a/docs/how_to/customization/custom_llms.md
+++ b/docs/how_to/customization/custom_llms.md
@@ -30,7 +30,7 @@ Below we show a few examples of LLM customization. This includes
 An example snippet of customizing the LLM being used is shown below.
 In this example, we use `text-davinci-002` instead of `text-davinci-003`. Available models include `text-davinci-003`,`text-curie-001`,`text-babbage-001`,`text-ada-001`, `code-davinci-002`,`code-cushman-001`. Note that
 you may plug in any LLM shown on Langchain's
-[LLM](https://langchain.readthedocs.io/en/latest/modules/llms.html) page.
+[LLM](https://langchain.readthedocs.io/en/latest/modules/models/llms.html) page.
 
 ```python
 

--- a/docs/how_to/customization/custom_llms.md
+++ b/docs/how_to/customization/custom_llms.md
@@ -30,7 +30,7 @@ Below we show a few examples of LLM customization. This includes
 An example snippet of customizing the LLM being used is shown below.
 In this example, we use `text-davinci-002` instead of `text-davinci-003`. Available models include `text-davinci-003`,`text-curie-001`,`text-babbage-001`,`text-ada-001`, `code-davinci-002`,`code-cushman-001`. Note that
 you may plug in any LLM shown on Langchain's
-[LLM](https://langchain.readthedocs.io/en/latest/modules/models/llms.html) page.
+[LLM](https://python.langchain.com/en/latest/modules/models/llms/integrations.html) page.
 
 ```python
 


### PR DESCRIPTION
Updated the second link to "Langchain's LLM page" (`2` on screenshot below) on the attached file to point to the same place as the first link (`1` on screenshot below). Second one was missing a directory and led to a 404.

![image](https://github.com/jerryjliu/llama_index/assets/3514397/f2d358c7-2f67-4407-a7db-3f63306fad59)
