### PR TITLE
modify column name for postgres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## Unreleased
+
+### Bug Fixes / Nits
+- Fix metadata column name in postgres vector store (#6622)
+
 ## [v0.6.35] - 2023-06-28
 - refactor structured output + pydantic programs (#6604)
 

--- a/llama_index/vector_stores/postgres.py
+++ b/llama_index/vector_stores/postgres.py
@@ -22,7 +22,7 @@ def get_data_model(base: Type, index_name: str) -> Any:
         __abstract__ = True  # tShis line is necessary
         id = Column(BIGINT, primary_key=True, autoincrement=True)
         text = Column(VARCHAR, nullable=False)
-        metadata = Column(JSON)
+        metadata_ = Column(JSON)
         doc_id = Column(VARCHAR)  # TODO: change to node_id
         embedding = Column(Vector(1536))  # type: ignore
 
@@ -143,14 +143,14 @@ class PGVectorStore(VectorStore):
         ids = []
         for item, sim in results:
             try:
-                node = metadata_dict_to_node(item.metadata)
+                node = metadata_dict_to_node(item.metadata_)
                 node.set_content(str(item.text))
             except Exception:
                 # NOTE: deprecated legacy logic for backward compatibility
                 node = TextNode(
                     id_=item.doc_id,
                     text=item.text,
-                    metadata=item.metadata,
+                    metadata=item.metadata_,
                     relationships={
                         NodeRelationship.SOURCE: RelatedNodeInfo(node_id=item.doc_id),
                     },


### PR DESCRIPTION
# Description

Postgres cannot have a column named "metadata" -- so, need to rename it :) 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense
