### PR TITLE
bring our loaders back in line with llama-hub

### DIFF
--- a/llama_index/readers/file/base.py
+++ b/llama_index/readers/file/base.py
@@ -192,7 +192,7 @@ class SimpleDirectoryReader(BaseReader):
                     reader_cls = DEFAULT_FILE_READER_CLS[file_suffix]
                     self.file_extractor[file_suffix] = reader_cls()
                 reader = self.file_extractor[file_suffix]
-                docs = reader.load_data(input_file, metadata=metadata or {})
+                docs = reader.load_data(input_file, metadata=metadata)
 
                 # iterate over docs if needed
                 if self.filename_as_id:

--- a/llama_index/readers/file/base.py
+++ b/llama_index/readers/file/base.py
@@ -192,7 +192,7 @@ class SimpleDirectoryReader(BaseReader):
                     reader_cls = DEFAULT_FILE_READER_CLS[file_suffix]
                     self.file_extractor[file_suffix] = reader_cls()
                 reader = self.file_extractor[file_suffix]
-                docs = reader.load_data(input_file, metadata=metadata)
+                docs = reader.load_data(input_file, extra_info=metadata)
 
                 # iterate over docs if needed
                 if self.filename_as_id:

--- a/llama_index/readers/file/docs_reader.py
+++ b/llama_index/readers/file/docs_reader.py
@@ -65,4 +65,4 @@ class DocxReader(BaseReader):
         if extra_info is not None:
             metadata.update(extra_info)
 
-        return [Document(text=text, metadata=metadata)]
+        return [Document(text=text, metadata=metadata or {})]

--- a/llama_index/readers/file/docs_reader.py
+++ b/llama_index/readers/file/docs_reader.py
@@ -13,7 +13,9 @@ from llama_index.schema import Document
 class PDFReader(BaseReader):
     """PDF parser."""
 
-    def load_data(self, file: Path, metadata: Optional[Dict] = None) -> List[Document]:
+    def load_data(
+        self, file: Path, extra_info: Optional[Dict] = None
+    ) -> List[Document]:
         """Parse file."""
         try:
             import pypdf
@@ -36,8 +38,8 @@ class PDFReader(BaseReader):
                 page_label = pdf.page_labels[page]
 
                 metadata = {"page_label": page_label, "file_name": file.name}
-                if metadata is not None:
-                    metadata.update(metadata)
+                if extra_info is not None:
+                    metadata.update(extra_info)
 
                 docs.append(Document(text=page_text, metadata=metadata))
             return docs
@@ -46,7 +48,9 @@ class PDFReader(BaseReader):
 class DocxReader(BaseReader):
     """Docx parser."""
 
-    def load_data(self, file: Path, metadata: Optional[Dict] = None) -> List[Document]:
+    def load_data(
+        self, file: Path, extra_info: Optional[Dict] = None
+    ) -> List[Document]:
         """Parse file."""
         try:
             import docx2txt
@@ -58,7 +62,7 @@ class DocxReader(BaseReader):
 
         text = docx2txt.process(file)
         metadata = {"file_name": file.name}
-        if metadata is not None:
-            metadata.update(metadata)
+        if extra_info is not None:
+            metadata.update(extra_info)
 
         return [Document(text=text, metadata=metadata)]

--- a/llama_index/readers/file/epub_reader.py
+++ b/llama_index/readers/file/epub_reader.py
@@ -40,4 +40,4 @@ class EpubReader(BaseReader):
                 )
 
         text = "\n".join(text_list)
-        return [Document(text=text, metadata=extra_info)]
+        return [Document(text=text, metadata=extra_info or {})]

--- a/llama_index/readers/file/epub_reader.py
+++ b/llama_index/readers/file/epub_reader.py
@@ -13,7 +13,9 @@ from llama_index.schema import Document
 class EpubReader(BaseReader):
     """Epub Parser."""
 
-    def load_data(self, file: Path, metadata: Optional[Dict] = None) -> List[Document]:
+    def load_data(
+        self, file: Path, extra_info: Optional[Dict] = None
+    ) -> List[Document]:
         """Parse file."""
         try:
             import ebooklib
@@ -38,4 +40,4 @@ class EpubReader(BaseReader):
                 )
 
         text = "\n".join(text_list)
-        return [Document(text=text, metadata=metadata)]
+        return [Document(text=text, metadata=extra_info)]

--- a/llama_index/readers/file/image_caption_reader.py
+++ b/llama_index/readers/file/image_caption_reader.py
@@ -54,7 +54,9 @@ class ImageCaptionReader(BaseReader):
         self._keep_image = keep_image
         self._prompt = prompt
 
