### PR TITLE
Fix bug where KG relation was added as node in get_networkx_graph

### DIFF
--- a/llama_index/indices/knowledge_graph/base.py
+++ b/llama_index/indices/knowledge_graph/base.py
@@ -272,7 +272,7 @@ class KnowledgeGraphIndex(BaseIndex[KG]):
         # add edges
         rel_map = self._graph_store.get_rel_map(list(g.nodes().keys()), 1)
         for keyword in rel_map.keys():
-            for obj, rel in rel_map[keyword]:
+            for rel, obj in rel_map[keyword]:
                 g.add_edge(keyword, obj, label=rel, title=rel)
 
         return g


### PR DESCRIPTION
# Description

Simple change that fixes a small bug in KnowledgeGraphIndex#get_networkx_graph method. The bug caused the relation between two nodes to be added as a node in the network_x graph, instead of being added as a label on the edge.

With this fix, the networkx graph are constructed correctly, which is useful for anyone using networkx to visualize etc.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Outputted a full networkx graph with nodes and edges before and after, and confirmed the change resulted in correct structure. Also used pyvis to render the graph and confirm visually.

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
