### PR TITLE
fix: TransformQueryEngine is imported from wrong file on the docs

### DIFF
--- a/docs/how_to/query_engine/advanced/query_transformations.md
+++ b/docs/how_to/query_engine/advanced/query_transformations.md
@@ -27,7 +27,7 @@ To use HyDE, an example code snippet is shown below.
 ```python
 from llama_index import VectorStoreIndex, SimpleDirectoryReader
 from llama_index.indices.query.query_transform.base import HyDEQueryTransform
-from llama_index.indices.query import TransformQueryEngine
+from llama_index.query_engine.transform_query_engine import TransformQueryEngine
 
 # load documents, build index
 documents = SimpleDirectoryReader('../paul_graham_essay/data').load_data()


### PR DESCRIPTION
# Description

https://gpt-index.readthedocs.io/en/latest/how_to/query_engine/advanced/query_transformations.html#hyde-hypothetical-document-embeddings
`TransformQueryEngine` is imported from wrong file on the document. Seems like [notebook example](https://github.com/jerryjliu/llama_index/blob/main/docs/examples/query_transformations/HyDEQueryTransformDemo.ipynb) is importing from correct file.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
