### PR TITLE
[wip] ResponseSynthesis UX

### DIFF
--- a/llama_index/indices/query/response_context.py
+++ b/llama_index/indices/query/response_context.py
@@ -1,0 +1,68 @@
+from pydantic import BaseModel, Field
+from typing import Any, Dict, List, Optional
+
+from llama_index.callbacks.base import CallbackManager
+from llama_index.indices.postprocessor.types import BaseNodePostprocessor
+from llama_index.indices.response import (
+    BaseResponseBuilder,
+    ResponseMode,
+)
+from llama_index.optimization.optimizer import BaseTokenUsageOptimizer
+from llama_index.prompts.prompts import (
+    QuestionAnswerPrompt,
+    RefinePrompt,
+    SimpleInputPrompt,
+)
+from llama_index.prompts.default_prompts import DEFAULT_TEXT_QA_PROMPT, DEFAULT_SIMPLE_INPUT_PROMPT
+from llama_index.prompts.default_prompt_selectors import DEFAULT_REFINE_PROMPT_SEL
+
+
+class ResponseContext(BaseModel):
+    """Response context, used to hold various response-related objects and services."""
+
+    # pre-processing
+    node_postprocessors: Optional[List[BaseNodePostprocessor]] = Field(
+        default=None, description="A list of node postprocessors."
+    )
+    optimizer: Optional[BaseTokenUsageOptimizer] = Field(
+        default=None, description="A token usage optimizer."
+    )
+
+    # response-builder
+    response_builder: Optional[BaseResponseBuilder] = Field(
+        default=None,
+        description="A response builder that uses text chunks to build a response.",
+    )
+    text_qa_template: QuestionAnswerPrompt = Field(
+        default=DEFAULT_TEXT_QA_PROMPT,
+        description="The prompt template used for the initial QA LLM call.",
+    )
+    refine_template: RefinePrompt = Field(
+        default=DEFAULT_REFINE_PROMPT_SEL,
+        description="The prompt template used for the refine LLM call(s).",
+    )
+    simple_template: SimpleInputPrompt = Field(
+        default=DEFAULT_SIMPLE_INPUT_PROMPT,
+        description=(
+            "The prompt template used for simple generation, when "
+            "response_mode='generation'."
+        ),
+    )
+    response_mode: ResponseMode = Field(
+        default=ResponseMode.COMPACT,
+        description="The response mode, used to fetch a response builder.",
+    )
+    response_kwargs: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Additional kwargs passed to the response builder.",
+    )
+
+    # miscelaneous
+    callback_manager: Optional[CallbackManager] = Field(
+        default=None, description="A callback manager."
+    )
+    streaming: bool = Field(
+        default=False, description="Whether to stream the response."
+    )
+    use_async: bool = Field(default=False, description="Whether to use async.")
+    verbose: bool = Field(default=False, description="Whether to print verbose output.")

--- a/llama_index/indices/query/response_context.py
+++ b/llama_index/indices/query/response_context.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 from typing import Any, Dict, List, Optional
 
 from llama_index.callbacks.base import CallbackManager
@@ -66,3 +66,36 @@ class ResponseContext(BaseModel):
     )
     use_async: bool = Field(default=False, description="Whether to use async.")
     verbose: bool = Field(default=False, description="Whether to print verbose output.")
+    
+    # ignore pydantic's type-checking for arbitrary types
+    class Config:
+        arbitrary_types_allowed = True
+
+    @classmethod
+    def from_defaults(
+        cls,
+        node_postprocessors: Optional[List[BaseNodePostprocessor]] = None,
+        optimizer: Optional[BaseTokenUsageOptimizer] = None,
+        response_mode: ResponseMode = ResponseMode.COMPACT,
+        text_qa_template: Optional[QuestionAnswerPrompt] = DEFAULT_TEXT_QA_PROMPT,
+        refine_template: Optional[RefinePrompt] = DEFAULT_REFINE_PROMPT_SEL,
+        simple_template: Optional[SimpleInputPrompt] = DEFAULT_SIMPLE_INPUT_PROMPT,
+        response_kwargs: Optional[Dict] = Field(default_factory=dict),
+        callback_manager: Optional[CallbackManager] = None,
+        streaming: bool = False,
+        use_async: bool = False,
+        verbose: bool = False,
+    ) -> "ResponseContext":
+        return cls(
+            node_postprocessors=node_postprocessors,
+            optimizer=optimizer,
+            response_mode=response_mode,
+            text_qa_template=text_qa_template,
+            refine_template=refine_template,
+            simple_template=simple_template,
+            response_kwargs=response_kwargs,
+            callback_manager=callback_manager,
+            streaming=streaming,
+            use_async=use_async,
+            verbose=verbose,
+        )

