### PR TITLE
docs: replace comma with colon in dict object

### DIFF
--- a/docs/how_to/customization/custom_documents.md
+++ b/docs/how_to/customization/custom_documents.md
@@ -12,7 +12,7 @@ There are a few ways to set up this dictionary:
 document = Document(
     'text', 
     extra_info={
-        'filename', '<doc_file_name>', 
+        'filename': '<doc_file_name>', 
         'category': '<category>'
     }
 )
@@ -21,7 +21,7 @@ document = Document(
 2. After the document is created:
 
 ```python
-document.extra_info = {'filename', '<doc_file_name>'}
+document.extra_info = {'filename': '<doc_file_name>'}
 ```
 
 3. Set the filename automatically using the `SimpleDirectoryReader` and `file_metadata` hook. This will automatically run the hook on each document to set the `extra_info` field:


### PR DESCRIPTION
# Description

The change involves correcting the syntax of the extra_info dictionary in the Document constructor and the subsequent assignment to document.extra_info. The issue fixed is the incorrect syntax of the extra_info dictionary in the old documentation.

So mainly, I replaced `,` with `:`

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] No tests needed

# Suggested Checklist:
- [x] I have made corresponding changes to the documentation