-    def load_data(self, file: Path, metadata: Optional[Dict] = None) -> List[Document]:
+    def load_data(
+        self, file: Path, extra_info: Optional[Dict] = None
+    ) -> List[Document]:
         """Parse file."""
         from PIL import Image
 
@@ -89,6 +91,6 @@ class ImageCaptionReader(BaseReader):
             ImageDocument(
                 text=text_str,
                 image=image_str,
-                metadata=metadata,
+                metadata=extra_info,
             )
         ]

--- a/llama_index/readers/file/image_caption_reader.py
+++ b/llama_index/readers/file/image_caption_reader.py
@@ -91,6 +91,6 @@ class ImageCaptionReader(BaseReader):
             ImageDocument(
                 text=text_str,
                 image=image_str,
-                metadata=extra_info,
+                metadata=extra_info or {},
             )
         ]

--- a/llama_index/readers/file/image_reader.py
+++ b/llama_index/readers/file/image_reader.py
@@ -51,7 +51,9 @@ class ImageReader(BaseReader):
         self._keep_image = keep_image
         self._parse_text = parse_text
 
-    def load_data(self, file: Path, metadata: Optional[Dict] = None) -> List[Document]:
+    def load_data(
+        self, file: Path, extra_info: Optional[Dict] = None
+    ) -> List[Document]:
         """Parse file."""
         from PIL import Image
 
@@ -107,4 +109,4 @@ class ImageReader(BaseReader):
             # remove first task start token
             text_str = re.sub(r"<.*?>", "", sequence, count=1).strip()
 
-        return [ImageDocument(text=text_str, image=image_str, metadata=metadata)]
+        return [ImageDocument(text=text_str, image=image_str, metadata=extra_info)]

--- a/llama_index/readers/file/image_reader.py
+++ b/llama_index/readers/file/image_reader.py
@@ -109,4 +109,6 @@ class ImageReader(BaseReader):
             # remove first task start token
             text_str = re.sub(r"<.*?>", "", sequence, count=1).strip()
 
-        return [ImageDocument(text=text_str, image=image_str, metadata=extra_info or {})]
+        return [
+            ImageDocument(text=text_str, image=image_str, metadata=extra_info or {})
+        ]

--- a/llama_index/readers/file/image_reader.py
+++ b/llama_index/readers/file/image_reader.py
@@ -109,4 +109,4 @@ class ImageReader(BaseReader):
             # remove first task start token
             text_str = re.sub(r"<.*?>", "", sequence, count=1).strip()
 
-        return [ImageDocument(text=text_str, image=image_str, metadata=extra_info)]
+        return [ImageDocument(text=text_str, image=image_str, metadata=extra_info or {})]

--- a/llama_index/readers/file/image_vision_llm_reader.py
+++ b/llama_index/readers/file/image_vision_llm_reader.py
@@ -50,7 +50,9 @@ class ImageVisionLLMReader(BaseReader):
         self._keep_image = keep_image
         self._prompt = prompt
 
-    def load_data(self, file: Path, metadata: Optional[Dict] = None) -> List[Document]:
+    def load_data(
+        self, file: Path, extra_info: Optional[Dict] = None
+    ) -> List[Document]:
         """Parse file."""
         from PIL import Image
 
@@ -85,6 +87,6 @@ class ImageVisionLLMReader(BaseReader):
             ImageDocument(
                 text=text_str,
                 image=image_str,
-                metadata=metadata,
+                metadata=extra_info,
             )
         ]

--- a/llama_index/readers/file/image_vision_llm_reader.py
+++ b/llama_index/readers/file/image_vision_llm_reader.py
@@ -87,6 +87,6 @@ class ImageVisionLLMReader(BaseReader):
             ImageDocument(
                 text=text_str,
                 image=image_str,
-                metadata=extra_info,
+                metadata=extra_info or {},
             )
         ]

--- a/llama_index/readers/file/ipynb_reader.py
+++ b/llama_index/readers/file/ipynb_reader.py
@@ -35,7 +35,7 @@ class IPYNBReader(BaseReader):
         splits.pop(0)
 
         if self._concatenate:
-            docs = [Document(text="\n\n".join(splits), metadata=extra_info)]
+            docs = [Document(text="\n\n".join(splits), metadata=extra_info or {})]
         else:
-            docs = [Document(text=s, metadata=extra_info) for s in splits]
+            docs = [Document(text=s, metadata=extra_info or {}) for s in splits]
         return docs

--- a/llama_index/readers/file/ipynb_reader.py
+++ b/llama_index/readers/file/ipynb_reader.py
@@ -18,7 +18,9 @@ class IPYNBReader(BaseReader):
         self._parser_config = parser_config
         self._concatenate = concatenate
 
