### PR TITLE
add filename_as_doc_id

### DIFF
--- a/docs/guides/tutorials/discover_llamaindex.md
+++ b/docs/guides/tutorials/discover_llamaindex.md
@@ -18,4 +18,12 @@ This video covers managing documents from a source that is consantly updating (i
 
 [Notebook + Supplimentary Material](https://github.com/jerryjliu/llama_index/tree/main/docs/examples/discover_llamaindex/document_management/)
 
-[Reference Docs](../../how_to/index_structs/document_management.md)
+[Reference Docs](../../how_to/index/document_management.md)
+
+## Joint Text to SQL and Semantic Search
+
+This video covers the tools built into LlamaIndex for combining SQL and semantic search into a single unified query interface.
+
+[Youtube](https://www.youtube.com/watch?v=ZIvcVJGtCrY)
+
+[Notebook](../../examples/query_engine/SQLAutoVectorQueryEngine.ipynb)

--- a/docs/how_to/customization/custom_documents.md
+++ b/docs/how_to/customization/custom_documents.md
@@ -1,4 +1,4 @@
-### Customizing Documents
+## Customizing Documents
 
 Documents also offer the chance to include useful metadata. Using the `extra_info` dictionary on each document, additional information can be included to help inform responses and track down sources for query responses. This information can be anything, such as filenames or categories, but the only requirement is that the keys must be strings, and the values must be either `str`, `float`, or `int`.
 
@@ -32,4 +32,14 @@ filename_fn = lambda filename: {'file_name': filename}
 
 # automatically sets the extra_info of each document according to filename_fn
 documents = SimpleDirectoryReader('./data', file_metadata=filename_fn)
+```
+
+## Customizing the doc_id
+
+As detailed in the section [Document Management](../index/document_management.md), the `doc_id` is used to enable effecient refreshing of documents in the index. When using the `SimpleDirectoryReader`, you can automatically set the `doc_id` to be the full path to each document:
+
+```python
+from llama_index import SimpleDirectoryReader
+
+documents = SimpleDirectoryReader("./data", filename_as_id=True).load_data()
 ```

--- a/docs/how_to/index/document_management.md
+++ b/docs/how_to/index/document_management.md
@@ -90,6 +90,8 @@ print(refreshed_docs)
 
 This is most useful when you are reading from a directory that is constantly updating with new information.
 
+To autmatically set the `doc_id` when using the `SimpleDirectoryReader`, you can set the `filename_as_id` flag. More details can be found [here](../customization/custom_documents.md).
+
 ## Document Tracking
 
 Any index that uses the docstore (i.e. all indexes except for most vector store integrations), you can also see which documents you have inserted into the docstore. 

--- a/llama_index/readers/file/base.py
+++ b/llama_index/readers/file/base.py
@@ -193,8 +193,8 @@ class SimpleDirectoryReader(BaseReader):
 
                 # iterate over docs if needed
                 if self.filename_as_id:
-                    for i in range(len(docs)):
-                        docs[i].doc_id = f"{str(Path(input_file))}_part_{i}"
+                    for i, doc in enumerate(docs):
+                        doc.doc_id = f"{str(input_file)}_part_{i}"
 
                 documents.extend(docs)
             else:
@@ -204,7 +204,7 @@ class SimpleDirectoryReader(BaseReader):
 
                 doc = Document(data, extra_info=metadata)
                 if self.filename_as_id:
-                    doc.doc_id = str(Path(input_file))
+                    doc.doc_id = str(input_file)
 
                 documents.append(doc)
 

--- a/llama_index/readers/file/base.py
+++ b/llama_index/readers/file/base.py
@@ -204,7 +204,7 @@ class SimpleDirectoryReader(BaseReader):
 
                 doc = Document(data, extra_info=metadata)
                 if self.filename_as_id:
-                    doc.doc_id = Path(input_file)
+                    doc.doc_id = str(Path(input_file))
 
                 documents.append(doc)
 

--- a/llama_index/readers/file/base.py
+++ b/llama_index/readers/file/base.py
@@ -190,9 +190,11 @@ class SimpleDirectoryReader(BaseReader):
                     self.file_extractor[file_suffix] = reader_cls()
                 reader = self.file_extractor[file_suffix]
                 docs = reader.load_data(input_file, extra_info=metadata)
+
+                # iterate over docs if needed
                 if self.filename_as_id:
                     for i in range(len(docs)):
-                        docs[i].doc_id = f"{Path(input_file)}_part_{i}"
+                        docs[i].doc_id = f"{str(Path(input_file))}_part_{i}"
 
                 documents.extend(docs)
             else:

--- a/llama_index/readers/file/base.py
+++ b/llama_index/readers/file/base.py
@@ -70,6 +70,7 @@ class SimpleDirectoryReader(BaseReader):
         exclude_hidden: bool = True,
         errors: str = "ignore",
         recursive: bool = False,
+        filename_as_id: bool = False,
         required_exts: Optional[List[str]] = None,
         file_extractor: Optional[Dict[str, BaseReader]] = None,
         num_files_limit: Optional[int] = None,
@@ -106,6 +107,7 @@ class SimpleDirectoryReader(BaseReader):
 
         self.supported_suffix = list(DEFAULT_FILE_READER_CLS.keys())
         self.file_metadata = file_metadata
+        self.filename_as_id = filename_as_id
 
     def _add_files(self, input_dir: Path) -> List[Path]:
         """Add files."""
@@ -188,6 +190,10 @@ class SimpleDirectoryReader(BaseReader):
                     self.file_extractor[file_suffix] = reader_cls()
                 reader = self.file_extractor[file_suffix]
                 docs = reader.load_data(input_file, extra_info=metadata)
+                if self.filename_as_id:
+                    for i in range(len(docs)):
+                        docs[i].doc_id = f"{Path(input_file)}_part_{i}"
+
                 documents.extend(docs)
             else:
                 # do standard read
@@ -195,6 +201,9 @@ class SimpleDirectoryReader(BaseReader):
                     data = f.read()
 
                 doc = Document(data, extra_info=metadata)
+                if self.filename_as_id:
+                    doc.doc_id = Path(input_file)
+
                 documents.append(doc)
 
         return documents

--- a/tests/readers/test_file.py
+++ b/tests/readers/test_file.py
@@ -272,3 +272,35 @@ def test_excluded_files() -> None:
                         "test2.txt",
                         "test4.txt",
                     }
+
+
+def test_filename_as_doc_id() -> None:
+    """Test if file metadata is added to Document."""
+    # test file_metadata
+    with TemporaryDirectory() as tmp_dir:
+        with open(f"{tmp_dir}/test1.txt", "w") as f:
+            f.write("test1")
+        with open(f"{tmp_dir}/test2.txt", "w") as f:
+            f.write("test2")
+        with open(f"{tmp_dir}/test3.txt", "w") as f:
+            f.write("test3")
+        with open(f"{tmp_dir}/test4.md", "w") as f:
+            f.write("test4")
+        with open(f"{tmp_dir}/test5.json", "w") as f:
+            f.write('{"test_1": {"test_2": [1, 2, 3]}}')
+
+        reader = SimpleDirectoryReader(tmp_dir, filename_as_id=True)
+
+        documents = reader.load_data()
+
+        doc_paths = [
+            f"{tmp_dir}/test1.txt",
+            f"{tmp_dir}/test2.txt",
+            f"{tmp_dir}/test3.txt",
+            f"{tmp_dir}/test4.md",
+            f"{tmp_dir}/test5.json",
+        ]
+
+        # check paths. Split handles path_part_X doc_ids from md and json files
+        for doc in documents:
+            assert str(doc.doc_id).split("_part")[0] in doc_paths


### PR DESCRIPTION
# Description

The `refresh()` function would be a lot easier to use if `doc_id()` was more consistent and automatic. This PR adds an option to have the `doc_id` be set to the filepath

Fixes https://github.com/jerryjliu/llama_index/issues/5772

(Also threw in some extra docs fixes for discover llamaindex)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Added new unit/integration tests
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
