### PR TITLE
more robust default pdf parser

### DIFF
--- a/llama_index/readers/file/docs_reader.py
+++ b/llama_index/readers/file/docs_reader.py
@@ -10,7 +10,7 @@ from llama_index.readers.base import BaseReader
 from llama_index.readers.schema.base import Document
 
 
-class PDFMinerReader(BaseReader):
+class PDFReader(BaseReader):
     """PDF parser based on pdfminer.six."""
 
     def load_data(


### PR DESCRIPTION
# Description

Due to https://github.com/py-pdf/pypdf/issues/1507 it would be good to have a more robust pdf parser.
This parser is based on pdfminer.six which produces better results.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
