### PR TITLE
Fixed variable sql_query_engine in the notebook

### DIFF
--- a/docs/examples/query_engine/SQLRouterQueryEngine.ipynb
+++ b/docs/examples/query_engine/SQLRouterQueryEngine.ipynb
@@ -321,7 +321,7 @@
     }
    ],
    "source": [
-    "query_engine = NLSQLTableQueryEngine(\n",
+    "sql_query_engine = NLSQLTableQueryEngine(\n",
     "    sql_database=sql_database,\n",
     "    tables=[\"city_stats\"],\n",
     ")"


### PR DESCRIPTION
# Description

Corrected the variable name in the notebook from 'query_engine' to 'sql_query_engine' for consistency and accuracy.

Fixes # (issue)

## Type of Change

- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Ran the notebook end to end to make sure it runs without error.

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
