### PR TITLE
fix llm metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes / Nits
 - fixed `response_mode="no_text"` response synthesizer (#6755)
+- fixed error setting `num_output` and `context_window` in service context (#6766)
 
 ## [v0.7.2] - 2023-07-06
 

--- a/llama_index/indices/service_context.py
+++ b/llama_index/indices/service_context.py
@@ -1,4 +1,3 @@
-import dataclasses
 import logging
 from dataclasses import dataclass
 from typing import Optional
@@ -39,9 +38,9 @@ def _get_default_prompt_helper(
 ) -> PromptHelper:
     """Get default prompt helper."""
     if context_window is not None:
-        llm_metadata = dataclasses.replace(llm_metadata, context_window=context_window)
+        llm_metadata.context_window = context_window
     if num_output is not None:
-        llm_metadata = dataclasses.replace(llm_metadata, num_output=num_output)
+        llm_metadata.num_output = num_output
     return PromptHelper.from_llm_metadata(llm_metadata=llm_metadata)
 
 


### PR DESCRIPTION
# Description

If you set num_output or context_window in the service context, it will error out because `llm_metadata` is a pydantic class now, not a dataclass

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested in terminal
- [x] I stared at the code and made sure it makes sense
