### PR TITLE
Backport old node name

### DIFF
--- a/llama_index/data_structs/__init__.py
+++ b/llama_index/data_structs/__init__.py
@@ -5,6 +5,7 @@ from llama_index.data_structs.data_structs import (
     IndexGraph,
     IndexList,
     KeywordTable,
+    Node,
 )
 
 from llama_index.data_structs.table import StructDatapoint
@@ -15,4 +16,5 @@ __all__ = [
     "IndexList",
     "IndexDict",
     "StructDatapoint",
+    "Node",
 ]

--- a/llama_index/data_structs/data_structs.py
+++ b/llama_index/data_structs/data_structs.py
@@ -11,8 +11,12 @@ from typing import Dict, List, Optional, Sequence, Set
 
 from dataclasses_json import DataClassJsonMixin
 
-from llama_index.schema import BaseNode
+from llama_index.schema import BaseNode, TextNode
 from llama_index.data_structs.struct_type import IndexStructType
+
+
+# TODO: legacy backport of old Node class
+Node = TextNode
 
 
 @dataclass

--- a/llama_index/schema.py
+++ b/llama_index/schema.py
@@ -302,6 +302,10 @@ class TextNode(BaseNode):
         return self.get_node_info()
 
 
+# TODO: legacy backport of old Node class
+Node = TextNode
+
+
 class ImageNode(TextNode):
     """Node with image."""
 


### PR DESCRIPTION
# Description

Simple backport of old `Node` object name, to avoid messy breakage.
