### PR TITLE
[wip] add context augmented openai agent

### DIFF
--- a/docs/examples/agent/openai_agent_context_retrieval.ipynb
+++ b/docs/examples/agent/openai_agent_context_retrieval.ipynb
@@ -1,0 +1,533 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "99cea58c-48bc-4af6-8358-df9695659983",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Context-Augmented OpenAI Agent"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "673df1fe-eb6c-46ea-9a73-a96e7ae7942e",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "In this tutorial, we show you how to use our `ContextRetrieverOpenAIAgent` implementation\n",
+    "to build an agent on top of OpenAI's function API and store/index an arbitrary number of tools. Our indexing/retrieval modules help to remove the complexity of having too many functions to fit in the prompt."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54b7bc2e-606f-411a-9490-fcfab9236dfc",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Initial Setup "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23e80e5b-aaee-4f23-b338-7ae62b08141f",
+   "metadata": {},
+   "source": [
+    "Here we setup a ContextRetrieverOpenAIAgent. This agent will perform retrieval first before calling any tools. This can help ground the agent's tool picking and answering capabilities in context."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "9d47283b-025e-4874-88ed-76245b22f82e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/jerryliu/Programming/gpt_index/.venv/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "from typing import Sequence\n",
+    "\n",
+    "from langchain.chat_models import ChatOpenAI\n",
+    "from langchain.memory import ChatMessageHistory\n",
+    "from llama_index import (\n",
+    "    SimpleDirectoryReader, \n",
+    "    VectorStoreIndex, \n",
+    "    StorageContext, \n",
+    "    load_index_from_storage\n",
+    ")\n",
+    "from llama_index.tools import QueryEngineTool, ToolMetadata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "9f034df0-f6f1-4ffb-9c4b-d68c2202051c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    storage_context = StorageContext.from_defaults(persist_dir='./storage/march')\n",
+    "    march_index = load_index_from_storage(storage_context)\n",
+    "\n",
+    "    storage_context = StorageContext.from_defaults(persist_dir='./storage/june')\n",
+    "    june_index = load_index_from_storage(storage_context)\n",
+    "    \n",
+    "    storage_context = StorageContext.from_defaults(persist_dir='./storage/sept')\n",
+    "    sept_index = load_index_from_storage(storage_context)\n",
+    "    \n",
+    "    index_loaded = True\n",
+    "except:\n",
+    "    index_loaded = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "2a90e4d4-589b-4349-a134-a2ef931d8e89",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# build indexes across the three data sources\n",
+    "\n",
+    "if not index_loaded:\n",
+    "    # load data \n",
+    "    march_docs = SimpleDirectoryReader(input_files=[\"../data/10q/uber_10q_march_2022.pdf\"]).load_data()\n",
+    "    june_docs = SimpleDirectoryReader(input_files=[\"../data/10q/uber_10q_june_2022.pdf\"]).load_data()\n",
+    "    sept_docs = SimpleDirectoryReader(input_files=[\"../data/10q/uber_10q_sept_2022.pdf\"]).load_data()\n",
+    "    \n",
+    "    # build index\n",
+    "    march_index = VectorStoreIndex.from_documents(march_docs)\n",
+    "    june_index = VectorStoreIndex.from_documents(june_docs)\n",
+    "    sept_index = VectorStoreIndex.from_documents(sept_docs)\n",
+    "    \n",
+    "    # persist index\n",
+    "    march_index.storage_context.persist(persist_dir=\"./storage/march\")\n",
+    "    june_index.storage_context.persist(persist_dir=\"./storage/june\")\n",
+    "    sept_index.storage_context.persist(persist_dir=\"./storage/sept\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "00f82f26-83a6-4a37-8a9f-55bf49d8b247",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "march_engine = march_index.as_query_engine(similarity_top_k=3)\n",
+    "june_engine = june_index.as_query_engine(similarity_top_k=3)\n",
+    "sept_engine = sept_index.as_query_engine(similarity_top_k=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "1edb4379-75b8-4b83-8a2d-16170fa6cb67",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "query_engine_tools = [\n",
+    "    QueryEngineTool(\n",
+    "        query_engine=march_engine, \n",
+    "        metadata=ToolMetadata(\n",
+    "            name='uber_march_10q', \n",
+    "            description=\"Provides information about Uber 10Q filings for March 2022. \"\n",
+    "            \"Use a detailed plain text question as input to the tool.\"\n",
+    "        )\n",
+    "    ),\n",
+    "    QueryEngineTool(\n",
+    "        query_engine=june_engine, \n",
+    "        metadata=ToolMetadata(\n",
+    "            name='uber_june_10q', \n",
+    "            description=\"Provides information about Uber financials for June 2021. \"\n",
+    "            \"Use a detailed plain text question as input to the tool.\"\n",
+    "        )\n",
+    "    ),\n",
+    "    QueryEngineTool(\n",
+    "        query_engine=sept_engine, \n",
+    "        metadata=ToolMetadata(\n",
+    "            name='uber_sept_10q', \n",
+    "            description=\"Provides information about Uber financials for Sept 2021. \"\n",
+    "            \"Use a detailed plain text question as input to the tool.\"\n",
+    "        )\n",
+    "    ),\n",
+    "]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b08efb96-ce44-4706-a22d-b0c670b23a60",
+   "metadata": {},
+   "source": [
+    "### Try Context-Augmented Agent\n",
+    "\n",
+    "Here we augment our agent with context in different settings:\n",
+    "- toy context: we define some abbreviations that map to financial terms (e.g. R=Revenue). We supply this as context to the agent"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "72709da5-785e-4b9d-9e8f-231a2d2fbb53",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from llama_index.schema import Document\n",
+    "from llama_index.agent import ContextRetrieverOpenAIAgent"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d2b235ed-d2a0-46cb-830b-d1a3affeb0c2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# toy index - stores a list of abbreviations\n",
+    "texts = [\n",
+    "    \"Abbrevation: X = Revenue\",\n",
+    "    \"Abbrevation: YZ = Risk Factors\",\n",
+    "    \"Abbreviation: Z = Costs\"\n",
+    "]\n",
+    "docs = [Document(text=t) for t in texts]\n",
+    "context_index = VectorStoreIndex.from_documents(docs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "7b58bac2-dbc2-40b2-a29e-f96c02ef5396",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "context_agent = ContextRetrieverOpenAIAgent.from_tools_and_retriever(\n",
+    "    query_engine_tools, \n",
+    "    context_index.as_retriever(similarity_top_k=1),\n",
+    "    verbose=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "b44e9819-69a5-4085-9957-27d8eb940d24",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33;1m\u001b[1;3mContext information is below.\n",
+      "---------------------\n",
+      "Abbrevation: YZ = Risk Factors\n",
+      "---------------------\n",
+      "Given the context information and not prior knowledge, either pick the corresponding tool or answer the function: What is the YZ of June 2022?\n",
+      "\n",
+      "\u001b[0m=== Calling Function ===\n",
+      "Calling function: uber_march_10q with args: {\n",
+      "  \"input\": \"What are the Risk Factors in June 2022?\"\n",
+      "}\n",
+      "Got output: \n",
+      "•We generate a significant percentage of our Gross Bookings from trips in large metropolitan areas, and these operations may be negatively affected by economic, social, weather, and regulatory conditions or other circumstances, including COVID-19.\n",
+      "•We may fail to offer autonomous vehicle technologies on our platform, fail to offer such technologies on our platform before our competitors, or such technologies may fail to perform as expected, may be inferior to those offered by our competitors, or may be perceived as less safe than those offered by competitors or non-autonomous vehicles.\n",
+      "•Our business depends on retaining and attracting high-quality personnel, and continued attrition, future attrition, or unsuccessful succession planning could adversely affect our business.\n",
+      "•We may experience security or data privacy breaches or other unauthorized or improper access to, use of, alteration of or destruction of our proprietary or confidential data, employee data, or platform user data.\n",
+      "•Cyberattacks, including computer malware, ransomware, viruses, spamming, and phishing attacks could harm our reputation, business, and operating results.\n",
+      "•We are subject to climate change risks, including physical and transitional risks, and if we are unable to manage such risks, our business may be adversely impacted.\n",
+      "•We have made climate related commitments that require us to invest significant effort, resources, and management time and circumstances may arise, including those beyond our control, that may require us to revise the contemplated timeframes for implementing these commitments.\n",
+      "•We rely on third parties maintaining open marketplaces to distribute our platform and to provide the software we use in certain of our products and offerings. If such third parties interfere with the distribution of our products or offerings or with our use of such software, our business would be adversely affected.\n",
+      "•We will require additional capital to support the growth of our business, and this capital might not be available on reasonable terms or at all.\n",
+      "•If we are unable to successfully identify, acquire and integrate suitable businesses, our operating results and prospects could be harmed, and any businesses we acquire may not perform as expected or be effectively integrated.\n",
+      "•We may continue to be blocked from or limited in providing or operating our products and offerings in certain jurisdictions, and may be required to modify our business model in those jurisdictions as a result.\n",
+      "•Our business is subject to numerous legal and regulatory risks that could have an adverse impact on our business and future prospects.\n",
+      "•Our business is subject to extensive government regulation and oversight relating to the provision of payment and financial services.\n",
+      "•We face risks related to our collection, use, transfer, disclosure, and other processing of data, which could result in investigations, inquiries, litigation, fines, legislative and regulatory action, and negative press about our privacy and data protection practices.\n",
+      "•If we are unable to protect our intellectual property, or if third parties are successful in claiming that we are misappropriating the intellectual property of others, we may incur significant expense and our business may be adversely affected.\n",
+      "•The market price of our common stock has been, and may continue to be, volatile or may decline steeply or suddenly regardless of our operating performance, and we may not be able to meet investor or analyst expectations. You may not be able to resell your shares at or above the price you paid and may lose all or part of your investment.\n",
+      "•General Economic Risks\n",
+      "•The coronavirus (“COVID-19”) pandemic and the impact of actions to mitigate the pandemic have adversely impacted and could continue to adversely impact our business, financial condition and results of operations.\n",
+      "•Political, social, and economic instability abroad, war, including the conflict between Russia and Ukraine, terrorist attacks and security concerns in general, and societal crime conditions that harm or disrupt the global economy and/or can directly impact platform users.\n",
+      "========================\n"
+     ]
+    }
+   ],
+   "source": [
+    "context_agent.chat(\"What is the YZ of June 2022?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c407dd42-39a3-4bda-8294-27ac043a5adb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "context_agent.chat(\"What is the X and Z in September 2022?\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad81c4e1-4ecb-405d-bb03-a4c3549816e7",
+   "metadata": {},
+   "source": [
+    "### Use Uber 10-Q as context, use Calculator as Tool"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "f8dc898e-5fe0-45a2-8e04-debdaeb2c1bb",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from llama_index.tools import BaseTool, FunctionTool\n",
+    "\n",
+    "\n",
+    "def magic_formula(revenue: int, cost: int) -> int:\n",
+    "    \"\"\"Runs MAGIC_FORMULA on revenue and cost.\"\"\"\n",
+    "    return revenue - cost\n",
+    "\n",
+    "magic_tool = FunctionTool.from_defaults(fn=magic_formula, name=\"magic_formula\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "4dc2e5b7-3b41-43ea-91db-847cf28fc6a8",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "context_agent = ContextRetrieverOpenAIAgent.from_tools_and_retriever(\n",
+    "    [magic_tool], \n",
+    "    sept_index.as_retriever(similarity_top_k=3),\n",
+    "    verbose=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "99b9a0f8-0029-495c-a44b-913d1e0556e9",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33;1m\u001b[1;3mContext information is below.\n",
+      "---------------------\n",
+      "Three Months Ended September 30, Nine Months Ended September 30,\n",
+      "2021 2022 2021 2022\n",
+      "Revenue 100 % 100 % 100 % 100 %\n",
+      "Costs and expenses\n",
+      "Cost of revenue, exclusive of depreciation and amortization shown separately\n",
+      "below 50 % 62 % 53 % 62 %\n",
+      "Operations and support 10 % 7 % 11 % 8 %\n",
+      "Sales and marketing 24 % 14 % 30 % 16 %\n",
+      "Research and development 10 % 9 % 13 % 9 %\n",
+      "General and administrative 13 % 11 % 15 % 10 %\n",
+      "Depreciation and amortization 4 % 3 % 6 % 3 %\n",
+      "Total costs and expenses 112 % 106 % 128 % 107 %\n",
+      "Loss from operations (12)% (6)% (28)% (7)%\n",
+      "Interest expense (3)% (2)% (3)% (2)%\n",
+      "Other income (expense), net (38)% (6)% 16 % (34)%\n",
+      "Loss before income taxes and income (loss) from equity method\n",
+      "investments (52)% (14)% (16)% (43)%\n",
+      "Provision for (benefit from) income taxes (2)% 1 % (3)% — %\n",
+      "Income (loss) from equity method investments — % — % — % — %\n",
+      "Net loss including non-controlling interests (50)% (14)% (12)% (42)%\n",
+      "Less: net income (loss) attributable to non-controlling interests,\n",
+      "net of tax — % — % (1)% — %\n",
+      "Net loss attributable to Uber Technologies, Inc. (50)% (14)% (12)% (42)%\n",
+      " Totals of percentage of revenues may not foot due to rounding.\n",
+      "The following discussion and analysis is for the three and nine months ended September 30, 2022 compared to same period in 2021.\n",
+      "Revenue\n",
+      "Three Months Ended September 30, Nine Months Ended September 30,\n",
+      "(In millions, except per centages) 2021 2022 % Change 2021 2022 % Change\n",
+      "Revenue $ 4,845 $ 8,343 72 %$ 11,677 $ 23,270 99 %\n",
+      "Three Months Ended September 30, 2022 Compared with the Same Period in 2021\n",
+      "Revenue increased $3.5 billion, or 72%, primarily attributable to an increase in Gross Bookings of 26%, or 32% on a constant currency basis. The increase in\n",
+      "Gross Bookings was primarily driven by increases in Mobility Trip volumes as the business recovers from the impacts of COVID-19 and a $1.3 billion increase in\n",
+      "Freight Gross Bookings resulting primarily from the acquisition of Transplace in the fourth quarter of 2021. Additionally, during the third quarter of 2022, we saw a\n",
+      "$1.1 billion increase in Mobility revenue as a result of business model changes in the UK. We also saw a $164 million increase in Delivery revenue resulting from\n",
+      "an increase in certain Courier payments and incentives that are recorded in cost of revenue, exclusive of depreciation and amortization, for certain markets where\n",
+      "we are primarily responsible for Delivery services and pay Couriers for services provided.\n",
+      "Nine Months Ended September 30, 2022 Compared with the Same Period in 2021\n",
+      "Revenue increased $11.6 billion, or 99%, primarily attributable to an increase in Gross Bookings of 31%, or 36% on a constant currency basis. The increase in\n",
+      "Gross Bookings was primarily driven by increases in Mobility Trip volumes as the business recovers from the impacts of COVID-19 and a $4.4 billion increase in\n",
+      "Freight Gross Bookings resulting primarily from the acquisition of Transplace in the fourth quarter of 2021. Additionally, during the first nine months of 2022, we\n",
+      "saw a $2.2 billion net increase in Mobility revenue as a result of business model changes in the UK and an accrual made for the resolution of historical claims in\n",
+      "the UK relating to the classification of drivers. We also saw a $751 million increase in Delivery revenue resulting from an increase in certain Courier payments and\n",
+      "incentives that are recorded in cost of revenue, exclusive of depreciation and amortization, for certain markets where we are primarily responsible for\n",
+      "UBER TECHNOLOGIES, INC.\n",
+      "CONDENSED CONSOLIDATED STATEMENTS OF OPERATIONS\n",
+      "(In millions, except share amounts which are reflected in thousands, and per share amounts)\n",
+      "(Unaudited)\n",
+      "Three Months Ended September  30, Nine Months Ended September  30,\n",
+      "2021 2022 2021 2022\n",
+      "Revenue $ 4,845 $ 8,343 $ 11,677 $ 23,270 \n",
+      "Costs and expenses\n",
+      "Cost of revenue, exclusive of depreciation and amortization shown separately\n",
+      "below 2,438 5,173 6,247 14,352 \n",
+      "Operations and support 475 617 1,330 1,808 \n",
+      "Sales and marketing 1,168 1,153 3,527 3,634 \n",
+      "Research and development 493 760 1,496 2,051 \n",
+      "General and administrative 625 908 1,705 2,391 \n",
+      "Depreciation and amortization 218 227 656 724 \n",
+      "Total costs and expenses 5,417 8,838 14,961 24,960 \n",
+      "Loss from operations (572) (495) (3,284) (1,690)\n",
+      "Interest expense (123) (146) (353) (414)\n",
+      "Other income (expense), net (1,832) (535) 1,821 (7,796)\n",
+      "Loss before income taxes and income (loss) from equity method investments (2,527) (1,176) (1,816) (9,900)\n",
+      "Provision for (benefit from) income taxes (101) 58 (395) (97)\n",
+      "Income (loss) from equity method investments (13) 30 (28) 65 \n",
+      "Net loss including non-controlling interests (2,439) (1,204) (1,449) (9,738)\n",
+      "Less: net income (loss) attributable to non-controlling interests, net of\n",
+      "tax (15) 2 (61) (2)\n",
+      "Net loss attributable to Uber Technologies, Inc. $ (2,424)$ (1,206)$ (1,388)$ (9,736)\n",
+      "Net loss per share attributable to Uber Technologies, Inc. common\n",
+      "stockholders:\n",
+      "Basic $ (1.28)$ (0.61)$ (0.74)$ (4.96)\n",
+      "Diluted $ (1.28)$ (0.61)$ (0.75)$ (4.97)\n",
+      "Weighted-average shares used to compute net loss per share attributable to\n",
+      "common stockholders:\n",
+      "Basic 1,898,954 1,979,299 1,877,655 1,964,483 \n",
+      "Diluted 1,898,954 1,979,299 1,878,997 1,968,228 \n",
+      "The accompanying notes are an integral part of these condensed consolidated financial statements.\n",
+      "5\n",
+      "Components of Results of Operations\n",
+      "Revenue\n",
+      "We generate substantially all of our revenue from fees paid by Drivers and Merchants for use of our platform. We have concluded that we are an agent in these\n",
+      "arrangements as we arrange for other parties to provide the service to the end-user. Under this model, revenue is net of Driver and Merchant earnings and Driver\n",
+      "incentives. We act as an agent in these transactions by connecting consumers to Drivers and Merchants to facilitate a Trip, meal or grocery delivery service.\n",
+      "During the first quarter of 2022, we modified our arrangements in certain markets and, as a result, concluded we are responsible for the provision of mobility\n",
+      "services to end-users in those markets. We have determined that in these transactions, end-users are our customers and our sole performance obligation in the\n",
+      "transaction is to provide transportation services to the end-user. We recognize revenue when a trip is complete. In these markets where we are responsible for\n",
+      "mobility services, we present revenue from end-users on a gross basis, as we control the service provided by Drivers to end-users, while payments to Drivers in\n",
+      "exchange for mobility services are recognized in cost of revenue, exclusive of depreciation and amortization.\n",
+      "For additional discussion related to our revenue, see the section titled “Management’s Discussion and Analysis of Financial Condition and Results of\n",
+      "Operations - Critical Accounting Estimates - Revenue Recognition,” “Note 1 - Description of Business and Summary of Significant Accounting Policies - Revenue\n",
+      "Recognition,” and “Note 2 - Revenue” to our audited consolidated financial statements included in our Annual Report Form 10-K for the year ended December 31,\n",
+      "2021 and Note 2 – Revenue in this Quarterly Report on Form 10-Q.\n",
+      "Cost of Revenue, Exclusive of Depreciation and Amortization\n",
+      "Cost of revenue, exclusive of depreciation and amortization, primarily consists of certain insurance costs related to our Mobility and Delivery offerings, credit\n",
+      "card processing fees, bank fees, data center and networking expenses, mobile device and service costs, costs incurred with Carriers for Uber Freight transportation\n",
+      "services, amounts related to fare chargebacks and other credit card losses as well as costs incurred for certain Mobility and Delivery transactions where we are\n",
+      "primarily responsible for mobility or delivery services and pay Drivers and Couriers for services.\n",
+      "We expect that cost of revenue, exclusive of depreciation and amortization, will fluctuate on an absolute dollar basis for the foreseeable future in line with Trip\n",
+      "volume changes on the platform. As Trips increase or decrease, we expect related changes for insurance costs, credit card processing fees, hosting and co-located\n",
+      "data center expenses, maps license fees, and other cost of revenue, exclusive of depreciation and amortization.\n",
+      "Operations and Support\n",
+      "Operations and support expenses primarily consist of compensation expenses, including stock-based compensation, for employees that support operations in\n",
+      "cities, including the general managers, Driver operations, platform user support representatives and community managers. Also included is the cost of customer\n",
+      "support, Driver background checks and the allocation of certain corporate costs.\n",
+      "As our business recovers from the impacts of COVID-19 and Trip volume increases, we would expect operations and support expenses to increase on an\n",
+      "absolute dollar basis for the foreseeable future, but decrease as a percentage of revenue as we become more efficient in supporting platform users.\n",
+      "Sales and Marketing\n",
+      "Sales and marketing expenses primarily consist of compensation costs, including stock-based compensation to sales and marketing employees, advertising\n",
+      "costs, product marketing costs and discounts, loyalty programs, promotions, refunds, and credits provided to end-users who are not customers, and the allocation of\n",
+      "certain corporate costs. We expense advertising and other promotional expenditures as incurred.\n",
+      "As our business recovers from the impacts of COVID-19, we would anticipate sales and marketing expenses to increase on an absolute dollar basis for\n",
+      "---------------------\n",
+      "Given the context information and not prior knowledge, either pick the corresponding tool or answer the function: Can you run MAGIC_FORMULA on Uber's revenue and cost?\n",
+      "\n",
+      "\u001b[0m=== Calling Function ===\n",
+      "Calling function: magic_formula with args: {\n",
+      "  \"revenue\": 23270,\n",
+      "  \"cost\": 24960\n",
+      "}\n",
+      "Got output: -1690\n",
+      "========================\n"
+     ]
+    }
+   ],
+   "source": [
+    "response = context_agent.chat(\"Can you run MAGIC_FORMULA on Uber's revenue and cost?\")  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "9830d9d8-ea62-4c23-af3a-e2fdd46d90d4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "None\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "767db937-c0bb-439a-ba4d-68658bc4596a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "llama_index_v2",
+   "language": "python",
+   "name": "llama_index_v2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/llama_index/agent/__init__.py
+++ b/llama_index/agent/__init__.py
@@ -1,4 +1,10 @@
 from llama_index.agent.openai_agent import OpenAIAgent, RetrieverOpenAIAgent
 from llama_index.agent.retriever_openai_agent import FnRetrieverOpenAIAgent
+from llama_index.agent.context_retriever_agent import ContextRetrieverOpenAIAgent
 
-__all__ = ["OpenAIAgent", "RetrieverOpenAIAgent", "FnRetrieverOpenAIAgent"]
+__all__ = [
+    "OpenAIAgent",
+    "RetrieverOpenAIAgent",
+    "FnRetrieverOpenAIAgent",
+    "ContextRetrieverOpenAIAgent",
+]

--- a/llama_index/agent/context_retriever_agent.py
+++ b/llama_index/agent/context_retriever_agent.py
@@ -1,0 +1,148 @@
+"""Context retriever agent."""
+
+from typing import List, Optional
+
+from llama_index.bridge.langchain import ChatMessageHistory, ChatOpenAI, print_text
+
+from llama_index.callbacks.base import CallbackManager
+from llama_index.schema import NodeWithScore
+from llama_index.indices.base_retriever import BaseRetriever
+from llama_index.response.schema import RESPONSE_TYPE
+from llama_index.tools import BaseTool
+from llama_index.prompts.prompts import QuestionAnswerPrompt
+from llama_index.agent.openai_agent import (
+    BaseOpenAIAgent,
+    DEFAULT_MAX_FUNCTION_CALLS,
+    SUPPORTED_MODEL_NAMES,
+)
+
+# inspired by DEFAULT_QA_PROMPT_TMPL from llama_index/prompts/default_prompts.py
+DEFAULT_QA_PROMPT_TMPL = (
+    "Context information is below.\n"
+    "---------------------\n"
+    "{context_str}\n"
+    "---------------------\n"
+    "Given the context information and not prior knowledge, "
+    "either pick the corresponding tool or answer the function: {query_str}\n"
+)
+DEFAULT_QA_PROMPT = QuestionAnswerPrompt(DEFAULT_QA_PROMPT_TMPL)
+
+
+class ContextRetrieverOpenAIAgent(BaseOpenAIAgent):
+    """ContextRetriever OpenAI Agent.
+
+    This agent performs retrieval from BaseRetriever before
+    calling the LLM. Allows it to augment user message with context.
+
+    NOTE: this is a beta feature, function interfaces might change.
+
+    Args:
+        retriever (BaseRetriever): A retriever.
+        qa_prompt (Optional[QuestionAnswerPrompt]): A QA prompt.
+        context_separator (str): A context separator.
+        llm (Optional[ChatOpenAI]): An LLM.
+        chat_history (Optional[ChatMessageHistory]): A chat history.
+        verbose (bool): Whether to print debug statements.
+        max_function_calls (int): Maximum number of function calls.
+        callback_manager (Optional[CallbackManager]): A callback manager.
+
+    """
+
+    def __init__(
+        self,
+        tools: List[BaseTool],
+        retriever: BaseRetriever,
+        qa_prompt: QuestionAnswerPrompt,
+        context_separator: str,
+        llm: ChatOpenAI,
+        chat_history: ChatMessageHistory,
+        verbose: bool = False,
+        max_function_calls: int = DEFAULT_MAX_FUNCTION_CALLS,
+        callback_manager: Optional[CallbackManager] = None,
+    ) -> None:
+        super().__init__(
+            llm=llm,
+            chat_history=chat_history,
+            verbose=verbose,
+            max_function_calls=max_function_calls,
+            callback_manager=callback_manager,
+        )
+        self._tools = tools
+        self._qa_prompt = qa_prompt
+        self._retriever = retriever
+        self._context_separator = context_separator
+
+    @classmethod
+    def from_tools_and_retriever(
+        cls,
+        tools: List[BaseTool],
+        retriever: BaseRetriever,
+        qa_prompt: Optional[QuestionAnswerPrompt] = None,
+        context_separator: str = "\n",
+        llm: Optional[ChatOpenAI] = None,
+        chat_history: Optional[ChatMessageHistory] = None,
+        verbose: bool = False,
+        max_function_calls: int = DEFAULT_MAX_FUNCTION_CALLS,
+        callback_manager: Optional[CallbackManager] = None,
+    ) -> "ContextRetrieverOpenAIAgent":
+        """Create a ContextRetrieverOpenAIAgent from a retriever.
+
+        Args:
+            retriever (BaseRetriever): A retriever.
+            qa_prompt (Optional[QuestionAnswerPrompt]): A QA prompt.
+            context_separator (str): A context separator.
+            llm (Optional[ChatOpenAI]): An LLM.
+            chat_history (Optional[ChatMessageHistory]): A chat history.
+            verbose (bool): Whether to print debug statements.
+            max_function_calls (int): Maximum number of function calls.
+            callback_manager (Optional[CallbackManager]): A callback manager.
+
+        """
+        qa_prompt = qa_prompt or DEFAULT_QA_PROMPT
+        lc_chat_history = chat_history or ChatMessageHistory()
+        llm = llm or ChatOpenAI(temperature=0, model_name="gpt-3.5-turbo-0613")
+        if not isinstance(llm, ChatOpenAI):
+            raise ValueError("llm must be a ChatOpenAI instance")
+
+        if llm.model_name not in SUPPORTED_MODEL_NAMES:
+            raise ValueError(
+                f"Model name {llm.model_name} not supported. "
+                f"Supported model names: {SUPPORTED_MODEL_NAMES}"
+            )
+
+        return cls(
+            tools=tools,
+            retriever=retriever,
+            qa_prompt=qa_prompt,
+            context_separator=context_separator,
+            llm=llm,
+            chat_history=lc_chat_history,
+            verbose=verbose,
+            max_function_calls=max_function_calls,
+            callback_manager=callback_manager,
+        )
+
+    def _get_tools(self, message: str) -> List[BaseTool]:
+        """Get tools."""
+        return self._tools
+
+    def chat(
+        self, message: str, chat_history: Optional[ChatMessageHistory] = None
+    ) -> RESPONSE_TYPE:
+        """Chat."""
+        # augment user message
+        retrieved_nodes_w_scores: List[NodeWithScore] = self._retriever.retrieve(
+            message
+        )
+        retrieved_nodes = [node.node for node in retrieved_nodes_w_scores]
+        retrieved_texts = [node.get_content() for node in retrieved_nodes]
+
+        # format message
+        context_str = self._context_separator.join(retrieved_texts)
+        formatted_message = self._qa_prompt.format(
+            context_str=context_str, query_str=message
+        )
+        if self._verbose:
+            print_text(formatted_message + "\n", color="yellow")
+
+        return super().chat(formatted_message, chat_history=chat_history)

--- a/llama_index/agent/openai_agent.py
+++ b/llama_index/agent/openai_agent.py
@@ -214,7 +214,12 @@ class OpenAIAgent(BaseOpenAIAgent):
 class RetrieverOpenAIAgent(BaseOpenAIAgent):
     """Retriever OpenAI Agent.
 
+    This agent specifically performs retrieval on top of functions
+    during query-time.
+
     NOTE: this is a beta feature, function interfaces might change.
+    NOTE: this is also a too generally named, a better name is
+        FunctionRetrieverOpenAIAgent
 
     TODO: add a native OpenAI Tool Index.
 


### PR DESCRIPTION
# Description

Extend OpenAIAgent to do retrieval and augment the user-message, before picking a Tool.

Thought this would be a cool feature to add. The inspiration came from the fact that a default OpenAI function agent picks a tool purely based on prior understanding/beliefs. There could be cases where it may need context to better do tool selection.

Conceptually speaking, you could argue that you could just have retrieval be a tool itself, and that if the agent was smart it could call the retrieval tool to get information before calling other tools. However I still think this agent is nice for the following reasons:
- This agent guarantees retrieval at each step
- We don't have a "raw" retrieval query engine right now - the query engine synthesizes a response with an extra LLM call. in contrast this agent does lower-level retrieval to augment the context. (of course we could add a "pass-through retrieval query engine") 

Guaranteeing retrieval can help users build agents in more constrained use cases.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [x] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

