### PR TITLE
patch node postprocessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes / Nits
 - Fix HF LLM output error (#6737)
 - Add system message support for langchain message templates (#6743)
+- Fixed applying node-postprocessors (#6749)
 
 ## [v0.7.1] - 2023-07-05
 

--- a/llama_index/query_engine/citation_query_engine.py
+++ b/llama_index/query_engine/citation_query_engine.py
@@ -266,7 +266,7 @@ class CitationQueryEngine(BaseQueryEngine):
         )
 
         retrieve_id = self.callback_manager.on_event_start(CBEventType.RETRIEVE)
-        nodes = self._retriever.retrieve(query_bundle)
+        nodes = self.retrieve(query_bundle)
         nodes = self._create_citation_nodes(nodes)
         self.callback_manager.on_event_end(
             CBEventType.RETRIEVE,
@@ -293,7 +293,7 @@ class CitationQueryEngine(BaseQueryEngine):
         )
 
         retrieve_id = self.callback_manager.on_event_start(CBEventType.RETRIEVE)
-        nodes = self._retriever.retrieve(query_bundle)
+        nodes = self.retrieve(query_bundle)
         nodes = self._create_citation_nodes(nodes)
         self.callback_manager.on_event_end(
             CBEventType.RETRIEVE,

--- a/llama_index/query_engine/retriever_query_engine.py
+++ b/llama_index/query_engine/retriever_query_engine.py
@@ -142,7 +142,7 @@ class RetrieverQueryEngine(BaseQueryEngine):
         )
 
         retrieve_id = self.callback_manager.on_event_start(CBEventType.RETRIEVE)
-        nodes = self._retriever.retrieve(query_bundle)
+        nodes = self.retrieve(query_bundle)
         self.callback_manager.on_event_end(
             CBEventType.RETRIEVE,
             payload={EventPayload.NODES: nodes},
@@ -168,7 +168,7 @@ class RetrieverQueryEngine(BaseQueryEngine):
         )
 
         retrieve_id = self.callback_manager.on_event_start(CBEventType.RETRIEVE)
-        nodes = self._retriever.retrieve(query_bundle)
+        nodes = self.retrieve(query_bundle)
         self.callback_manager.on_event_end(
             CBEventType.RETRIEVE,
             payload={EventPayload.NODES: nodes},


### PR DESCRIPTION
# Description

`_query()` was skipping the node post processors in q few query engines. 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