--- a/llama_index/indices/query/response_context.py
+++ b/llama_index/indices/query/response_context.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field
 from typing import Any, Dict, List, Optional
 
 from llama_index.callbacks.base import CallbackManager
@@ -13,7 +13,10 @@ from llama_index.prompts.prompts import (
     RefinePrompt,
     SimpleInputPrompt,
 )
-from llama_index.prompts.default_prompts import DEFAULT_TEXT_QA_PROMPT, DEFAULT_SIMPLE_INPUT_PROMPT
+from llama_index.prompts.default_prompts import (
+    DEFAULT_TEXT_QA_PROMPT,
+    DEFAULT_SIMPLE_INPUT_PROMPT,
+)
 from llama_index.prompts.default_prompt_selectors import DEFAULT_REFINE_PROMPT_SEL
 
 
@@ -66,7 +69,7 @@ class ResponseContext(BaseModel):
     )
     use_async: bool = Field(default=False, description="Whether to use async.")
     verbose: bool = Field(default=False, description="Whether to print verbose output.")
-    
+
     # ignore pydantic's type-checking for arbitrary types
     class Config:
         arbitrary_types_allowed = True

--- a/llama_index/indices/query/response_synthesis.py
+++ b/llama_index/indices/query/response_synthesis.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Generator, List, Optional, Sequence
 from llama_index.callbacks.base import CallbackManager
 from llama_index.callbacks.schema import CBEventType, EventPayload
 from llama_index.indices.postprocessor.types import BaseNodePostprocessor
+from llama_index.indices.query.response_context import ResponseContext
 from llama_index.indices.query.schema import QueryBundle
 from llama_index.indices.response import (
     BaseResponseBuilder,
@@ -61,6 +62,41 @@ class ResponseSynthesizer:
         self._verbose = verbose
 
     @classmethod
+    def from_context(
+        cls, response_context: ResponseContext, service_context: ServiceContext
+    ) -> "ResponseSynthesizer":
+        """Initialize response synthesizer from response context.
+
+        Args:
+            response_context (ResponseContext): A response context.
+
+        Returns:
+            ResponseSynthesizer: A response synthesizer object.
+        """
+
+        if response_context.response_builder is None:
+            # Get response builder based on response context
+            response_context.response_builder = get_response_builder(
+                service_context,
+                response_context.text_qa_template,
+                response_context.refine_template,
+                response_context.simple_template,
+                response_context.response_mode,
+                use_async=response_context.use_async,
+                streaming=response_context.streaming,
+            )
+
+        return cls(
+            response_builder=response_context.response_builder,
+            response_mode=response_context.response_mode,
+            response_kwargs=response_context.response_kwargs,
+            optimizer=response_context.optimizer,
+            node_postprocessors=response_context.node_postprocessors,
+            callback_manager=response_context.callback_manager,
+            verbose=response_context.verbose,
+        )
+
+    @classmethod
     def from_args(
         cls,
         service_context: Optional[ServiceContext] = None,
@@ -76,7 +112,9 @@ class ResponseSynthesizer:
         optimizer: Optional[BaseTokenUsageOptimizer] = None,
         verbose: bool = False,
     ) -> "ResponseSynthesizer":
-        """Initialize response synthesizer from args.
+        """TODO: Deprecated
+
+        Initialize response synthesizer from args.
 
         Args:
             service_context (Optional[ServiceContext]): A service context.


### PR DESCRIPTION
# Description

The current response synthesis module has a million options, and setting any of them is a bit of a guessing game since everything is passed as kwargs from `as_query_engine()`

This PR is an initial stab at improving this. The idea is to introduce a `response_context` object that hold all these arguments, and would be able to pass this in at the query engine level, or at the response synthesizer level.

I used pydantic for the context, because I think having the field descriptions creates a nicer UX. But also, it makes the `from_defaults` a little redundant, but I wanted to keep that to reinforce the `from_defaults` pattern we have. Could definitely convert that into a dataclass instead though!

Lastly, this easily exposes the response builder, which before was not exposed nicely at all.

Currently this PR is basically no-op, but can move forward if we like the idea.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

# TODO
- [ ] Agree on proper UX pattern
- [ ] Integrate into the library more widely
- [ ] notebook
- [ ] unit-tests
