### PR TITLE
Only consider LLM content for text splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes / Nits
 - Fix HF LLM output error (#6737)
+- Only consider metadata intended for LLM when splitting text (#6744)
 
 ## [v0.7.1] - 2023-07-05
 

--- a/llama_index/node_parser/node_utils.py
+++ b/llama_index/node_parser/node_utils.py
@@ -33,11 +33,13 @@ def get_text_splits_from_document(
         # use this to extract extra information about the chunks
         text_splits = text_splitter.split_text_with_overlaps(
             document.get_content(metadata_mode=MetadataMode.NONE),
-            metadata_str=document.get_metadata_str() if include_metadata else None,
+            metadata_str=document.get_metadata_str(mode=MetadataMode.LLM)
+            if include_metadata
+            else None,
         )
     else:
         text_chunks = text_splitter.split_text(
-            document.get_content(),
+            document.get_content(metadata_mode=MetadataMode.NONE),
         )
         text_splits = [TextSplit(text_chunk=text_chunk) for text_chunk in text_chunks]
 

--- a/llama_index/query_engine/citation_query_engine.py
+++ b/llama_index/query_engine/citation_query_engine.py
@@ -18,7 +18,7 @@ from llama_index.response_synthesizers import (
     ResponseMode,
     get_response_synthesizer,
 )
-from llama_index.schema import NodeWithScore, TextNode
+from llama_index.schema import NodeWithScore, TextNode, MetadataMode
 
 
 CITATION_QA_TEMPLATE = Prompt(
@@ -186,7 +186,7 @@ class CitationQueryEngine(BaseQueryEngine):
         new_nodes: List[NodeWithScore] = []
         for node in nodes:
             splits = self.text_splitter.split_text_with_overlaps(
-                node.node.get_content()
+                node.node.get_content(metadata_mode=MetadataMode.LLM)
             )
 
             start_offset = 0


### PR DESCRIPTION
# Description

Our text splitters should only consider LLM content/metadata when splitting text. This is because people may put a lot of extra text in the metadata that is only intended to be used for embeddings.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense
