### PR TITLE
support langchain system messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes / Nits
 - Fix HF LLM output error (#6737)
+- Add system message support for langchain message templates (#6743)
 
 ## [v0.7.1] - 2023-07-05
 

--- a/llama_index/bridge/langchain.py
+++ b/llama_index/bridge/langchain.py
@@ -39,7 +39,13 @@ from langchain.input import print_text, get_color_mapping
 from langchain.callbacks.base import BaseCallbackHandler, BaseCallbackManager
 
 # schema
-from langchain.schema import AIMessage, FunctionMessage, BaseMessage, HumanMessage
+from langchain.schema import (
+    AIMessage,
+    FunctionMessage,
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+)
 from langchain.schema import BaseMemory
 from langchain.schema import BaseOutputParser, LLMResult
 from langchain.schema import ChatGeneration
@@ -89,6 +95,7 @@ __all__ = [
     "FunctionMessage",
     "BaseMessage",
     "HumanMessage",
+    "SystemMessage",
     "BaseMemory",
     "BaseOutputParser",
     "HumanMessage",

--- a/llama_index/llms/langchain_utils.py
+++ b/llama_index/llms/langchain_utils.py
@@ -13,9 +13,10 @@ from llama_index.bridge.langchain import (
     FunctionMessage,
     HumanMessage,
     OpenAI,
+    SystemMessage,
 )
 from llama_index.constants import AI21_J2_CONTEXT_WINDOW, COHERE_CONTEXT_WINDOW
-from llama_index.llms.base import ChatMessage, LLMMetadata
+from llama_index.llms.base import ChatMessage, LLMMetadata, MessageRole
 from llama_index.llms.openai_utils import openai_modelname_to_contextsize
 
 
@@ -49,6 +50,12 @@ def to_lc_messages(messages: Sequence[ChatMessage]) -> List[LCMessage]:
                     name=name,
                 )
             )
+        elif message.role == "system":
+            lc_messages.append(
+                SystemMessage(
+                    content=message.content, additional_kwargs=message.additional_kwargs
+                )
+            )
         else:
             raise ValueError(f"Invalid role: {message.role}")
     return lc_messages
@@ -62,7 +69,7 @@ def from_lc_messages(lc_messages: Sequence[LCMessage]) -> List[ChatMessage]:
                 ChatMessage(
                     content=lc_message.content,
                     additional_kwargs=lc_message.additional_kwargs,
-                    role="user",
+                    role=MessageRole.USER,
                 )
             )
         elif isinstance(lc_message, AIMessage):
@@ -70,7 +77,7 @@ def from_lc_messages(lc_messages: Sequence[LCMessage]) -> List[ChatMessage]:
                 ChatMessage(
                     content=lc_message.content,
                     additional_kwargs=lc_message.additional_kwargs,
-                    role="assistant",
+                    role=MessageRole.ASSISTANT,
                 )
             )
         elif isinstance(lc_message, FunctionMessage):
@@ -79,7 +86,15 @@ def from_lc_messages(lc_messages: Sequence[LCMessage]) -> List[ChatMessage]:
                     content=lc_message.content,
                     additional_kwargs=lc_message.additional_kwargs,
                     name=lc_message.name,
-                    role="function",
+                    role=MessageRole.FUNCTION,
+                )
+            )
+        elif isinstance(lc_message, SystemMessage):
+            messages.append(
+                ChatMessage(
+                    content=lc_message.content,
+                    additional_kwargs=lc_message.additional_kwargs,
+                    role=MessageRole.SYSTEM,
                 )
             )
         else:

--- a/tests/llms/test_langchain.py
+++ b/tests/llms/test_langchain.py
@@ -1,6 +1,16 @@
-from llama_index.bridge.langchain import FakeListLLM
-from llama_index.llms.base import ChatMessage
+from typing import List
+
+from llama_index.bridge.langchain import (
+    FakeListLLM,
+    SystemMessage,
+    HumanMessage,
+    AIMessage,
+    FunctionMessage,
+    BaseMessage,
+)
+from llama_index.llms.base import ChatMessage, MessageRole
 from llama_index.llms.langchain import LangChainLLM
+from llama_index.llms.langchain_utils import from_lc_messages, to_lc_messages
 
 
 def test_basic() -> None:
@@ -12,3 +22,35 @@ def test_basic() -> None:
 
     llm.complete(prompt)
     llm.chat([message])
+
+
+def test_to_lc_messages() -> None:
+    lc_messages: List[BaseMessage] = [
+        SystemMessage(content="test system message"),
+        HumanMessage(content="test human message"),
+        AIMessage(content="test ai message"),
+        FunctionMessage(content="test function message", name="test function"),
+    ]
+
+    messages = from_lc_messages(lc_messages)
+
+    for i in range(len(messages)):
+        assert messages[i].content == lc_messages[i].content
+
+
+def test_from_lc_messages() -> None:
+    messages = [
+        ChatMessage(content="test system message", role=MessageRole.SYSTEM),
+        ChatMessage(content="test human message", role=MessageRole.USER),
+        ChatMessage(content="test ai message", role=MessageRole.ASSISTANT),
+        ChatMessage(
+            content="test function message",
+            role=MessageRole.FUNCTION,
+            additional_kwargs={"name": "test function"},
+        ),
+    ]
+
+    lc_messages = to_lc_messages(messages)
+
+    for i in range(len(messages)):
+        assert messages[i].content == lc_messages[i].content


### PR DESCRIPTION
# Description

Our `from_lc_messages()` util function was not using system messages. This is used by users who customized prompt templates for query engines to include system messages.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added new unit/integration tests
- [x] I stared at the code and made sure it makes sense
