### PR TITLE
Update vector_stores.md

### DIFF
--- a/docs/how_to/integrations/vector_stores.md
+++ b/docs/how_to/integrations/vector_stores.md
@@ -24,6 +24,7 @@ as the storage backend for `VectorStoreIndex`.
 - Supabase (`SupabaseVectorStore`). [Quickstart](https://supabase.github.io/vecs/api/).
 - DocArray (`DocArrayHnswVectorStore`, `DocArrayInMemoryVectorStore`). [Installation/Python Client](https://github.com/docarray/docarray#installation).
 - MongoDB Atlas (`MongoDBAtlasVectorSearch`). [Installation/Quickstart] (https://www.mongodb.com/atlas/database).
+- Redis (`RedisVectorStore`). [Installation](https://redis.io/docs/getting-started/installation/).
 
 A detailed API reference is [found here](/reference/indices/vector_store.rst).
 
@@ -75,6 +76,7 @@ response = query_engine.query("What did the author do growing up?")
 Below we show more examples of how to construct various vector stores we support.
 
 **Redis**
+
 First, start Redis-Stack (or get url from Redis provider)
 
 ```bash


### PR DESCRIPTION
Adding missing bullet for Redis in the list of backends.

# Description

The bullet list at the top of this document did not include Redis. I would expect the list to include Redis, because every other backend mentioned in the document is also mentioned in the list. This fixes what appears to be an oversight in the docs.

Fixes #1895 

## Type of Change

- [x] This change requires a documentation update
