### PR TITLE
Minor docs update for streaming

### DIFF
--- a/docs/examples/customization/streaming/SimpleIndexDemo-streaming.ipynb
+++ b/docs/examples/customization/streaming/SimpleIndexDemo-streaming.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9c48213d-6e6a-4c10-838a-2a7c710c3a05",
    "metadata": {},
@@ -9,6 +10,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "50d3b817-b70e-4667-be4f-d3a0fe4bd119",
    "metadata": {},
@@ -18,12 +20,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 2,
    "id": "690a6918-7c75-4f95-9ccc-d2c4a1fe00d7",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:numexpr.utils:Note: NumExpr detected 12 cores but \"NUMEXPR_MAX_THREADS\" not set, so enforcing safe limit of 8.\n",
+      "Note: NumExpr detected 12 cores but \"NUMEXPR_MAX_THREADS\" not set, so enforcing safe limit of 8.\n",
+      "INFO:numexpr.utils:NumExpr defaulting to 8 threads.\n",
+      "NumExpr defaulting to 8 threads.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/suo/miniconda3/envs/llama/lib/python3.9/site-packages/deeplake/util/check_latest_version.py:32: UserWarning: A newer version of deeplake (3.6.7) is available. It's recommended that you update to the latest version using `pip install -U deeplake`.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
    "source": [
     "import logging\n",
     "import sys\n",
@@ -37,22 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "id": "d105229e",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "llm_predictor = LLMPredictor(llm=OpenAI(temperature=0, model_name=\"text-davinci-003\", streaming=True))\n",
-    "service_context = ServiceContext.from_defaults(\n",
-    "    llm_predictor=llm_predictor\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 3,
    "id": "03d1691e-544b-454f-825b-5ee12f7faa8a",
    "metadata": {
     "tags": []
@@ -65,33 +71,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 4,
    "id": "ad144ee7-96da-4dd6-be00-fd6cf0c78e58",
    "metadata": {
     "scrolled": true,
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:llama_index.token_counter.token_counter:> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
-      "> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
-      "> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
-      "> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
-      "INFO:llama_index.token_counter.token_counter:> [build_index_from_nodes] Total embedding token usage: 20729 tokens\n",
-      "> [build_index_from_nodes] Total embedding token usage: 20729 tokens\n",
-      "> [build_index_from_nodes] Total embedding token usage: 20729 tokens\n",
-      "> [build_index_from_nodes] Total embedding token usage: 20729 tokens\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "index = VectorStoreIndex.from_documents(documents, service_context=service_context)"
+    "index = VectorStoreIndex.from_documents(documents)"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "b6caf93b-6345-4c65-a346-a95b0f1746c4",
    "metadata": {},
@@ -101,36 +93,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 5,
    "id": "85466fdf-93f3-4cb1-a5f9-0056a8245a6f",
    "metadata": {
     "scrolled": true,
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:llama_index.token_counter.token_counter:> [retrieve] Total LLM token usage: 0 tokens\n",
-      "> [retrieve] Total LLM token usage: 0 tokens\n",
-      "> [retrieve] Total LLM token usage: 0 tokens\n",
-      "> [retrieve] Total LLM token usage: 0 tokens\n",
-      "INFO:llama_index.token_counter.token_counter:> [retrieve] Total embedding token usage: 8 tokens\n",
-      "> [retrieve] Total embedding token usage: 8 tokens\n",
-      "> [retrieve] Total embedding token usage: 8 tokens\n",
-      "> [retrieve] Total embedding token usage: 8 tokens\n",
-      "INFO:llama_index.token_counter.token_counter:> [get_response] Total LLM token usage: 0 tokens\n",
-      "> [get_response] Total LLM token usage: 0 tokens\n",
-      "> [get_response] Total LLM token usage: 0 tokens\n",
-      "> [get_response] Total LLM token usage: 0 tokens\n",
-      "INFO:llama_index.token_counter.token_counter:> [get_response] Total embedding token usage: 0 tokens\n",
-      "> [get_response] Total embedding token usage: 0 tokens\n",
-      "> [get_response] Total embedding token usage: 0 tokens\n",
-      "> [get_response] Total embedding token usage: 0 tokens\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# set Logging to DEBUG for more detailed outputs\n",
     "query_engine = index.as_query_engine(\n",
@@ -144,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 6,
    "id": "29ed26f2",
    "metadata": {
     "tags": []
@@ -155,7 +124,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "The author grew up writing short stories and programming on an IBM 1401. He also nagged his father to buy him a TRS-80 microcomputer, on which he wrote simple games, a program to predict how high his model rockets would fly, and a word processor. He also studied philosophy in college."
+      "The author grew up writing short stories and programming on an IBM 1401. He also nagged his father to buy him a TRS-80 microcomputer, on which he wrote simple games, a program to predict how high his model rockets would fly, and a word processor. He eventually went to college to study philosophy, but found it boring and switched to AI."
      ]
     }
    ],
@@ -174,9 +143,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "llama_index_v2",
+   "display_name": "llama",
    "language": "python",
-   "name": "llama_index_v2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -188,7 +157,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/docs/examples/customization/streaming/chat_engine_condense_question_stream_response.ipynb
+++ b/docs/examples/customization/streaming/chat_engine_condense_question_stream_response.ipynb
@@ -58,21 +58,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "164ef191-f86a-4ce1-aa9d-64d61f29dd45",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "llm_predictor = LLMPredictor(llm=OpenAI(temperature=0, model_name=\"text-davinci-003\", streaming=True))\n",
-    "service_context = ServiceContext.from_defaults(\n",
-    "    llm_predictor=llm_predictor\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 3,
    "id": "c4a6b55f",
    "metadata": {},
@@ -100,7 +85,7 @@
     }
    ],
    "source": [
-    "index = VectorStoreIndex.from_documents(documents, service_context=service_context)"
+    "index = VectorStoreIndex.from_documents(documents)"
    ]
   },
   {

--- a/docs/how_to/customization/streaming.md
+++ b/docs/how_to/customization/streaming.md
@@ -5,19 +5,10 @@ This allows you to start printing or processing the beginning of the response be
 This can drastically reduce the perceived latency of queries.
 
 ### Setup
-To enable streaming, you need to configure two things:
-1. Use an LLM that supports streaming, and set `streaming=True`.
-```python
-llm_predictor = LLMPredictor(
-    llm=ChatOpenAI(temperature=0, model_name="gpt-3.5-turbo", streaming=True)
-)
-service_context = ServiceContext.from_defaults(
-    llm_predictor=llm_predictor
-)
-```
-Right now, streaming is supported by OpenAI and HuggingFace LLMs.
+To enable streaming, you need to use an LLM that supports streaming.
+Right now, streaming is supported by `OpenAI`, `HuggingFaceLLM`, and most LangChain LLMs (via `LangChainLLM`).
 
-2. Configure query engine to use streaming  
+Configure query engine to use streaming:
 
 If you are using the high-level API, set `streaming=True` when building a query engine.
 ```python


### PR DESCRIPTION
# Description

Update notebook and docs for streaming, since we no longer require user to set streaming flag on the LLM itself.
Streaming vs not is controlled by calling the `complete` vs. `stream_complete` endpoint.  
