### PR TITLE
Fix recovering metadata from docstore

### DIFF
--- a/llama_index/indices/vector_store/retrievers/retriever.py
+++ b/llama_index/indices/vector_store/retrievers/retriever.py
@@ -106,7 +106,8 @@ class VectorIndexRetriever(BaseRetriever):
                     source_node is not None and source_node.node_type != ObjectType.TEXT
                 ):
                     node_id = query_result.nodes[i].node_id
-                    if node_id in self._docstore.docs:
+                    docstore_node_ids = self._docstore.docs.keys()
+                    if node_id in docstore_node_ids:
                         query_result.nodes[
                             i
                         ] = self._docstore.get_node(  # type: ignore[index]
@@ -115,7 +116,7 @@ class VectorIndexRetriever(BaseRetriever):
                     # Fix metadata for nodes that have source node in the docstore
                     elif (
                         source_node is not None
-                        and source_node.node_id in self._docstore.docs
+                        and source_node.node_id in docstore_node_ids
                     ):
                         query_result.nodes[
                             i

--- a/llama_index/indices/vector_store/retrievers/retriever.py
+++ b/llama_index/indices/vector_store/retrievers/retriever.py
@@ -112,6 +112,16 @@ class VectorIndexRetriever(BaseRetriever):
                         ] = self._docstore.get_node(  # type: ignore[index]
                             node_id
                         )
+                    # Fix metadata for nodes that have source node in the docstore
+                    elif (
+                        source_node is not None
+                        and source_node.node_id in self._docstore.docs
+                    ):
+                        query_result.nodes[
+                            i
+                        ] = self._docstore.get_node(  # type: ignore[index]
+                            source_node.node_id
+                        )
 
         log_vector_store_query_result(query_result)
 


### PR DESCRIPTION
# Description

Fix recovering metadata from docstore

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Test code:
```bash


from llama_index import VectorStoreIndex, SimpleDirectoryReader
from llama_index.vector_stores import MilvusVectorStore
from llama_index.storage.storage_context import StorageContext
from llama_index.storage.index_store import MongoIndexStore
from llama_index.storage.docstore import MongoDocumentStore

MONGO_URL = "mongodb://localhost:27017"

def metadata(path):
    return {"path": path}

documents = SimpleDirectoryReader('data/paul_graham/', file_metadata=metadata).load_data()
docstore = MongoDocumentStore.from_uri(MONGO_URL)
docstore.add_documents(documents)
index_store = MongoIndexStore.from_uri(MONGO_URL)
vector_store = MilvusVectorStore(overwrite=True)
storage_context = StorageContext.from_defaults(vector_store=vector_store, index_store=index_store, docstore=docstore)
index = VectorStoreIndex.from_documents(documents, storage_context=storage_context)

query_engine = index.as_query_engine()
response = query_engine.query("What did the author learn?")
for n in response.source_nodes:
    print(n.node.metadata)
```

Should display:
```bash
{'path': 'data/paul_graham/paul_graham_essay.txt'}
```

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
