### PR TITLE
[fix document] JSONReader parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bug Fixes / Nits
 - `as_chat_engine` properly inherits the current service context (#6470)
+- use namespace when deleting from pinecone (#6475)
 
 ## [v0.6.26] - 2023-06-14
 

--- a/llama_index/readers/json.py
+++ b/llama_index/readers/json.py
@@ -54,15 +54,15 @@ class JSONReader(BaseReader):
 
     Args:
         levels_back (int): the number of levels to go back in the JSON tree, 0
-        if you want all levels. If levels_back is None, then we just format the
-        JSON and make each line an embedding
+          if you want all levels. If levels_back is None, then we just format the
+          JSON and make each line an embedding
 
         collapse_length (int): the maximum number of characters a JSON fragment
-        would be collapsed in the output (levels_back needs to be not None)
-        ex: if collapse_length = 10, and
-        input is {a: [1, 2, 3], b: {"hello": "world", "foo": "bar"}}
-        then a would be collapsed into one line, while b would not.
-        Recommend starting around 100 and then adjusting from there.
+          would be collapsed in the output (levels_back needs to be not None)
+          ex: if collapse_length = 10, and
+          input is {a: [1, 2, 3], b: {"hello": "world", "foo": "bar"}}
+          then a would be collapsed into one line, while b would not.
+          Recommend starting around 100 and then adjusting from there.
 
     """
 


### PR DESCRIPTION
# Description

The display of the JSONReader parameter documentation is broken due to missing indentation.

I have added indentation and fixed it so that the parameters are displayed correctly.

before:
<img width="764" alt="image" src="https://github.com/jerryjliu/llama_index/assets/989985/86a16125-1179-4e2a-ad9e-ba9d93089422">

after:
<img width="740" alt="image" src="https://github.com/jerryjliu/llama_index/assets/989985/eea184cb-6b7b-452d-9516-2378f8602295">

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
