### PR TITLE
Allow null values for the 'image' property in the ImageNode class and se…

### DIFF
--- a/llama_index/schema.py
+++ b/llama_index/schema.py
@@ -311,7 +311,7 @@ class ImageNode(TextNode):
 
     # TODO: store reference instead of actual image
     # base64 encoded image str
-    image: str
+    image: Optional[str] = None
 
     @classmethod
     def get_type(cls) -> str:


### PR DESCRIPTION
…t default to None

# Description

I was repeatedly running into the following error when uploading an image to an index:
```
1 validation error for ImageNode:
image
none is not an allowed value (type=type_error.none.not_allowed)

```

This has been fixed by modifying the ImageNode class to allow null values for the image property.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
