### PR TITLE
Add the ability to change chroma implementation

### DIFF
--- a/llama_index/readers/chroma.py
+++ b/llama_index/readers/chroma.py
@@ -22,6 +22,7 @@ class ChromaReader(BaseReader):
         collection_name: str,
         persist_directory: Optional[str] = None,
         chroma_api_impl: str = "rest",
+        chroma_db_impl: str = None,
         host: str = "localhost",
         port: int = 8000,
     ) -> None:
@@ -41,6 +42,7 @@ class ChromaReader(BaseReader):
         self._client = chromadb.Client(
             Settings(
                 chroma_api_impl=chroma_api_impl,
+                chroma_db_impl=chroma_db_impl or "chromadb.db.duckdb.DuckDB",
                 chroma_server_host=host,
                 chroma_server_http_port=port,
                 persist_directory=persist_directory

--- a/llama_index/readers/chroma.py
+++ b/llama_index/readers/chroma.py
@@ -22,7 +22,7 @@ class ChromaReader(BaseReader):
         collection_name: str,
         persist_directory: Optional[str] = None,
         chroma_api_impl: str = "rest",
-        chroma_db_impl: str = None,
+        chroma_db_impl: Optional[str] = None,
         host: str = "localhost",
         port: int = 8000,
     ) -> None:

--- a/llama_index/readers/chroma.py
+++ b/llama_index/readers/chroma.py
@@ -21,6 +21,7 @@ class ChromaReader(BaseReader):
         self,
         collection_name: str,
         persist_directory: Optional[str] = None,
+        chroma_api_impl: str = "rest",
         host: str = "localhost",
         port: int = 8000,
     ) -> None:
@@ -39,7 +40,7 @@ class ChromaReader(BaseReader):
 
         self._client = chromadb.Client(
             Settings(
-                chroma_api_impl="rest",
+                chroma_api_impl=chroma_api_impl,
                 chroma_server_host=host,
                 chroma_server_http_port=port,
                 persist_directory=persist_directory


### PR DESCRIPTION
# Description

Added the ability to use a local chroma store instead of server by changing `chroma_api_impl="duckdb+parquet"` in `ChromaReader`

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
