### PR TITLE
chat engine should inherit service context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### New Features
 - Add node doc_id filtering to weaviate (#6467)
 
+### Bug Fixes / Nits
+- `as_chat_engine` properly inherits the current service context (#6470)
+
 ## [v0.6.26] - 2023-06-14
 
 ### New Features

--- a/llama_index/indices/base.py
+++ b/llama_index/indices/base.py
@@ -348,7 +348,9 @@ class BaseIndex(Generic[IS], ABC):
 
             query_engine = self.as_query_engine(**kwargs)
             return CondenseQuestionChatEngine.from_defaults(
-                query_engine=query_engine, **kwargs
+                query_engine=query_engine,
+                service_context=self.service_context,
+                **kwargs,
             )
         elif chat_mode == ChatMode.REACT:
             # NOTE: lazy import
@@ -356,7 +358,9 @@ class BaseIndex(Generic[IS], ABC):
 
             query_engine = self.as_query_engine(**kwargs)
             return ReActChatEngine.from_query_engine(
-                query_engine=query_engine, **kwargs
+                query_engine=query_engine,
+                service_context=self.service_context,
+                **kwargs,
             )
         else:
             raise ValueError(f"Unknown chat mode: {chat_mode}")


### PR DESCRIPTION
# Description

chat engine should inherit service context

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
