### PR TITLE
Fix schema error of pinecone date type

### DIFF
--- a/llama_index/schema.py
+++ b/llama_index/schema.py
@@ -1,6 +1,7 @@
 """Base schema for data structures."""
 from abc import abstractmethod
 from dataclasses import dataclass
+from datetime import datetime
 from hashlib import sha256
 from typing import Any, Dict, List, Optional
 
@@ -17,7 +18,7 @@ def _validate_is_flat_dict(metadata_dict: dict) -> None:
     for key, val in metadata_dict.items():
         if not isinstance(key, str):
             raise ValueError("Metadata key must be str!")
-        if not isinstance(val, (str, int, float, type(None))):
+        if not isinstance(val, (str, int, float, type(None), datetime)):
             raise ValueError("Value must be one of (str, int, float, None)")
 
 


### PR DESCRIPTION
# Description

The date type extra_info field would cause a ValueError when retrieving data from Pinecone. The error occurred because the date was not stored as a string, while Llama_index requires values to be one of (str, int, float, None).


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
some steps to reproduce
```
def text_to_document(texts: List[str], corpus:str, source:str) -> List[LlamaDocument]:  
    """Return a Document object from a text string."""  
    documents = []  
    for line in texts:  
        metadata = {  
            "source": source,  
            "corpus": corpus,  
            "creare_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S")  
        }  
        document = LlamaDocument(line.strip(), extra_info=metadata)  
        documents.append(document)  
    return documents  
  
docs = text_to_document(["test case"], "it-corpus", "service-record")  
print(type(docs[0].extra_info["creare_at"]))  
  
for doc in docs:  
    nodes = index.service_context.node_parser.get_nodes_from_documents([doc])  
    index.insert_nodes(nodes)  
  
query_engine = index.as_query_engine()  
print(query_engine.query("test case"))  
```

it will output
```
<class 'str'>
Traceback (most recent call last):
.....
  File "/Users/ianz/Work/miniconda3/envs/autoxx/lib/python3.10/site-packages/llama_index/schema.py", line 21, in _validate_is_flat_dict
    raise ValueError("Value must be one of (str, int, float, None)")
ValueError: Value must be one of (str, int, float, None)
```


- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
