### PR TITLE
store node content in redis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # ChangeLog
 
 ## Unreleased
+
+### New Features
 - Added async support for "compact" and "refine" response modes (#6590)
+
+### Bug Fixes / Nits
+- Improve metadata/node storage and retrieval for RedisVectorStore (#6678)
 
 ## [v0.6.37] - 2023-06-30
 


### PR DESCRIPTION
# Description

Redis wasn't storing/recovering metadata properly. Now that nodes can be serialized, this fix ensures the entire node is also retrieved (including metadata!)

Fixes https://github.com/jerryjliu/llama_index/pull/6619

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested with old/new versions, tested for backward compat
- [x] I stared at the code and made sure it makes sense
