### PR TITLE
MD reader: remove html tags and leave linebreaks alone

### DIFF
--- a/llama_index/readers/file/markdown_reader.py
+++ b/llama_index/readers/file/markdown_reader.py
@@ -65,7 +65,7 @@ class MarkdownReader(BaseReader):
             ]
         else:
             markdown_tups = [
-                (key, re.sub("\n", "", value)) for key, value in markdown_tups
+                (key, re.sub("<.*?>", "", value)) for key, value in markdown_tups
             ]
 
         return markdown_tups


### PR DESCRIPTION
# Description

Returned markdown chunks were different if they were in a MD heading section or not.

With a MD heading, the chunk had html tags removed and line breaks (\n) preserved.

Without a MD heading, the html tags were not removed but line breaks were, destroying MD tables (among other MD formatting that require line breaks like lists etc.)

Fixes # (issue)
I've simply copied the re.sub() from the headings branch to the no-headings branch.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

