### PR TITLE
fix variable name clash for legacy vector indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Added sources to agent/chat engine responses (#6854)
 - Added basic chat buffer memory to agents / chat engines (#6857)
 
+### Bug Fixes / Nits
+- Fixed support for legacy vector store metadata (#6867)
+
 ## [v0.7.5] - 2023-07-11
 
 ### New Features

--- a/llama_index/vector_stores/utils.py
+++ b/llama_index/vector_stores/utils.py
@@ -95,13 +95,13 @@ def legacy_metadata_dict_to_node(
     metadata.pop("ref_doc_id", None)
 
     # remaining metadata is metadata or node_info
-    metadata = {}
+    new_metadata = {}
     for key, val in metadata.items():
         # NOTE: right now we enforce metadata to be dict of simple types.
         #       dump anything that's not a simple type into node_info.
         if isinstance(val, (str, int, float, type(None))):
-            metadata[key] = val
+            new_metadata[key] = val
         else:
             node_info[key] = val
 
-    return metadata, node_info, relationships
+    return new_metadata, node_info, relationships


### PR DESCRIPTION
# Description

Loading data from legacy vector stores was causing some issues due to variable names overlapping

Fixes https://github.com/jerryjliu/llama_index/issues/6864

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense
- [x] Tested in terminal
