### PR TITLE
Removing stray imports from examples/docs

### DIFF
--- a/docs/guides/tutorials/building_a_chatbot.md
+++ b/docs/guides/tutorials/building_a_chatbot.md
@@ -129,9 +129,7 @@ LlamaIndex provides some wrappers around indices and graphs so that they can be 
 
 ```python
 # do imports
-from langchain.agents import Tool
 from langchain.chains.conversation.memory import ConversationBufferMemory
-from langchain.chat_models import ChatOpenAI
 from langchain.agents import initialize_agent
 
 from llama_index.langchain_helpers.agents import LlamaToolkit, create_llama_chat_agent, IndexToolConfig

--- a/examples/chatbot/Chatbot_SEC.ipynb
+++ b/examples/chatbot/Chatbot_SEC.ipynb
@@ -263,9 +263,7 @@
             },
             "outputs": [],
             "source": [
-                "from langchain.agents import Tool\n",
                 "from langchain.chains.conversation.memory import ConversationBufferMemory\n",
-                "from langchain.chat_models import ChatOpenAI\n",
                 "from langchain.agents import initialize_agent\n",
                 "\n",
                 "from llama_index.langchain_helpers.agents import LlamaToolkit, create_llama_chat_agent, IndexToolConfig"


### PR DESCRIPTION
Another thing I found as I was browsing around, to hopefully help keep stuff up to date. Neither removed import seems to be used anywhere in this example, and in our code that got a chatbot up and running, the imports weren't necessary.

Didn't see any automated conversions from the Jupyter notebooks to the docs, but hopefully this won't get in the way if they do exist.

We're running into some issues getting a `GPTVectorStoreIndex` to actually index an entire Github repo using the LlamaHub loader, as it's only seeming to send one request over the wire and ignoring the rest of the repo, so we may be in touch with a real bug report soon. Trying to build up some good credit in advance by putting these in, sorry if they're annoying...