### PR TITLE
Set default chat engine mode to use openai agent

### DIFF
--- a/docs/examples/chat_engine/chat_engine_openai_agent.ipynb
+++ b/docs/examples/chat_engine/chat_engine_openai_agent.ipynb
@@ -1,0 +1,132 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "4d3e1610-942d-458e-8379-ebb1fe88ac2c",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Chat Engine - OpenAI Agent Mode"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d3cb595-1bd4-446e-93ba-6e3cfc1d4a29",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Get started in 5 lines of code"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "941f4d3a-b84c-409d-b371-85c33ab7b68f",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Load data and build index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "4a258574-a4d1-42cc-9f1a-bc6f5d4c6a37",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from llama_index import VectorStoreIndex, SimpleDirectoryReader, ServiceContext\n",
+    "from llama_index.llms import OpenAI\n",
+    "\n",
+    "# Necessary to use the latest OpenAI models that support function calling API\n",
+    "service_context = ServiceContext.from_defaults(llm=OpenAI(model='gpt-3.5-turbo-0613'))\n",
+    "data = SimpleDirectoryReader(input_dir=\"../data/paul_graham/\").load_data()\n",
+    "index = VectorStoreIndex.from_documents(data, service_context=service_context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e0dc626-c877-422f-913a-afd3d3c8cdc8",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Configure chat engine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "37717d64-851d-46c2-b64c-2f5efaaa37f9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "chat_engine = index.as_chat_engine(chat_mode=\"openai_agent\", verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5b86747-22ca-4626-9df7-ff123ac57883",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Chat with your data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "5b4b6686-21cd-4974-b767-4ebad4cefb36",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Calling Function ===\n",
+      "Calling function: query_engine_tool with args: {\n",
+      "  \"input\": \"Who did Paul Graham hand over YC to?\"\n",
+      "}\n",
+      "Got output: Paul Graham handed over YC to Sam Altman.\n",
+      "========================\n",
+      "Paul Graham handed over YC to Sam Altman.\n"
+     ]
+    }
+   ],
+   "source": [
+    "response = chat_engine.chat(\n",
+    "    \"Use the tool to answer: Who did Paul Graham hand over YC to?\"\n",
+    ")\n",
+    "print(response)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/llama_index/chat_engine/react.py
+++ b/llama_index/chat_engine/react.py
@@ -1,26 +1,18 @@
 from typing import Any, List, Optional, Sequence
 
-from llama_index.bridge.langchain import (
-    BaseChatMemory,
-    ChatMessageHistory,
-    ConversationBufferMemory,
-)
+from llama_index.bridge.langchain import (BaseChatMemory, ChatMessageHistory,
+                                          ConversationBufferMemory)
 from llama_index.chat_engine.types import BaseChatEngine
 from llama_index.indices.query.base import BaseQueryEngine
 from llama_index.indices.service_context import ServiceContext
-from llama_index.langchain_helpers.agents.agents import (
-    AgentExecutor,
-    AgentType,
-    initialize_agent,
-)
+from llama_index.langchain_helpers.agents.agents import (AgentExecutor,
+                                                         AgentType,
+                                                         initialize_agent)
 from llama_index.llm_predictor.base import LLMPredictor
 from llama_index.llms.base import ChatMessage
 from llama_index.llms.langchain import LangChainLLM
-from llama_index.llms.langchain_utils import (
-    from_lc_messages,
-    is_chat_model,
-    to_lc_messages,
-)
+from llama_index.llms.langchain_utils import (from_lc_messages, is_chat_model,
+                                              to_lc_messages)
 from llama_index.response.schema import RESPONSE_TYPE, Response
 from llama_index.tools.query_engine import QueryEngineTool
 

--- a/llama_index/chat_engine/types.py
+++ b/llama_index/chat_engine/types.py
@@ -69,3 +69,9 @@ class ChatMode(str, Enum):
     Use a ReAct agent loop with query engine tools. 
     Implemented via LangChain agent.
     """
+    OPENAI_AGENT = "openai_agent"
+    """Corresponds to `OpenAIAgent`.
+
+    Use an OpenAI agent loop with query engine tools. 
+    This requires the latest OpenAI models that support function calling API.
+    """

--- a/llama_index/indices/base.py
+++ b/llama_index/indices/base.py
@@ -1,8 +1,7 @@
 """Base index classes."""
 import logging
 from abc import ABC, abstractmethod
-from typing import (Any, Dict, Generic, List, Optional, Sequence, Type,
-                    TypeVar, cast)
+from typing import Any, Dict, Generic, List, Optional, Sequence, Type, TypeVar, cast
 
 from llama_index.chat_engine.types import BaseChatEngine, ChatMode
 from llama_index.data_structs.data_structs import IndexStruct
@@ -332,8 +331,7 @@ class BaseIndex(Generic[IS], ABC):
 
     def as_query_engine(self, **kwargs: Any) -> BaseQueryEngine:
         # NOTE: lazy import
-        from llama_index.query_engine.retriever_query_engine import \
-            RetrieverQueryEngine
+        from llama_index.query_engine.retriever_query_engine import RetrieverQueryEngine
 
         retriever = self.as_retriever(**kwargs)
 
@@ -343,7 +341,7 @@ class BaseIndex(Generic[IS], ABC):
         return RetrieverQueryEngine.from_args(**kwargs)
 
     def as_chat_engine(
-        self, chat_mode: ChatMode = ChatMode.CONDENSE_QUESTION, **kwargs: Any
+        self, chat_mode: ChatMode = ChatMode.OPENAI_AGENT, **kwargs: Any
     ) -> BaseChatEngine:
         query_engine = self.as_query_engine(**kwargs)
         if "service_context" not in kwargs:

--- a/llama_index/indices/service_context.py
+++ b/llama_index/indices/service_context.py
@@ -226,6 +226,12 @@ class ServiceContext:
             callback_manager=callback_manager,
         )
 
+    @property
+    def llm(self) -> LLM:
+        if not isinstance(self.llm_predictor, LLMPredictor):
+            raise ValueError("llm_predictor must be an instance of LLMPredictor")
+        return self.llm_predictor.llm
+
 
 def set_global_service_context(service_context: Optional[ServiceContext]) -> None:
     """Helper function to set the global service context."""

--- a/llama_index/tools/query_engine.py
+++ b/llama_index/tools/query_engine.py
@@ -4,7 +4,7 @@ from llama_index.indices.query.base import BaseQueryEngine
 from llama_index.langchain_helpers.agents.tools import IndexToolConfig, LlamaIndexTool
 from llama_index.tools.types import BaseTool, ToolMetadata
 
-DEFAULT_NAME = "Query Engine Tool"
+DEFAULT_NAME = "query_engine_tool"
 DEFAULT_DESCRIPTION = """Useful for running a natural language query
 against a knowledge base and get back a natural language response.
 """


### PR DESCRIPTION
# Description
Set default chat engine mode to use openai agent

### Caveat
Right now we use `text-davinci-003` as the default LLM, but we need the newer `gpt-3.5-turbo-0613` to use the openai agent. This creates an extra step required (setting LLM) before the user can run `index.as_chat_engine(...)`

IMO ideally, we can move to using `gpt-3.5-turbo-0613` as the default LLM everywhere in llama index. Right now this is undesirable since our prompts don't work well with the new turbo model.

