### PR TITLE
[wip] add instruct flare query engine 

### DIFF
--- a/docs/examples/query_engine/flare_query_engine.ipynb
+++ b/docs/examples/query_engine/flare_query_engine.ipynb
@@ -1,0 +1,479 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f866cc0a-460e-4dbf-91b7-f541a4c0eda6",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# FLARE Query Engine\n",
+    "\n",
+    "Adapted from the paper \"Active Retrieval Augmented Generation\"\n",
+    "\n",
+    "Currently implements FLARE Instruct, which tells the LLM to generate retrieval instructions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "920e6742-5296-46ed-83f5-8b0d999b88a3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/jerryliu/Programming/gpt_index/.venv/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "from langchain.llms import OpenAI\n",
+    "from langchain.chat_models import ChatOpenAI\n",
+    "from llama_index.query_engine import FLAREInstructQueryEngine\n",
+    "from llama_index import (\n",
+    "    VectorStoreIndex,\n",
+    "    ResponseSynthesizer,\n",
+    "    SimpleDirectoryReader,\n",
+    "    StorageContext,\n",
+    "    load_index_from_storage,\n",
+    "    LLMPredictor,\n",
+    "    ServiceContext,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "377c6a8b-2d3f-488c-8f45-4eb5001d32ca",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Skill 1. Use the Search API to look up relevant information by writing \"[Search(query)]\" where \"query\" is the search query you want to look up. For example: \n",
+      "\n",
+      "Query: But what are the risks during production of nanomaterials?\n",
+      "Answer: [Search(What are some nanomaterial production risks?)]\n",
+      "\n",
+      "Query: The colors on the flag of Ghana have the following meanings.\n",
+      "Answer: Red is for [Search(What is the meaning of Ghana's flag being red?)], green for forests, and gold for mineral wealth.\n",
+      "\n",
+      "Query: What did the author do during his time in college?\n",
+      "Answer: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as [Search(What humanities classes did the author take in college?)].\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "Now given the query, please answer the following question. You may use the Search API \"[Search(query)]\" whenever possible.\n",
+      "If the answer is complete and no longer contains any \"[Search(query)]\" tags, write \"done\" to finish the task.\n",
+      "\n",
+      "\n",
+      "Query: {query_str}\n",
+      "Answer: {existing_answer}     \n"
+     ]
+    }
+   ],
+   "source": [
+    "from llama_index.query_engine.flare_query_engine import DEFAULT_INSTRUCT_PROMPT_TMPL\n",
+    "print(DEFAULT_INSTRUCT_PROMPT_TMPL)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "507256f4-7831-4ad3-8bdd-c19ad6623d6d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "service_context = ServiceContext.from_defaults(\n",
+    "    llm_predictor=LLMPredictor(llm=ChatOpenAI(model_name='gpt-3.5-turbo', temperature=0)),\n",
+    "    chunk_size=512\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "5dac4df9-a42f-4cc5-a708-542e3c33f3d2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "documents = SimpleDirectoryReader(\"../data/paul_graham\").load_data()\n",
+    "index = VectorStoreIndex.from_documents(documents, service_context=service_context)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8a749d71-2ad5-4ee3-aa1e-48e9567b706d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "index_query_engine = index.as_query_engine(similarity_top_k=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "91fcdbcd-f0f6-4580-9016-d89394e05aab",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "flare_query_engine = FLAREInstructQueryEngine(\n",
+    "    query_engine=index_query_engine,\n",
+    "    service_context=service_context,\n",
+    "    verbose=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "6a6dcb43-8854-481a-8d6e-62e2c355b72c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<llama_index.query_engine.flare_query_engine.FLAREInstructQueryEngine at 0x152d5f5b0>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "flare_query_engine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "e1ca238e-884b-4221-b3a8-0bb106fa0de9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;1m\u001b[1;3mQuery: What did the author do during his time in college?\n",
+      "\u001b[0m\u001b[36;1m\u001b[1;3mCurrent response: \n",
+      "\u001b[0mSkill 1. Use the Search API to look up relevant information by writing \"[Search(query)]\" where \"query\" is the search query you want to look up. For example: \n",
+      "\n",
+      "Query: But what are the risks during production of nanomaterials?\n",
+      "Answer: [Search(What are some nanomaterial production risks?)]\n",
+      "\n",
+      "Query: The colors on the flag of Ghana have the following meanings.\n",
+      "Answer: Red is for [Search(What is the meaning of Ghana's flag being red?)], green for forests, and gold for mineral wealth.\n",
+      "\n",
+      "Query: What did the author do during his time in college?\n",
+      "Answer: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as [Search(What humanities classes did the author take in college?)].\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "Now given the query, please answer the following question. You may use the Search API \"[Search(query)]\" whenever possible.\n",
+      "If the answer is complete and no longer contains any \"[Search(query)]\" tags, write \"done\" to finish the task.\n",
+      "\n",
+      "\n",
+      "Query: What did the author do during his time in college?\n",
+      "Answer:      \n",
+      "\u001b[38;5;200m\u001b[1;3mLookahead response: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as [Search(What humanities classes did the author take in college?)]\n",
+      "\u001b[0mquery tasks: [QueryTask(query_str='What humanities classes did the author take in college?', start_idx=112, end_idx=176)]\n",
+      "query_answer:  The context information does not provide any information about the humanities classes the author took in college.\n",
+      "updated lookahead_resp: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as The context information does not provide any information about the humanities classes the author took in college.\n",
+      "relevant_lookahead_resp:  The author took introductory CS classes during his freshman year. He also took some humanities classes, such as The context information does not provide any information about t\n",
+      "\u001b[36;1m\u001b[1;3mCurrent response:  The author took introductory CS classes during his freshman year. He also took some humanities classes, such as The context information does not provide any information about t\n",
+      "\u001b[0mSkill 1. Use the Search API to look up relevant information by writing \"[Search(query)]\" where \"query\" is the search query you want to look up. For example: \n",
+      "\n",
+      "Query: But what are the risks during production of nanomaterials?\n",
+      "Answer: [Search(What are some nanomaterial production risks?)]\n",
+      "\n",
+      "Query: The colors on the flag of Ghana have the following meanings.\n",
+      "Answer: Red is for [Search(What is the meaning of Ghana's flag being red?)], green for forests, and gold for mineral wealth.\n",
+      "\n",
+      "Query: What did the author do during his time in college?\n",
+      "Answer: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as [Search(What humanities classes did the author take in college?)].\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "Now given the query, please answer the following question. You may use the Search API \"[Search(query)]\" whenever possible.\n",
+      "If the answer is complete and no longer contains any \"[Search(query)]\" tags, write \"done\" to finish the task.\n",
+      "\n",
+      "\n",
+      "Query: What did the author do during his time in college?\n",
+      "Answer:  The author took introductory CS classes during his freshman year. He also took some humanities classes, such as The context information does not provide any information about t     \n",
+      "\u001b[38;5;200m\u001b[1;3mLookahead response: [Search(What humanities classes did the author take in college?)]\n",
+      "\u001b[0mquery tasks: [QueryTask(query_str='What humanities classes did the author take in college?', start_idx=0, end_idx=64)]\n",
+      "query_answer:  The context information does not provide any information about the humanities classes the author took in college.\n",
+      "updated lookahead_resp: The context information does not provide any information about the humanities classes the author took in college.\n",
+      "relevant_lookahead_resp:  The context information does not provide any information about t\n",
+      "\u001b[36;1m\u001b[1;3mCurrent response: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as The context information does not provide any information about t The context information does not provide any information about t\n",
+      "\u001b[0mSkill 1. Use the Search API to look up relevant information by writing \"[Search(query)]\" where \"query\" is the search query you want to look up. For example: \n",
+      "\n",
+      "Query: But what are the risks during production of nanomaterials?\n",
+      "Answer: [Search(What are some nanomaterial production risks?)]\n",
+      "\n",
+      "Query: The colors on the flag of Ghana have the following meanings.\n",
+      "Answer: Red is for [Search(What is the meaning of Ghana's flag being red?)], green for forests, and gold for mineral wealth.\n",
+      "\n",
+      "Query: What did the author do during his time in college?\n",
+      "Answer: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as [Search(What humanities classes did the author take in college?)].\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "Now given the query, please answer the following question. You may use the Search API \"[Search(query)]\" whenever possible.\n",
+      "If the answer is complete and no longer contains any \"[Search(query)]\" tags, write \"done\" to finish the task.\n",
+      "\n",
+      "\n",
+      "Query: What did the author do during his time in college?\n",
+      "Answer: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as The context information does not provide any information about t The context information does not provide any information about t     \n",
+      "\u001b[38;5;200m\u001b[1;3mLookahead response: [Search(What humanities classes did the author take in college?)]\n",
+      "\u001b[0mquery tasks: [QueryTask(query_str='What humanities classes did the author take in college?', start_idx=0, end_idx=64)]\n",
+      "query_answer:  The context information does not provide any information about the humanities classes the author took in college.\n",
+      "updated lookahead_resp: The context information does not provide any information about the humanities classes the author took in college.\n",
+      "relevant_lookahead_resp:  The context information does not provide any information about t\n",
+      "\u001b[36;1m\u001b[1;3mCurrent response: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t\n",
+      "\u001b[0mSkill 1. Use the Search API to look up relevant information by writing \"[Search(query)]\" where \"query\" is the search query you want to look up. For example: \n",
+      "\n",
+      "Query: But what are the risks during production of nanomaterials?\n",
+      "Answer: [Search(What are some nanomaterial production risks?)]\n",
+      "\n",
+      "Query: The colors on the flag of Ghana have the following meanings.\n",
+      "Answer: Red is for [Search(What is the meaning of Ghana's flag being red?)], green for forests, and gold for mineral wealth.\n",
+      "\n",
+      "Query: What did the author do during his time in college?\n",
+      "Answer: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as [Search(What humanities classes did the author take in college?)].\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "Now given the query, please answer the following question. You may use the Search API \"[Search(query)]\" whenever possible.\n",
+      "If the answer is complete and no longer contains any \"[Search(query)]\" tags, write \"done\" to finish the task.\n",
+      "\n",
+      "\n",
+      "Query: What did the author do during his time in college?\n",
+      "Answer: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t     \n",
+      "\u001b[38;5;200m\u001b[1;3mLookahead response: [Search(What humanities classes did the author take in college?)]\n",
+      "\u001b[0mquery tasks: [QueryTask(query_str='What humanities classes did the author take in college?', start_idx=0, end_idx=64)]\n",
+      "query_answer:  The context information does not provide any information about the humanities classes the author took in college.\n",
+      "updated lookahead_resp: The context information does not provide any information about the humanities classes the author took in college.\n",
+      "relevant_lookahead_resp:  The context information does not provide any information about t\n",
+      "\u001b[36;1m\u001b[1;3mCurrent response: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t\n",
+      "\u001b[0mSkill 1. Use the Search API to look up relevant information by writing \"[Search(query)]\" where \"query\" is the search query you want to look up. For example: \n",
+      "\n",
+      "Query: But what are the risks during production of nanomaterials?\n",
+      "Answer: [Search(What are some nanomaterial production risks?)]\n",
+      "\n",
+      "Query: The colors on the flag of Ghana have the following meanings.\n",
+      "Answer: Red is for [Search(What is the meaning of Ghana's flag being red?)], green for forests, and gold for mineral wealth.\n",
+      "\n",
+      "Query: What did the author do during his time in college?\n",
+      "Answer: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as [Search(What humanities classes did the author take in college?)].\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "Now given the query, please answer the following question. You may use the Search API \"[Search(query)]\" whenever possible.\n",
+      "If the answer is complete and no longer contains any \"[Search(query)]\" tags, write \"done\" to finish the task.\n",
+      "\n",
+      "\n",
+      "Query: What did the author do during his time in college?\n",
+      "Answer: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t     \n",
+      "\u001b[38;5;200m\u001b[1;3mLookahead response: [Search(What humanities classes did the author take in college?)]\n",
+      "\u001b[0mquery tasks: [QueryTask(query_str='What humanities classes did the author take in college?', start_idx=0, end_idx=64)]\n",
+      "query_answer:  The context information does not provide any information about the humanities classes the author took in college.\n",
+      "updated lookahead_resp: The context information does not provide any information about the humanities classes the author took in college.\n",
+      "relevant_lookahead_resp:  The context information does not provide any information about t\n",
+      "\u001b[36;1m\u001b[1;3mCurrent response: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t\n",
+      "\u001b[0mSkill 1. Use the Search API to look up relevant information by writing \"[Search(query)]\" where \"query\" is the search query you want to look up. For example: \n",
+      "\n",
+      "Query: But what are the risks during production of nanomaterials?\n",
+      "Answer: [Search(What are some nanomaterial production risks?)]\n",
+      "\n",
+      "Query: The colors on the flag of Ghana have the following meanings.\n",
+      "Answer: Red is for [Search(What is the meaning of Ghana's flag being red?)], green for forests, and gold for mineral wealth.\n",
+      "\n",
+      "Query: What did the author do during his time in college?\n",
+      "Answer: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as [Search(What humanities classes did the author take in college?)].\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "Now given the query, please answer the following question. You may use the Search API \"[Search(query)]\" whenever possible.\n",
+      "If the answer is complete and no longer contains any \"[Search(query)]\" tags, write \"done\" to finish the task.\n",
+      "\n",
+      "\n",
+      "Query: What did the author do during his time in college?\n",
+      "Answer: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t     \n",
+      "\u001b[38;5;200m\u001b[1;3mLookahead response: [Search(What humanities classes did the author take in college?)]\n",
+      "\u001b[0mquery tasks: [QueryTask(query_str='What humanities classes did the author take in college?', start_idx=0, end_idx=64)]\n",
+      "query_answer:  The context information does not provide any information about the humanities classes the author took in college.\n",
+      "updated lookahead_resp: The context information does not provide any information about the humanities classes the author took in college.\n",
+      "relevant_lookahead_resp:  The context information does not provide any information about t\n",
+      "\u001b[36;1m\u001b[1;3mCurrent response: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t\n",
+      "\u001b[0mSkill 1. Use the Search API to look up relevant information by writing \"[Search(query)]\" where \"query\" is the search query you want to look up. For example: \n",
+      "\n",
+      "Query: But what are the risks during production of nanomaterials?\n",
+      "Answer: [Search(What are some nanomaterial production risks?)]\n",
+      "\n",
+      "Query: The colors on the flag of Ghana have the following meanings.\n",
+      "Answer: Red is for [Search(What is the meaning of Ghana's flag being red?)], green for forests, and gold for mineral wealth.\n",
+      "\n",
+      "Query: What did the author do during his time in college?\n",
+      "Answer: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as [Search(What humanities classes did the author take in college?)].\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "Now given the query, please answer the following question. You may use the Search API \"[Search(query)]\" whenever possible.\n",
+      "If the answer is complete and no longer contains any \"[Search(query)]\" tags, write \"done\" to finish the task.\n",
+      "\n",
+      "\n",
+      "Query: What did the author do during his time in college?\n",
+      "Answer: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t     \n",
+      "\u001b[38;5;200m\u001b[1;3mLookahead response: [Search(What humanities classes did the author take in college?)]\n",
+      "\u001b[0mquery tasks: [QueryTask(query_str='What humanities classes did the author take in college?', start_idx=0, end_idx=64)]\n",
+      "query_answer:  The context information does not provide any information about the humanities classes the author took in college.\n",
+      "updated lookahead_resp: The context information does not provide any information about the humanities classes the author took in college.\n",
+      "relevant_lookahead_resp:  The context information does not provide any information about t\n",
+      "\u001b[36;1m\u001b[1;3mCurrent response: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t\n",
+      "\u001b[0mSkill 1. Use the Search API to look up relevant information by writing \"[Search(query)]\" where \"query\" is the search query you want to look up. For example: \n",
+      "\n",
+      "Query: But what are the risks during production of nanomaterials?\n",
+      "Answer: [Search(What are some nanomaterial production risks?)]\n",
+      "\n",
+      "Query: The colors on the flag of Ghana have the following meanings.\n",
+      "Answer: Red is for [Search(What is the meaning of Ghana's flag being red?)], green for forests, and gold for mineral wealth.\n",
+      "\n",
+      "Query: What did the author do during his time in college?\n",
+      "Answer: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as [Search(What humanities classes did the author take in college?)].\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "Now given the query, please answer the following question. You may use the Search API \"[Search(query)]\" whenever possible.\n",
+      "If the answer is complete and no longer contains any \"[Search(query)]\" tags, write \"done\" to finish the task.\n",
+      "\n",
+      "\n",
+      "Query: What did the author do during his time in college?\n",
+      "Answer: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t     \n",
+      "\u001b[38;5;200m\u001b[1;3mLookahead response: [Search(What humanities classes did the author take in college?)]\n",
+      "\u001b[0mquery tasks: [QueryTask(query_str='What humanities classes did the author take in college?', start_idx=0, end_idx=64)]\n",
+      "query_answer:  The context information does not provide any information about the humanities classes the author took in college.\n",
+      "updated lookahead_resp: The context information does not provide any information about the humanities classes the author took in college.\n",
+      "relevant_lookahead_resp:  The context information does not provide any information about t\n",
+      "\u001b[36;1m\u001b[1;3mCurrent response: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t\n",
+      "\u001b[0mSkill 1. Use the Search API to look up relevant information by writing \"[Search(query)]\" where \"query\" is the search query you want to look up. For example: \n",
+      "\n",
+      "Query: But what are the risks during production of nanomaterials?\n",
+      "Answer: [Search(What are some nanomaterial production risks?)]\n",
+      "\n",
+      "Query: The colors on the flag of Ghana have the following meanings.\n",
+      "Answer: Red is for [Search(What is the meaning of Ghana's flag being red?)], green for forests, and gold for mineral wealth.\n",
+      "\n",
+      "Query: What did the author do during his time in college?\n",
+      "Answer: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as [Search(What humanities classes did the author take in college?)].\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "Now given the query, please answer the following question. You may use the Search API \"[Search(query)]\" whenever possible.\n",
+      "If the answer is complete and no longer contains any \"[Search(query)]\" tags, write \"done\" to finish the task.\n",
+      "\n",
+      "\n",
+      "Query: What did the author do during his time in college?\n",
+      "Answer: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t     \n",
+      "\u001b[38;5;200m\u001b[1;3mLookahead response: [Search(What humanities classes did the author take in college?)]\n",
+      "\u001b[0mquery tasks: [QueryTask(query_str='What humanities classes did the author take in college?', start_idx=0, end_idx=64)]\n",
+      "query_answer:  The context information does not provide any information about the humanities classes the author took in college.\n",
+      "updated lookahead_resp: The context information does not provide any information about the humanities classes the author took in college.\n",
+      "relevant_lookahead_resp:  The context information does not provide any information about t\n",
+      "\u001b[36;1m\u001b[1;3mCurrent response: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t\n",
+      "\u001b[0mSkill 1. Use the Search API to look up relevant information by writing \"[Search(query)]\" where \"query\" is the search query you want to look up. For example: \n",
+      "\n",
+      "Query: But what are the risks during production of nanomaterials?\n",
+      "Answer: [Search(What are some nanomaterial production risks?)]\n",
+      "\n",
+      "Query: The colors on the flag of Ghana have the following meanings.\n",
+      "Answer: Red is for [Search(What is the meaning of Ghana's flag being red?)], green for forests, and gold for mineral wealth.\n",
+      "\n",
+      "Query: What did the author do during his time in college?\n",
+      "Answer: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as [Search(What humanities classes did the author take in college?)].\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n",
+      "Now given the query, please answer the following question. You may use the Search API \"[Search(query)]\" whenever possible.\n",
+      "If the answer is complete and no longer contains any \"[Search(query)]\" tags, write \"done\" to finish the task.\n",
+      "\n",
+      "\n",
+      "Query: What did the author do during his time in college?\n",
+      "Answer: The author took introductory CS classes during his freshman year. He also took some humanities classes, such as The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t The context information does not provide any information about t     \n",
+      "\u001b[38;5;200m\u001b[1;3mLookahead response: [Search(What humanities classes did the author take in college?)]\n",
+      "\u001b[0mquery tasks: [QueryTask(query_str='What humanities classes did the author take in college?', start_idx=0, end_idx=64)]\n",
+      "query_answer:  The context information does not provide any information about the humanities classes the author took in college.\n",
+      "updated lookahead_resp: The context information does not provide any information about the humanities classes the author took in college.\n",
+      "relevant_lookahead_resp:  The context information does not provide any information about t\n"
+     ]
+    }
+   ],
+   "source": [
+    "response = flare_query_engine.query(\"What did the author do during his time in college?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "78085cc6-d9b7-486b-8c6c-5ad092678642",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "llama_index_v2",
+   "language": "python",
+   "name": "llama_index_v2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/llama_index/query_engine/__init__.py
+++ b/llama_index/query_engine/__init__.py
@@ -11,6 +11,7 @@ from llama_index.query_engine.sql_join_query_engine import SQLJoinQueryEngine
 from llama_index.query_engine.sql_vector_query_engine import SQLAutoVectorQueryEngine
 from llama_index.query_engine.sub_question_query_engine import SubQuestionQueryEngine
 from llama_index.query_engine.transform_query_engine import TransformQueryEngine
+from llama_index.query_engine.flare_query_engine import FLAREInstructQueryEngine
 
 __all__ = [
     "CitationQueryEngine",
@@ -24,4 +25,5 @@ __all__ = [
     "SQLJoinQueryEngine",
     "SQLAutoVectorQueryEngine",
     "RetryQueryEngine",
+    "FLAREInstructQueryEngine",
 ]

--- a/llama_index/query_engine/flare_query_engine.py
+++ b/llama_index/query_engine/flare_query_engine.py
@@ -1,0 +1,281 @@
+"""Query engines based on the FLARE paper.
+
+Active Retrieval Augmented Generation.
+
+"""
+
+from langchain.input import print_text
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, Tuple, cast
+from llama_index.indices.query.base import BaseQueryEngine
+from llama_index.indices.service_context import ServiceContext
+from llama_index.indices.query.schema import QueryBundle
+from llama_index.response.schema import RESPONSE_TYPE, Response
+from llama_index.prompts.base import Prompt
+from llama_index.indices.base_retriever import BaseRetriever
+from llama_index.indices.query.base import BaseQueryEngine
+from llama_index.output_parsers.base import BaseOutputParser
+from llama_index.callbacks.base import CallbackManager
+
+
+# These prompts are taken from the FLARE repo:
+# https://github.com/jzbjyb/FLARE/blob/main/src/templates.py
+
+DEFAULT_EXAMPLES = """
+Query: But what are the risks during production of nanomaterials?
+Answer: [Search(What are some nanomaterial production risks?)]
+
+Query: The colors on the flag of Ghana have the following meanings.
+Answer: Red is for [Search(What is the meaning of Ghana's flag being red?)], green for forests, and gold for mineral wealth.
+
+Query: What did the author do during his time in college?
+Answer: The author took introductory CS classes during his freshman year. He also took some \
+humanities classes, such as [Search(What humanities classes did the author take in college?)].
+
+"""
+
+DEFAULT_FIRST_SKILL = f"""\
+Skill 1. Use the Search API to look up relevant information by writing "[Search(query)]" where "query" is the search query you want to look up. For example: 
+{DEFAULT_EXAMPLES}
+
+"""
+
+# DEFAULT_SECOND_SKILL = f"""\
+# Skill 2. Answer questions by thinking step-by-step. First, write out the reasoning steps, then draw the conclusion.
+
+# """
+
+# DEFAULT_THIRD_SKILL = f"""\
+# Now, combine the aforementioned two skills. First, write out the reasoning steps, then draw the conclusion, \
+# where the reasoning steps should also utilize the Search API "[Search(query)]" whenever possible.
+
+# When you are done, write "done" to finish the task.\
+
+# """
+
+# DEFAULT_INSTRUCT_PROMPT_TMPL = (
+#     DEFAULT_FIRST_SKILL
+#     + DEFAULT_SECOND_SKILL
+#     + DEFAULT_THIRD_SKILL
+#     + (
+#         """
+# Query: {query_str}
+# Answer: {existing_answer} \
+#     """
+#     )
+# )
+
+DEFAULT_END = """
+Now given the query, please answer the following question. You may use the Search API \
+"[Search(query)]" whenever possible.
+If the answer is complete and no longer contains any "[Search(query)]" tags, write "done" to finish the task.
+
+"""
+
+DEFAULT_INSTRUCT_PROMPT_TMPL = (
+    DEFAULT_FIRST_SKILL
+    + DEFAULT_END
+    + (
+        """
+Query: {query_str}
+Answer: {existing_answer} \
+    """
+    )
+)
+
+DEFAULT_INSTRUCT_PROMPT = Prompt(DEFAULT_INSTRUCT_PROMPT_TMPL)
+
+
+def default_parse_is_done_fn(response: str) -> bool:
+    """Default parse is done function."""
+    return "done" in response.lower()
+
+
+def default_format_done_answer(response: str) -> str:
+    """Default format done answer."""
+    return response.replace("done", "").strip()
+
+
+class IsDoneOutputParser(BaseOutputParser):
+    """Is done output parser."""
+
+    def __init__(
+        self,
+        is_done_fn: Optional[Callable[[str], bool]] = None,
+        fmt_answer_fn: Optional[Callable[[str], str]] = None,
+    ) -> None:
+        """Init params."""
+        self._is_done_fn = is_done_fn or default_parse_is_done_fn
+        self._fmt_answer_fn = fmt_answer_fn or default_format_done_answer
+
+    def parse(self, output: str) -> Any:
+        """Parse output."""
+        is_done = default_parse_is_done_fn(output)
+        if is_done:
+            return True, self._fmt_answer_fn(output)
+        else:
+            return False, output
+
+    def format(self, output: str) -> str:
+        """Format a query with structured output formatting instructions."""
+        raise NotImplementedError
+
+
+class QueryTaskOutputParser(BaseOutputParser):
+    """QueryTask output parser.
+
+    By default, parses output that contains "[Search(query)]" tags.
+
+    """
+
+    def parse(self, output: str) -> Any:
+        """Parse output."""
+        query_tasks = []
+        for idx, char in enumerate(output):
+            if char == "[":
+                start_idx = idx
+            elif char == "]":
+                end_idx = idx
+                raw_query_str = output[start_idx + 1 : end_idx]
+                query_str = raw_query_str.split("(")[1].split(")")[0]
+                query_tasks.append(QueryTask(query_str, start_idx, end_idx))
+        return query_tasks
+
+    def format(self, output: str) -> str:
+        """Format a query with structured output formatting instructions."""
+        raise NotImplementedError
+
+
+@dataclass
+class QueryTask:
+    """Query task."""
+
+    query_str: str
+    start_idx: int
+    end_idx: int
+
+
+class FLAREInstructQueryEngine(BaseQueryEngine):
+    """FLARE Instruct query engine.
+
+    This is the version of FLARE that uses retrieval-encouraging instructions.
+
+    Args:
+
+    """
+
+    def __init__(
+        self,
+        query_engine: BaseQueryEngine,
+        service_context: Optional[ServiceContext] = None,
+        instruct_prompt: Optional[Prompt] = None,
+        done_output_parser: Optional[IsDoneOutputParser] = None,
+        query_task_output_parser: Optional[QueryTaskOutputParser] = None,
+        max_iterations: int = 10,
+        max_lookahead_query_tasks: int = 1,
+        callback_manager: Optional[CallbackManager] = None,
+        verbose: bool = False,
+    ) -> None:
+        """Init params."""
+        super().__init__(callback_manager=callback_manager)
+        self._query_engine = query_engine
+        self._service_context = service_context or ServiceContext.from_defaults()
+        self._instruct_prompt = instruct_prompt or DEFAULT_INSTRUCT_PROMPT
+        self._done_output_parser = done_output_parser or IsDoneOutputParser()
+        self._query_task_output_parser = (
+            query_task_output_parser or QueryTaskOutputParser()
+        )
+        self._max_iterations = max_iterations
+        self._max_lookahead_query_tasks = max_lookahead_query_tasks
+        self._verbose = verbose
+
+    def _insert_answer(
+        self,
+        response: str,
+        query_task: QueryTask,
+        answer: str,
+    ) -> str:
+        """Insert answer into response."""
+        return (
+            response[: query_task.start_idx]
+            + answer
+            + response[query_task.end_idx + 1 :]
+        )
+
+    def _query(self, query_bundle: QueryBundle) -> RESPONSE_TYPE:
+        """Query and get response."""
+        print_text(f"Query: {query_bundle.query_str}\n", color="green")
+        cur_response = ""
+        source_nodes = []
+        for iter in range(self._max_iterations):
+            if self._verbose:
+                print_text(f"Current response: {cur_response}\n", color="blue")
+            # generate "lookahead response" that contains "[Search(query)]" tags
+            # e.g.
+            # The colors on the flag of Ghana have the following meanings. Red is
+            # for [Search(Ghana flag meaning)],...
+            lookahead_resp, fmt_response = self._service_context.llm_predictor.predict(
+                self._instruct_prompt,
+                query_str=query_bundle.query_str,
+                existing_answer=cur_response,
+            )
+            lookahead_resp = lookahead_resp.strip()
+            print(fmt_response)
+            print_text(f"Lookahead response: {lookahead_resp}\n", color="pink")
+
+            is_done, fmt_lookahead = self._done_output_parser.parse(lookahead_resp)
+            if is_done:
+                cur_response = cur_response.strip() + " " + fmt_lookahead.strip()
+                break
+
+            # parse lookahead response into query tasks
+            query_tasks = self._query_task_output_parser.parse(lookahead_resp)
+
+            print(f"query tasks: {query_tasks}")
+
+            # get answers for each query task
+            query_tasks = query_tasks[: self._max_lookahead_query_tasks]
+            query_answers = []
+            for idx, query_task in enumerate(query_tasks):
+                answer_obj = self._query_engine.query(query_task.query_str)
+                if not isinstance(answer_obj, Response):
+                    raise ValueError(
+                        f"Expected Response object, got {type(answer_obj)} instead."
+                    )
+                query_answer = answer_obj.response
+                query_answers.append(query_answer)
+
+            # update lookahead response
+            # TODO:
+
+            # for idx, query_task in enumerate(query_tasks):
+            #     if idx >= self._max_lookahead_query_tasks:
+            #         break
+            #     # get answer
+            #     answer_obj = self._query_engine.query(query_task.query_str)
+            #     if not isinstance(answer_obj, Response):
+            #         raise ValueError(
+            #             f"Expected Response object, got {type(answer_obj)} instead."
+            #         )
+            #     query_answer = answer_obj.response
+            #     print("query_answer: ", query_answer)
+            #     source_nodes.extend(answer_obj.source_nodes)
+            #     # replace answer
+            #     lookahead_resp = self._insert_answer(
+            #         lookahead_resp, query_task, query_answer
+            #     )
+            #     print(f"updated lookahead_resp: {lookahead_resp}")
+
+            # get relevant lookahead response by truncation
+            truncate_idx = query_tasks[-1].end_idx
+            relevant_lookahead_resp = lookahead_resp[:truncate_idx]
+            print("relevant_lookahead_resp: ", relevant_lookahead_resp)
+
+            # append the relevant lookahead response to the final response
+            cur_response = cur_response.strip() + " " + relevant_lookahead_resp.strip()
+
+        # NOTE: at the moment, does not support streaming
+        return Response(response=cur_response)
+
+    async def _aquery(self, query_bundle: QueryBundle) -> RESPONSE_TYPE:
+        return self._query(query_bundle)


### PR DESCRIPTION
# Description

Initial implementation of FLARE, specifically the instruction variant where we use the LLM to generate "Search" tags to do a secondary retrieval pass.

I couldn't quite grok everything in the source repo, but I did implement an initial version that I felt made sense:
- At the beginning, feed in user query and the existing answer.
- Generate a "lookahead" sentence that contains "search" tags. Parse this lookahead sentence and extract the search tags, and run those against a query engine to extract the answers. Insert into the lookahead template for an actual answer.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [x] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
