### PR TITLE
fix doc_id vs node_id filtering for vector stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Unreleased
 
+### New Features
+- Added async support for "compact" and "refine" response modes (#6590)
+
 ### Bug Fixes / Nits
 - Fixed node vs. document filtering in vector stores (#6677)
-- Added async support for "compact" and "refine" response modes (#6590)
 
 ## [v0.6.37] - 2023-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## Unreleased
+
+### Bug Fixes / Nits
+- Fixed node vs. document filtering in vector stores (#6677)
+
 ## [v0.6.37] - 2023-06-30
 
 ### New Features

--- a/llama_index/indices/vector_store/base.py
+++ b/llama_index/indices/vector_store/base.py
@@ -77,7 +77,7 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
 
         return VectorIndexRetriever(
             self,
-            doc_ids=list(self.index_struct.nodes_dict.values()),
+            node_ids=list(self.index_struct.nodes_dict.values()),
             **kwargs,
         )
 

--- a/llama_index/indices/vector_store/retrievers/retriever.py
+++ b/llama_index/indices/vector_store/retrievers/retriever.py
@@ -42,6 +42,7 @@ class VectorIndexRetriever(BaseRetriever):
         vector_store_query_mode: VectorStoreQueryMode = VectorStoreQueryMode.DEFAULT,
         filters: Optional[MetadataFilters] = None,
         alpha: Optional[float] = None,
+        node_ids: Optional[List[str]] = None,
         doc_ids: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> None:
@@ -54,6 +55,7 @@ class VectorIndexRetriever(BaseRetriever):
         self._similarity_top_k = similarity_top_k
         self._vector_store_query_mode = VectorStoreQueryMode(vector_store_query_mode)
         self._alpha = alpha
+        self._node_ids = node_ids
         self._doc_ids = doc_ids
         self._filters = filters
 
@@ -75,6 +77,7 @@ class VectorIndexRetriever(BaseRetriever):
         query = VectorStoreQuery(
             query_embedding=query_bundle.embedding,
             similarity_top_k=self._similarity_top_k,
+            node_ids=self._node_ids,
             doc_ids=self._doc_ids,
             query_str=query_bundle.query_str,
             mode=self._vector_store_query_mode,

--- a/llama_index/vector_stores/dynamodb.py
+++ b/llama_index/vector_stores/dynamodb.py
@@ -120,8 +120,8 @@ class DynamoDBVectorStore(VectorStore):
         # TODO: consolidate with get_query_text_embedding_similarities
         items = self._kvstore.get_all(collection=self._collection_embedding).items()
 
-        if query.doc_ids:
-            available_ids = set(query.doc_ids)
+        if query.node_ids:
+            available_ids = set(query.node_ids)
 
             node_ids = [k for k, _ in items if k in available_ids]
             embeddings = [v[self._key_value] for k, v in items if k in available_ids]

--- a/llama_index/vector_stores/qdrant.py
+++ b/llama_index/vector_stores/qdrant.py
@@ -228,6 +228,14 @@ class QdrantVectorStore(VectorStore):
                 )
             )
 
+        if query.node_ids:
+            must_conditions.append(
+                FieldCondition(
+                    key="id",
+                    match=MatchAny(any=query.node_ids),
+                )
+            )
+
         # Qdrant does not use the query.query_str property for the filtering. Full-text
         # filtering cannot handle longer queries and can effectively filter our all the
         # nodes. See: https://github.com/jerryjliu/llama_index/pull/1181

--- a/llama_index/vector_stores/simple.py
+++ b/llama_index/vector_stores/simple.py
@@ -41,8 +41,9 @@ class SimpleVectorStoreData(DataClassJsonMixin):
     """Simple Vector Store Data container.
 
     Args:
-        embedding_dict (Optional[dict]): dict mapping doc_ids to embeddings.
-        text_id_to_ref_doc_id (Optional[dict]): dict mapping text_ids to ref_doc_ids.
+        embedding_dict (Optional[dict]): dict mapping node_ids to embeddings.
+        text_id_to_ref_doc_id (Optional[dict]): 
+            dict mapping text_ids/node_ids to ref_doc_ids.
 
     """
 

--- a/llama_index/vector_stores/simple.py
+++ b/llama_index/vector_stores/simple.py
@@ -42,7 +42,7 @@ class SimpleVectorStoreData(DataClassJsonMixin):
 
     Args:
         embedding_dict (Optional[dict]): dict mapping node_ids to embeddings.
-        text_id_to_ref_doc_id (Optional[dict]): 
+        text_id_to_ref_doc_id (Optional[dict]):
             dict mapping text_ids/node_ids to ref_doc_ids.
 
     """

--- a/llama_index/vector_stores/simple.py
+++ b/llama_index/vector_stores/simple.py
@@ -136,8 +136,8 @@ class SimpleVectorStore(VectorStore):
         # TODO: consolidate with get_query_text_embedding_similarities
         items = self._data.embedding_dict.items()
 
-        if query.doc_ids:
-            available_ids = set(query.doc_ids)
+        if query.node_ids:
+            available_ids = set(query.node_ids)
 
             node_ids = [t[0] for t in items if t[0] in available_ids]
             embeddings = [t[1] for t in items if t[0] in available_ids]

--- a/llama_index/vector_stores/types.py
+++ b/llama_index/vector_stores/types.py
@@ -122,6 +122,7 @@ class VectorStoreQuery:
     query_embedding: Optional[List[float]] = None
     similarity_top_k: int = 1
     doc_ids: Optional[List[str]] = None
+    node_ids: Optional[List[str]] = None
     query_str: Optional[str] = None
 
     mode: VectorStoreQueryMode = VectorStoreQueryMode.DEFAULT


### PR DESCRIPTION
# Description

The `VectorStoreRetriever` has a `doc_ids` parameter. Some vector stores were using this to filter node_ids, and others to filter doc_ids (likely due to how the naming worked in past version of llama-index).

This PR clarifies the retriever, and fixes what is actually being filtered in vector stores. Now, you can filter by doc_id or node_id

Fixes https://github.com/jerryjliu/llama_index/pull/6619

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense
