### PR TITLE
fix variable name clash in optimizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## Unrleased
+
+### Bug Fixes / Nits
+- Fix indexing error in `SentenceEmbeddingOptimizer` (#6850)
+
 ## [v0.7.4] - 2023-07-08
 
 ### New Features

--- a/llama_index/indices/postprocessor/optimizer.py
+++ b/llama_index/indices/postprocessor/optimizer.py
@@ -111,8 +111,8 @@ class SentenceEmbeddingOptimizer(BaseNodePostprocessor):
 
             logger.debug(f"> Top {len(top_idxs)} sentences with scores:\n")
             if logger.isEnabledFor(logging.DEBUG):
-                for i in range(len(top_idxs)):
-                    logger.debug(f"{i}. {top_sentences[i]} ({top_similarities[i]})")
+                for idx in range(len(top_idxs)):
+                    logger.debug(f"{i}. {top_sentences[idx]} ({top_similarities[idx]})")
 
             nodes[i].node.set_content(" ".join(top_sentences))
 

--- a/llama_index/indices/postprocessor/optimizer.py
+++ b/llama_index/indices/postprocessor/optimizer.py
@@ -112,7 +112,9 @@ class SentenceEmbeddingOptimizer(BaseNodePostprocessor):
             logger.debug(f"> Top {len(top_idxs)} sentences with scores:\n")
             if logger.isEnabledFor(logging.DEBUG):
                 for idx in range(len(top_idxs)):
-                    logger.debug(f"{i}. {top_sentences[idx]} ({top_similarities[idx]})")
+                    logger.debug(
+                        f"{idx}. {top_sentences[idx]} ({top_similarities[idx]})"
+                    )
 
             nodes[i].node.set_content(" ".join(top_sentences))
 

--- a/llama_index/indices/postprocessor/optimizer.py
+++ b/llama_index/indices/postprocessor/optimizer.py
@@ -67,8 +67,8 @@ class SentenceEmbeddingOptimizer(BaseNodePostprocessor):
         if query_bundle is None:
             return nodes
 
-        for i in range(len(nodes)):
-            text = nodes[i].node.get_content(metadata_mode=MetadataMode.LLM)
+        for node_idx in range(len(nodes)):
+            text = nodes[node_idx].node.get_content(metadata_mode=MetadataMode.LLM)
 
             split_text = self._tokenizer_fn(text)
 
@@ -107,7 +107,7 @@ class SentenceEmbeddingOptimizer(BaseNodePostprocessor):
             if len(top_idxs) == 0:
                 raise ValueError("Optimizer returned zero sentences.")
 
-            top_sentences = [split_text[i] for i in top_idxs]
+            top_sentences = [split_text[idx] for idx in top_idxs]
 
             logger.debug(f"> Top {len(top_idxs)} sentences with scores:\n")
             if logger.isEnabledFor(logging.DEBUG):
@@ -116,6 +116,6 @@ class SentenceEmbeddingOptimizer(BaseNodePostprocessor):
                         f"{idx}. {top_sentences[idx]} ({top_similarities[idx]})"
                     )
 
-            nodes[i].node.set_content(" ".join(top_sentences))
+            nodes[node_idx].node.set_content(" ".join(top_sentences))
 
         return nodes


### PR DESCRIPTION
# Description

Duplicate for loops use the same iterator variable, which can cause indexing issues.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

