### PR TITLE
fix delete bug using pinecone vector store

### DIFF
--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -238,7 +238,9 @@ class PineconeVectorStore(VectorStore):
         """
         # delete by filtering on the doc_id metadata
         self._pinecone_index.delete(
-            filter={"doc_id": {"$eq": ref_doc_id}}, **delete_kwargs
+            filter={"doc_id": {"$eq": ref_doc_id}},
+            namespace=self._namespace,
+            **delete_kwargs,
         )
 
     @property


### PR DESCRIPTION
# Description

If the namespace is set for the pinecone vector store, deleting the corresponding vector from pinecone will not succeed cause by the deleted code does not set the correct namespace

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [] Added new unit/integration tests
- [] Added new notebook (that tests end-to-end)
- [] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