-    def load_data(self, file: Path, metadata: Optional[Dict] = None) -> List[Document]:
+    def load_data(
+        self, file: Path, extra_info: Optional[Dict] = None
+    ) -> List[Document]:
         """Parse file."""
 
         if file.name.endswith(".ipynb"):
@@ -33,7 +35,7 @@ class IPYNBReader(BaseReader):
         splits.pop(0)
 
         if self._concatenate:
-            docs = [Document(text="\n\n".join(splits), metadata=metadata)]
+            docs = [Document(text="\n\n".join(splits), metadata=extra_info)]
         else:
-            docs = [Document(text=s, metadata=metadata) for s in splits]
+            docs = [Document(text=s, metadata=extra_info) for s in splits]
         return docs

--- a/llama_index/readers/file/markdown_reader.py
+++ b/llama_index/readers/file/markdown_reader.py
@@ -108,9 +108,9 @@ class MarkdownReader(BaseReader):
         # TODO: don't include headers right now
         for header, value in tups:
             if header is None:
-                results.append(Document(text=value, metadata=extra_info))
+                results.append(Document(text=value, metadata=extra_info or {}))
             else:
                 results.append(
-                    Document(text=f"\n\n{header}\n{value}", metadata=extra_info)
+                    Document(text=f"\n\n{header}\n{value}", metadata=extra_info or {})
                 )
         return results

--- a/llama_index/readers/file/markdown_reader.py
+++ b/llama_index/readers/file/markdown_reader.py
@@ -99,16 +99,18 @@ class MarkdownReader(BaseReader):
         markdown_tups = self.markdown_to_tups(content)
         return markdown_tups
 
-    def load_data(self, file: Path, metadata: Optional[Dict] = None) -> List[Document]:
+    def load_data(
+        self, file: Path, extra_info: Optional[Dict] = None
+    ) -> List[Document]:
         """Parse file into string."""
         tups = self.parse_tups(file)
         results = []
         # TODO: don't include headers right now
         for header, value in tups:
             if header is None:
-                results.append(Document(text=value, metadata=metadata or {}))
+                results.append(Document(text=value, metadata=extra_info))
             else:
                 results.append(
-                    Document(text=f"\n\n{header}\n{value}", metadata=metadata or {})
+                    Document(text=f"\n\n{header}\n{value}", metadata=extra_info)
                 )
         return results

--- a/llama_index/readers/file/mbox_reader.py
+++ b/llama_index/readers/file/mbox_reader.py
@@ -104,4 +104,4 @@ class MboxReader(BaseReader):
             if self.max_count > 0 and i >= self.max_count:
                 break
 
-        return [Document(text=result, metadata=extra_info) for result in results]
+        return [Document(text=result, metadata=extra_info or {}) for result in results]

--- a/llama_index/readers/file/mbox_reader.py
+++ b/llama_index/readers/file/mbox_reader.py
@@ -50,7 +50,9 @@ class MboxReader(BaseReader):
         self.max_count = max_count
         self.message_format = message_format
 
-    def load_data(self, file: Path, metadata: Optional[Dict] = None) -> List[Document]:
+    def load_data(
+        self, file: Path, extra_info: Optional[Dict] = None
+    ) -> List[Document]:
         """Parse file into string."""
         # Import required libraries
         import mailbox
@@ -102,4 +104,4 @@ class MboxReader(BaseReader):
             if self.max_count > 0 and i >= self.max_count:
                 break
 
-        return [Document(text=result, metadata=metadata) for result in results]
+        return [Document(text=result, metadata=extra_info) for result in results]

--- a/llama_index/readers/file/slides_reader.py
+++ b/llama_index/readers/file/slides_reader.py
@@ -86,7 +86,7 @@ class PptxReader(BaseReader):
     def load_data(
         self,
         file: Path,
-        metadata: Optional[Dict] = None,
+        extra_info: Optional[Dict] = None,
     ) -> List[Document]:
         """Parse file."""
         from pptx import Presentation
@@ -110,4 +110,4 @@ class PptxReader(BaseReader):
                 if hasattr(shape, "text"):
                     result += f"{shape.text}\n"
 
-        return [Document(text=result, metadata=metadata)]
+        return [Document(text=result, metadata=extra_info)]

--- a/llama_index/readers/file/slides_reader.py
+++ b/llama_index/readers/file/slides_reader.py
@@ -110,4 +110,4 @@ class PptxReader(BaseReader):
                 if hasattr(shape, "text"):
                     result += f"{shape.text}\n"
 
