### PR TITLE
[Issue 6417] Fix prompt_templates docs page

### DIFF
--- a/docs/reference/prompts.rst
+++ b/docs/reference/prompts.rst
@@ -20,15 +20,6 @@ The list of ChatGPT refine prompts can be
 `found here <https://github.com/jerryjliu/llama_index/blob/main/llama_index/prompts/chat_prompts.py>`_.
 
 
-Prompts
-^^^^^^^
-
-.. automodule:: llama_index.prompts.prompts
-   :members:
-   :inherited-members:
-   :exclude-members: get_full_format_args
-
-
 Base Prompt Class
 ^^^^^^^^^^^^^^^^^
 
@@ -37,3 +28,7 @@ Base Prompt Class
    :inherited-members:
    :exclude-members: Config, construct, copy, dict, from_examples, from_file, get_full_format_args, output_parser, save, template, template_format, update_forward_refs, validate_variable_names, json, template_is_valid
 
+
+Subclass Prompts (deprecated)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Deprecated, but still available for reference at `this link <https://github.com/jerryjliu/llama_index/blob/113109365b216428440b19eb23c9fae749d6880a/llama_index/prompts/prompts.py>`_.


### PR DESCRIPTION
# Description
Documents fix for prompt_templates 
 - Mark Subclass Prompt types as deprecated 
 - Remove the erroneous autogen doc for the Subclass Prompts (Sphinx used the comment _after_ the object as the docstring, which caused most of the docstrings in wrong order). 
 
Fixes # (issue)
Issue 6417

## Type of Change
Documentation

Please delete options that are not relevant.
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [] build and run local Sphinx doc 

# Suggested Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
