### PR TITLE
Fix: use "generation" as default response_mode for EmptyIndex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ modules/
 # pipenv
 Pipfile
 Pipfile.lock
+
+# pyright
+pyrightconfig.json

--- a/llama_index/indices/empty/base.py
+++ b/llama_index/indices/empty/base.py
@@ -11,6 +11,7 @@ from llama_index.data_structs.data_structs import EmptyIndexStruct
 from llama_index.data_structs.node import Node
 from llama_index.indices.base import BaseIndex
 from llama_index.indices.base_retriever import BaseRetriever
+from llama_index.indices.query.base import BaseQueryEngine
 from llama_index.indices.service_context import ServiceContext
 from llama_index.storage.docstore.types import RefDocInfo
 
@@ -47,6 +48,11 @@ class EmptyIndex(BaseIndex[EmptyIndexStruct]):
         from llama_index.indices.empty.retrievers import EmptyIndexRetriever
 
         return EmptyIndexRetriever(self)
+
+    def as_query_engine(self, **kwargs: Any) -> BaseQueryEngine:
+        if "response_mode" not in kwargs:
+            kwargs["response_mode"] = "generation"
+        return super().as_query_engine(**kwargs)
 
     def _build_index_from_nodes(self, nodes: Sequence[Node]) -> EmptyIndexStruct:
         """Build the index from documents.

--- a/llama_index/indices/empty/base.py
+++ b/llama_index/indices/empty/base.py
@@ -52,6 +52,10 @@ class EmptyIndex(BaseIndex[EmptyIndexStruct]):
     def as_query_engine(self, **kwargs: Any) -> BaseQueryEngine:
         if "response_mode" not in kwargs:
             kwargs["response_mode"] = "generation"
+        else:
+            if kwargs["response_mode"] != "generation":
+                raise ValueError("EmptyIndex only supports response_mode=generation.")
+
         return super().as_query_engine(**kwargs)
 
     def _build_index_from_nodes(self, nodes: Sequence[Node]) -> EmptyIndexStruct:


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
The current version of `EmptyIndex` uses the `CompactRefine` response_mode for synthesis. This doesn't seem to work and the `Generation` response_mode is better suited to be the default here
Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
