### PR TITLE
update milvus to store node content

### DIFF
--- a/llama_index/vector_stores/milvus.py
+++ b/llama_index/vector_stores/milvus.py
@@ -15,6 +15,7 @@ from llama_index.vector_stores.types import (
     VectorStoreQueryMode,
     VectorStoreQueryResult,
 )
+from llama_index.vector_stores.utils import node_to_metadata_dict, metadata_dict_to_node
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +57,7 @@ class MilvusVectorStore(VectorStore):
     """
 
     stores_text: bool = True
-    stores_node: bool = False
+    stores_node: bool = True
 
     def __init__(
         self,
@@ -216,6 +217,12 @@ class MilvusVectorStore(VectorStore):
                     description="The embedding vector",
                     dim=self.dim,
                 ),
+                FieldSchema(
+                    name="node",
+                    dtype=DataType.VARCHAR,
+                    description="The node content",
+                    max_length=65535,
+                ),
             ]
 
             col_schema = CollectionSchema(fields=fields)
@@ -317,6 +324,7 @@ class MilvusVectorStore(VectorStore):
         doc_ids = []
         texts = []
         embeddings = []
+        nodes = []
 
         # Process that data we are going to insert
         for result in embedding_results:
@@ -325,9 +333,13 @@ class MilvusVectorStore(VectorStore):
             texts.append(result.node.get_content(metadata_mode=MetadataMode.NONE))
             embeddings.append(result.embedding)
 
+            # Store node without text
+            metadata = node_to_metadata_dict(result.node, remove_text=True)
+            nodes.append(metadata["_node_content"])
+
         try:
             # Insert the data into milvus
-            self.collection.insert([ids, doc_ids, texts, embeddings])
+            self.collection.insert([ids, doc_ids, texts, embeddings, nodes])
             logger.debug(
                 f"Successfully inserted embeddings into: {self.collection_name} "
                 f"Num Inserted: {len(ids)}"
@@ -401,6 +413,20 @@ class MilvusVectorStore(VectorStore):
                 "embedding",
                 self.search_params,
                 limit=query.similarity_top_k,
+                output_fields=["doc_id", "text", "node"],
+                expr=expr,
+            )
+            logger.debug(
+                f"Successfully searched embedding in collection: {self.collection_name}"
+                f" Num Results: {len(res[0])}"
+            )
+        except MilvusException:
+            # TODO: Legacy support for old dbs
+            res = self.collection.search(
+                [query.query_embedding],
+                "embedding",
+                self.search_params,
+                limit=query.similarity_top_k,
                 output_fields=["doc_id", "text"],
                 expr=expr,
             )
@@ -408,27 +434,26 @@ class MilvusVectorStore(VectorStore):
                 f"Successfully searched embedding in collection: {self.collection_name}"
                 f" Num Results: {len(res[0])}"
             )
-        except MilvusException as e:
-            logger.debug(
-                f"Unsuccessfully searched embedding in collection: "
-                f"{self.collection_name}"
-            )
-            raise e
 
         nodes = []
         similarities = []
         ids = []
 
         for hit in res[0]:
-            node = TextNode(
-                text=hit.entity.get("text"),
-                id_=hit.id,
-                relationships={
-                    NodeRelationship.SOURCE: RelatedNodeInfo(
-                        node_id=hit.entity.get("doc_id")
-                    ),
-                },
-            )
+            try:
+                node = metadata_dict_to_node({"_node_content": hit.entity.get("node")})
+                node.text = hit.entity.get("text")
+            except Exception:
+                # TODO: Legacy support for old nodes
+                node = TextNode(
+                    text=hit.entity.get("text"),
+                    id_=hit.id,
+                    relationships={
+                        NodeRelationship.SOURCE: RelatedNodeInfo(
+                            node_id=hit.entity.get("doc_id")
+                        ),
+                    },
+                )
             nodes.append(node)
             similarities.append(hit.score)
             ids.append(hit.id)


### PR DESCRIPTION
# Description

With the new node changes, milvus can store and load the actual node objects now, therefore retaining metadata.

Fixes # (issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested locally with new and old milvus dbs
- [x] I stared at the code and made sure it makes sense
