### PR TITLE
Remove hardcoded chunk size for citation query engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 ## [Unreleased]
 
 ### New Features
+- None
+
+### Bug Fixes
+- None
+
+### Breaking/Deprecated API Changes
+- None
+
+### Miscellaneous
+- None
+
+## [v0.6.22] - 2023-06-10
+
+### New Features
 - Added `SQLJoinQueryEngine` (generalization of `SQLAutoVectorQueryEngine`) (#6265)
 - Added support for graph stores under the hood, and initial support for Nebula KG. More docs coming soon! (#2581)
 - Added guideline evaluator to allow llm to provide feedback based on user guidelines (#4664)
@@ -12,9 +26,6 @@
 ### Bug Fixes
 - Fixed bug with `delete_ref_doc` not removing all metadata from the docstore (#6192)
 - FIxed bug with loading existing QDrantVectorStore (#6230)
-
-### Breaking/Deprecated API Changes
-- None
 
 ### Miscellaneous 
 - Added changelog officially to github repo (#6191)

--- a/docs/examples/query_engine/citation_query_engine.ipynb
+++ b/docs/examples/query_engine/citation_query_engine.ipynb
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 2,
    "id": "1a9c49be",
    "metadata": {},
    "outputs": [],
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 3,
    "id": "80b8d666",
    "metadata": {},
    "outputs": [],
@@ -92,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 4,
    "id": "7bc3d1e9",
    "metadata": {},
    "outputs": [],
@@ -107,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 5,
    "id": "b80df9c3",
    "metadata": {},
    "outputs": [],
@@ -117,7 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 6,
    "id": "1f13b143",
    "metadata": {},
    "outputs": [
@@ -125,12 +125,31 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Before college, the author worked on writing short stories and programming on an IBM 1401 using an early version of Fortran [11]. Later, the author got a TRS-80 and wrote simple games, a program to predict how high model rockets would fly, and a word processor that their father used to write at least one book [14].\n"
+      "Before college, the author worked on writing short stories and programming on an IBM 1401 using an early version of Fortran [5]. The author's friend built a microcomputer from a kit by Heathkit, which impressed and envious the author [6]. The author eventually convinced their father to buy a TRS-80, which they used to write simple games, a program to predict how high model rockets would fly, and a word processor that their father used to write at least one book [6].\n"
      ]
     }
    ],
    "source": [
     "print(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c7064870",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6\n"
+     ]
+    }
+   ],
+   "source": [
+    "# source nodes are 6, because the original chunks of 1024-sized nodes were broken into more granular nodes\n",
+    "print(len(response.source_nodes))"
    ]
   },
   {
@@ -146,7 +165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 8,
    "id": "e7397ccb",
    "metadata": {},
    "outputs": [
@@ -154,9 +173,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Source 11:\n",
-      "\t\t\n",
-      "\n",
+      "Source 5:\n",
       "What I Worked On\n",
       "\n",
       "February 2021\n",
@@ -165,18 +182,22 @@
       "\n",
       "The first programs I tried writing were on the IBM 1401 that our school district used for what was then called \"data processing.\" This was in 9th grade, so I was 13 or 14. The school district's 1401 happened to be in the basement of our junior high school, and my friend Rich Draves and I got permission to use it. It was like a mini Bond villain's lair down there, with all these alien-looking machines — CPU, disk drives, printer, card reader — sitting up on a raised floor under bright fluorescent lights.\n",
       "\n",
-      "The language we used was an early version of Fortran. You had to type programs on punch cards, then stack them\n",
+      "The language we used was an early version of Fortran. You had to type programs on punch cards, then stack them in the card reader and press a button to load the program into memory and run it. The result would ordinarily be to print something on the spectacularly loud printer.\n",
+      "\n",
+      "I was puzzled by the 1401. I couldn't figure out what to do with it. And in retrospect there's not much I could have done with it. The only form of input to programs was data stored on punched cards, and I didn't have any data stored on punched cards. The only other option was to do things that didn't rely on any input, like calculate approximations of pi, but I didn't know enough math to do anything interesting of that type. So I'm not surprised I can't remember any programs I wrote, because they can't have done much. My clearest memory is of the moment I learned it was possible for programs not to terminate, when one of mine didn't. On a machine without time-sharing, this was a social as well as a technical error, as the data center manager's expression made clear.\n",
+      "\n",
+      "With microcomputers, everything changed. Now you could have a computer sitting right in front of you, on a desk, that could respond to your keystrokes as it was running instead of just churning through a stack of punch cards and then stopping.\n",
       "\n"
      ]
     }
    ],
    "source": [
-    "print(response.source_nodes[10].node.get_text())"
+    "print(response.source_nodes[4].node.get_text())"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 10,
    "id": "911db74a",
    "metadata": {},
    "outputs": [
@@ -184,20 +205,24 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Source 14:\n",
-      "used to write at least one book. There was only room in memory for about 2 pages of text, so he'd write 2 pages at a time and then print them out, but it was a lot better than a typewriter.\n",
+      "Source 6:\n",
+      "[1]\n",
+      "\n",
+      "The first of my friends to get a microcomputer built it himself. It was sold as a kit by Heathkit. I remember vividly how impressed and envious I felt watching him sitting in front of it, typing programs right into the computer.\n",
+      "\n",
+      "Computers were expensive in those days and it took me years of nagging before I convinced my father to buy one, a TRS-80, in about 1980. The gold standard then was the Apple II, but a TRS-80 was good enough. This was when I really started programming. I wrote simple games, a program to predict how high my model rockets would fly, and a word processor that my father used to write at least one book. There was only room in memory for about 2 pages of text, so he'd write 2 pages at a time and then print them out, but it was a lot better than a typewriter.\n",
       "\n",
       "Though I liked programming, I didn't plan to study it in college. In college I was going to study philosophy, which sounded much more powerful. It seemed, to my naive high school self, to be the study of the ultimate truths, compared to which the things studied in other fields would be mere domain knowledge. What I discovered when I got to college was that the other fields took up so much of the space of ideas that there wasn't much left for these supposed ultimate truths. All that seemed left for philosophy were edge cases that people in other fields felt could safely be ignored.\n",
       "\n",
       "I couldn't have put this into words when I was 18. All I knew at the time was that I kept taking philosophy courses and they kept being boring. So I decided to switch to AI.\n",
       "\n",
-      "AI was in the air in the mid 1980s, but there were two\n",
+      "AI was in the air in the mid 1980s, but there were two things especially that made me want to work on it: a novel by Heinlein called The Moon is a Harsh Mistress, which featured an intelligent computer called Mike, and a PBS documentary that showed Terry Winograd using SHRDLU. I haven't tried\n",
       "\n"
      ]
     }
    ],
    "source": [
-    "print(response.source_nodes[13].node.get_text())"
+    "print(response.source_nodes[5].node.get_text())"
    ]
   },
   {
@@ -205,12 +230,16 @@
    "id": "4ba9767b",
    "metadata": {},
    "source": [
-    "## Adjusting Settings"
+    "## Adjusting Settings\n",
+    "\n",
+    "Note that setting the chunk size larger than the original chunk size of the nodes will have no effect.\n",
+    "\n",
+    "The default node chunk size is 1024, so here, we are not making our citation nodes any more granular."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 11,
    "id": "ca0b4dc3",
    "metadata": {},
    "outputs": [],
@@ -225,7 +254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 12,
    "id": "ce1649ba",
    "metadata": {},
    "outputs": [],
@@ -235,7 +264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 13,
    "id": "3ca375ad",
    "metadata": {},
    "outputs": [
@@ -243,12 +272,31 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Before college, the author worked on writing short stories and programming on an IBM 1401 using an early version of Fortran [11]. They later got a TRS-80 microcomputer and wrote simple games, a program to predict how high model rockets would fly, and a word processor that their father used to write at least one book [14].\n"
+      "The author wrote short stories and programmed on an IBM 1401 in 9th grade with a friend using an early version of Fortran. They later convinced their father to buy a TRS-80 and wrote simple games, a program to predict how high their model rockets would fly, and a word processor that their father used to write at least one book [3].\n"
      ]
     }
    ],
    "source": [
     "print(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "0278ecb2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3\n"
+     ]
+    }
+   ],
+   "source": [
+    "# should be less source nodes now!\n",
+    "print(len(response.source_nodes))"
    ]
   },
   {
@@ -264,7 +312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 15,
    "id": "7af6ec68",
    "metadata": {},
    "outputs": [
@@ -272,9 +320,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Source 11:\n",
-      "\t\t\n",
-      "\n",
+      "Source 3:\n",
       "What I Worked On\n",
       "\n",
       "February 2021\n",
@@ -283,39 +329,27 @@
       "\n",
       "The first programs I tried writing were on the IBM 1401 that our school district used for what was then called \"data processing.\" This was in 9th grade, so I was 13 or 14. The school district's 1401 happened to be in the basement of our junior high school, and my friend Rich Draves and I got permission to use it. It was like a mini Bond villain's lair down there, with all these alien-looking machines — CPU, disk drives, printer, card reader — sitting up on a raised floor under bright fluorescent lights.\n",
       "\n",
-      "The language we used was an early version of Fortran. You had to type programs on punch cards, then stack them\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(response.source_nodes[10].node.get_text())"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 35,
-   "id": "37583036",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Source 14:\n",
-      "used to write at least one book. There was only room in memory for about 2 pages of text, so he'd write 2 pages at a time and then print them out, but it was a lot better than a typewriter.\n",
+      "The language we used was an early version of Fortran. You had to type programs on punch cards, then stack them in the card reader and press a button to load the program into memory and run it. The result would ordinarily be to print something on the spectacularly loud printer.\n",
+      "\n",
+      "I was puzzled by the 1401. I couldn't figure out what to do with it. And in retrospect there's not much I could have done with it. The only form of input to programs was data stored on punched cards, and I didn't have any data stored on punched cards. The only other option was to do things that didn't rely on any input, like calculate approximations of pi, but I didn't know enough math to do anything interesting of that type. So I'm not surprised I can't remember any programs I wrote, because they can't have done much. My clearest memory is of the moment I learned it was possible for programs not to terminate, when one of mine didn't. On a machine without time-sharing, this was a social as well as a technical error, as the data center manager's expression made clear.\n",
+      "\n",
+      "With microcomputers, everything changed. Now you could have a computer sitting right in front of you, on a desk, that could respond to your keystrokes as it was running instead of just churning through a stack of punch cards and then stopping. [1]\n",
+      "\n",
+      "The first of my friends to get a microcomputer built it himself. It was sold as a kit by Heathkit. I remember vividly how impressed and envious I felt watching him sitting in front of it, typing programs right into the computer.\n",
+      "\n",
+      "Computers were expensive in those days and it took me years of nagging before I convinced my father to buy one, a TRS-80, in about 1980. The gold standard then was the Apple II, but a TRS-80 was good enough. This was when I really started programming. I wrote simple games, a program to predict how high my model rockets would fly, and a word processor that my father used to write at least one book. There was only room in memory for about 2 pages of text, so he'd write 2 pages at a time and then print them out, but it was a lot better than a typewriter.\n",
       "\n",
       "Though I liked programming, I didn't plan to study it in college. In college I was going to study philosophy, which sounded much more powerful. It seemed, to my naive high school self, to be the study of the ultimate truths, compared to which the things studied in other fields would be mere domain knowledge. What I discovered when I got to college was that the other fields took up so much of the space of ideas that there wasn't much left for these supposed ultimate truths. All that seemed left for philosophy were edge cases that people in other fields felt could safely be ignored.\n",
       "\n",
       "I couldn't have put this into words when I was 18. All I knew at the time was that I kept taking philosophy courses and they kept being boring. So I decided to switch to AI.\n",
       "\n",
-      "AI was in the air in the mid 1980s, but there were two\n",
+      "AI was in the air in the mid 1980s, but there were two things especially that made me want to work on it: a novel by Heinlein called The Moon is a Harsh Mistress, which featured an intelligent computer called Mike, and a PBS documentary that showed Terry Winograd using SHRDLU. I haven't tried\n",
       "\n"
      ]
     }
    ],
    "source": [
-    "print(response.source_nodes[13].node.get_text())"
+    "print(response.source_nodes[2].node.get_text())"
    ]
   },
   {

--- a/llama_index/query_engine/citation_query_engine.py
+++ b/llama_index/query_engine/citation_query_engine.py
@@ -11,10 +11,7 @@ from llama_index.indices.query.base import BaseQueryEngine
 from llama_index.indices.query.response_synthesis import ResponseSynthesizer
 from llama_index.indices.query.schema import QueryBundle
 from llama_index.indices.response.type import ResponseMode
-from llama_index.langchain_helpers.text_splitter import (
-    TokenTextSplitter,
-    SentenceSplitter,
-)
+from llama_index.langchain_helpers.text_splitter import SentenceSplitter
 from llama_index.optimization.optimizer import BaseTokenUsageOptimizer
 from llama_index.prompts.base import Prompt
 from llama_index.response.schema import RESPONSE_TYPE
@@ -185,11 +182,9 @@ class CitationQueryEngine(BaseQueryEngine):
 
     def _create_citation_nodes(self, nodes: List[NodeWithScore]) -> List[NodeWithScore]:
         """Modify retrieved nodes to be granular sources."""
-        text_splitter = TokenTextSplitter(chunk_size=256, chunk_overlap=20)
-
         new_nodes: List[NodeWithScore] = []
         for node in nodes:
-            splits = text_splitter.split_text_with_overlaps(node.node.get_text())
+            splits = self.text_splitter.split_text_with_overlaps(node.node.get_text())
 
             start_offset = 0
             if node.node.node_info:

--- a/llama_index/query_engine/citation_query_engine.py
+++ b/llama_index/query_engine/citation_query_engine.py
@@ -1,5 +1,4 @@
-from typing import Any, Dict, List, Optional, Sequence
-from langchain.text_splitter import TextSplitter
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 from llama_index.callbacks.schema import CBEventType
 from llama_index.data_structs.node import NodeWithScore, Node
@@ -11,7 +10,10 @@ from llama_index.indices.query.base import BaseQueryEngine
 from llama_index.indices.query.response_synthesis import ResponseSynthesizer
 from llama_index.indices.query.schema import QueryBundle
 from llama_index.indices.response.type import ResponseMode
-from llama_index.langchain_helpers.text_splitter import SentenceSplitter
+from llama_index.langchain_helpers.text_splitter import (
+    SentenceSplitter,
+    TokenTextSplitter,
+)
 from llama_index.optimization.optimizer import BaseTokenUsageOptimizer
 from llama_index.prompts.base import Prompt
 from llama_index.response.schema import RESPONSE_TYPE
@@ -71,6 +73,8 @@ CITATION_REFINE_TEMPLATE = Prompt(
 DEFAULT_CITATION_CHUNK_SIZE = 512
 DEFAULT_CITATION_CHUNK_OVERLAP = 20
 
+TextSplitterType = Union[SentenceSplitter, TokenTextSplitter]
+
 
 class CitationQueryEngine(BaseQueryEngine):
     """Citation query engine.
@@ -83,7 +87,7 @@ class CitationQueryEngine(BaseQueryEngine):
             Size of citation chunks, default=512. Useful for controlling
             granularity of sources.
         citation_chunk_overlap (int): Overlap of citation nodes, default=20.
-        text_splitter (Optional[TextSplitter]):
+        text_splitter (Optional[TextSplitterType]):
             A text splitter for creating citation source nodes. Default is
             a SentenceSplitter.
         callback_manager (Optional[CallbackManager]): A callback manager.
@@ -95,7 +99,7 @@ class CitationQueryEngine(BaseQueryEngine):
         response_synthesizer: Optional[ResponseSynthesizer] = None,
         citation_chunk_size: int = DEFAULT_CITATION_CHUNK_SIZE,
         citation_chunk_overlap: int = DEFAULT_CITATION_CHUNK_OVERLAP,
-        text_splitter: Optional[TextSplitter] = None,
+        text_splitter: Optional[TextSplitterType] = None,
         callback_manager: Optional[CallbackManager] = None,
     ) -> None:
         self.text_splitter = text_splitter or SentenceSplitter(
@@ -115,7 +119,7 @@ class CitationQueryEngine(BaseQueryEngine):
         index: BaseGPTIndex,
         citation_chunk_size: int = DEFAULT_CITATION_CHUNK_SIZE,
         citation_chunk_overlap: int = DEFAULT_CITATION_CHUNK_OVERLAP,
-        text_splitter: Optional[TextSplitter] = None,
+        text_splitter: Optional[TextSplitterType] = None,
         citation_qa_template: Prompt = CITATION_QA_TEMPLATE,
         citation_refine_template: Prompt = CITATION_REFINE_TEMPLATE,
         retriever: Optional[BaseRetriever] = None,
@@ -138,7 +142,7 @@ class CitationQueryEngine(BaseQueryEngine):
                 Size of citation chunks, default=512. Useful for controlling
                 granularity of sources.
             citation_chunk_overlap (int): Overlap of citation nodes, default=20.
-            text_splitter (Optional[TextSplitter]):
+            text_splitter (Optional[TextSplitterType]):
                 A text splitter for creating citation source nodes. Default is
                 a SentenceSplitter.
             citation_qa_template (Prompt): Template for initial citation QA


### PR DESCRIPTION
# Description

Citation query engine had the chunk size hardcoded

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
