### PR TITLE
fix(predictor): register callback for streaming response

### DIFF
--- a/llama_index/langchain_helpers/streaming.py
+++ b/llama_index/langchain_helpers/streaming.py
@@ -3,14 +3,20 @@ from threading import Event
 from typing import Any, Generator, Union
 
 from llama_index.bridge.langchain import BaseCallbackHandler, LLMResult
+from llama_index.callbacks.schema import CBEventType, EventPayload
 
 
 class StreamingGeneratorCallbackHandler(BaseCallbackHandler):
     """Streaming callback handler."""
 
-    def __init__(self) -> None:
+    def __init__(self, incomplete_payload, event_id, callback_manager) -> None:
         self._token_queue: Queue = Queue()
         self._done = Event()
+        self._callback_manager = callback_manager
+        self._prediction_token_count = 0
+        self._generated_response = ""
+        self._payload = incomplete_payload
+        self._event_id = event_id
 
     def __deepcopy__(self, memo: Any) -> "StreamingGeneratorCallbackHandler":
         # NOTE: hack to bypass deepcopy in langchain
@@ -18,9 +24,22 @@ class StreamingGeneratorCallbackHandler(BaseCallbackHandler):
 
     def on_llm_new_token(self, token: str, **kwargs: Any) -> Any:
         """Run on new LLM token. Only available when streaming is enabled."""
+        self._prediction_token_count += 1
         self._token_queue.put_nowait(token)
 
     def on_llm_end(self, response: LLMResult, **kwargs: Any) -> None:
+        self._payload["prediction_tokens_count"] = self._prediction_token_count
+        self._payload["total_tokens_used"] = (
+            self._payload["formatted_prompt_tokens_count"]
+            + self._prediction_token_count
+        )
+        self._payload[EventPayload.RESPONSE] = self._generated_response
+
+        self._callback_manager.on_event_end(
+            CBEventType.LLM,
+            payload=self._payload,
+            event_id=self._event_id,
+        )
         self._done.set()
 
     def on_llm_error(
@@ -32,6 +51,7 @@ class StreamingGeneratorCallbackHandler(BaseCallbackHandler):
         while True:
             if not self._token_queue.empty():
                 token = self._token_queue.get_nowait()
+                self._generated_response += token
                 yield token
             elif self._done.is_set():
                 break


### PR DESCRIPTION
# Description
Register callback to manager for streaming response

Fixes https://github.com/jerryjliu/llama_index/issues/6594

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

--- 

Unfortunately, this still does not work as expected. The trace will end when the query function completes due to context manager behaviour. 

Hence, the event registered by the streaming response will not be captured in the trace.