-        return [Document(text=result, metadata=extra_info)]
+        return [Document(text=result, metadata=extra_info or {})]

--- a/llama_index/readers/file/tabular_reader.py
+++ b/llama_index/readers/file/tabular_reader.py
@@ -105,7 +105,11 @@ class PandasCSVReader(BaseReader):
 
         if self._concat_rows:
             return [
-                Document(text=(self._row_joiner).join(text_list), metadata=extra_info or {})
+                Document(
+                    text=(self._row_joiner).join(text_list), metadata=extra_info or {}
+                )
             ]
         else:
-            return [Document(text=text, metadata=extra_info or {}) for text in text_list]
+            return [
+                Document(text=text, metadata=extra_info or {}) for text in text_list
+            ]

--- a/llama_index/readers/file/tabular_reader.py
+++ b/llama_index/readers/file/tabular_reader.py
@@ -27,7 +27,9 @@ class CSVReader(BaseReader):
         super().__init__(*args, **kwargs)
         self._concat_rows = concat_rows
 
-    def load_data(self, file: Path, metadata: Optional[Dict] = None) -> List[Document]:
+    def load_data(
+        self, file: Path, extra_info: Optional[Dict] = None
+    ) -> List[Document]:
         """Parse file.
 
         Returns:
@@ -44,9 +46,9 @@ class CSVReader(BaseReader):
             for row in csv_reader:
                 text_list.append(", ".join(row))
         if self._concat_rows:
-            return [Document(text="\n".join(text_list), metadata=metadata)]
+            return [Document(text="\n".join(text_list), metadata=extra_info)]
         else:
-            return [Document(text=text, metadata=metadata) for text in text_list]
+            return [Document(text=text, metadata=extra_info) for text in text_list]
 
 
 class PandasCSVReader(BaseReader):
@@ -91,7 +93,9 @@ class PandasCSVReader(BaseReader):
         self._row_joiner = row_joiner
         self._pandas_config = pandas_config
 
-    def load_data(self, file: Path, metadata: Optional[Dict] = None) -> List[Document]:
+    def load_data(
+        self, file: Path, extra_info: Optional[Dict] = None
+    ) -> List[Document]:
         """Parse file."""
         df = pd.read_csv(file, **self._pandas_config)
 
@@ -101,7 +105,7 @@ class PandasCSVReader(BaseReader):
 
         if self._concat_rows:
             return [
-                Document(text=(self._row_joiner).join(text_list), metadata=metadata)
+                Document(text=(self._row_joiner).join(text_list), metadata=extra_info)
             ]
         else:
-            return [Document(text=text, metadata=metadata) for text in text_list]
+            return [Document(text=text, metadata=extra_info) for text in text_list]

--- a/llama_index/readers/file/tabular_reader.py
+++ b/llama_index/readers/file/tabular_reader.py
@@ -105,7 +105,7 @@ class PandasCSVReader(BaseReader):
 
         if self._concat_rows:
             return [
-                Document(text=(self._row_joiner).join(text_list), metadata=extra_info)
+                Document(text=(self._row_joiner).join(text_list), metadata=extra_info or {})
             ]
         else:
-            return [Document(text=text, metadata=extra_info) for text in text_list]
+            return [Document(text=text, metadata=extra_info or {}) for text in text_list]

--- a/llama_index/readers/file/video_audio_reader.py
+++ b/llama_index/readers/file/video_audio_reader.py
@@ -35,7 +35,9 @@ class VideoAudioReader(BaseReader):
 
         self.parser_config = {"model": model}
 
-    def load_data(self, file: Path, metadata: Optional[Dict] = None) -> List[Document]:
+    def load_data(
+        self, file: Path, extra_info: Optional[Dict] = None
+    ) -> List[Document]:
         """Parse file."""
         import whisper
 
@@ -59,4 +61,4 @@ class VideoAudioReader(BaseReader):
 
         transcript = result["text"]
 
-        return [Document(text=transcript, metadata=metadata)]
+        return [Document(text=transcript, metadata=extra_info)]

--- a/llama_index/readers/file/video_audio_reader.py
+++ b/llama_index/readers/file/video_audio_reader.py
@@ -61,4 +61,4 @@ class VideoAudioReader(BaseReader):
 
         transcript = result["text"]
 
-        return [Document(text=transcript, metadata=extra_info)]
+        return [Document(text=transcript, metadata=extra_info or {})]


### PR DESCRIPTION
# Description

SimpleDirectoryReader was not passing metadata correctly to sub-loaders (it was changing metadata from `None` to `{}`), causing downstream loaders to not properly set metadata

Fixes https://github.com/jerryjliu/llama_index/issues/6629

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense