### PR TITLE
Allow SimpleDirectoryReader to support custom file extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@
 
 ### Bug Fixes / Nits
 - `as_chat_engine` properly inherits the current service context (#6470)
-- use namespace when deleting from pinecone (#6475)
-- fix paths when using fsspec on windows (#3778)
+- Use namespace when deleting from pinecone (#6475)
+- Fix paths when using fsspec on windows (#3778)
+- Fix for using custom file readers in `SimpleDirectoryReader` (#6477)
 
 ## [v0.6.26] - 2023-06-14
 

--- a/llama_index/readers/file/base.py
+++ b/llama_index/readers/file/base.py
@@ -182,7 +182,7 @@ class SimpleDirectoryReader(BaseReader):
                 metadata = self.file_metadata(str(input_file))
 
             file_suffix = input_file.suffix.lower()
-            if file_suffix in self.supported_suffix:
+            if file_suffix in self.supported_suffix or file_suffix in self.file_extractor:
                 # use file readers
                 if file_suffix not in self.file_extractor:
                     # instantiate file reader if not already

--- a/llama_index/readers/file/base.py
+++ b/llama_index/readers/file/base.py
@@ -182,7 +182,10 @@ class SimpleDirectoryReader(BaseReader):
                 metadata = self.file_metadata(str(input_file))
 
             file_suffix = input_file.suffix.lower()
-            if file_suffix in self.supported_suffix or file_suffix in self.file_extractor:
+            if (
+                file_suffix in self.supported_suffix
+                or file_suffix in self.file_extractor
+            ):
                 # use file readers
                 if file_suffix not in self.file_extractor:
                     # instantiate file reader if not already


### PR DESCRIPTION
# Description

For now, SimpleDirectoryReader only supports the default file extensions as mentioned in DEFAULT_FILE_READER_CLS.
By checking if the file extension is in one of the (optional) file_extractors, we allow the developer to use the classic SimpleDirectoryReader class not only with custom readers but also with other file extensions.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update (**more precisely a clarification**)

# How Has This Been Tested?
Create a directory to read and copy in there a markdown file. Rename the extension to whatever you want (for example: "new_ext_but_really_md").
Then create a `SimpleDirectoryReader` instance with a `file_extractor` dict with the new extension handled by `MarkdownReader` and call `load_data()`
```
documents = SimpleDirectoryReader(doc_folder, file_extractor={".new_ext_but_really_md": MarkdownReader() }).load_data()
```

