### PR TITLE
take into account overlap size when determining if single token in a …

### DIFF
--- a/llama_index/langchain_helpers/text_splitter.py
+++ b/llama_index/langchain_helpers/text_splitter.py
@@ -406,7 +406,10 @@ class SentenceSplitter(TextSplitter):
                 else:
                     splits2 = [split]
                 for split2 in splits2:
-                    if len(self.tokenizer(split2)) <= effective_chunk_size:
+                    if (
+                        len(self.tokenizer(split2))
+                        <= effective_chunk_size - self._chunk_overlap
+                    ):
                         new_splits.append(Split(split2, False))
                     else:
                         splits3 = split2.split(self._separator)

--- a/llama_index/langchain_helpers/text_splitter.py
+++ b/llama_index/langchain_helpers/text_splitter.py
@@ -419,7 +419,7 @@ class SentenceSplitter(TextSplitter):
         while len(new_splits) > 0:
             cur_token = new_splits[0]
             cur_len = len(self.tokenizer(cur_token.text))
-            if cur_len > effective_chunk_size:
+            if cur_len > effective_chunk_size - self._chunk_overlap:
                 raise ValueError("Single token exceed chunk size")
             if cur_tokens + cur_len > effective_chunk_size:
                 docs.append(TextSplit("".join(cur_doc_list).strip()))

--- a/llama_index/langchain_helpers/text_splitter.py
+++ b/llama_index/langchain_helpers/text_splitter.py
@@ -424,11 +424,18 @@ class SentenceSplitter(TextSplitter):
             cur_len = len(self.tokenizer(cur_token.text))
             if cur_len > effective_chunk_size - self._chunk_overlap:
                 raise ValueError("Single token exceed chunk size")
+
+            # If we add any more tokens to the current doc list, we'll exceed
+            # the effective size.
+            # Combine what we've accumulated so far and reset the current doc list
             if cur_tokens + cur_len > effective_chunk_size:
                 docs.append(TextSplit("".join(cur_doc_list).strip()))
                 cur_doc_list = []
                 cur_tokens = 0
             else:
+                # If this is a sentence, add it to the current doc list
+                # If adding these tokens wouldn't put us over the usable
+                # effective chunk size, add it as well
                 if (
                     cur_token.is_sentence
                     or cur_tokens + cur_len < effective_chunk_size - self._chunk_overlap

--- a/tests/langchain_helpers/test_text_splitter.py
+++ b/tests/langchain_helpers/test_text_splitter.py
@@ -88,11 +88,12 @@ def test_split_diff_sentence_token2() -> None:
     assert sentence_split[1] == " ".join(["bar"] * 15)
 
 
-def test_sentence_splitter_infinite_loop() -> None:
+def test_sentence_splitter_raises_error_when_token_size_in_overlap() -> None:
     sentence_splitter = SentenceSplitter(
         chunk_size=20,
         chunk_overlap=5,
         secondary_chunking_regex="[^\,]+[,]",
+        separator="***",
     )
     # This is ok
     sentence_splitter.split_text_with_overlaps("This is fine. No problems.")
@@ -108,3 +109,20 @@ def test_sentence_splitter_infinite_loop() -> None:
         sentence_splitter.split_text_with_overlaps(
             "This is a sentence hand-crafted to be very very bad for the sentence splitter, since the secondary_chunking_regex won't get the resulting splits small enough"  # noqa: E501
         )
+
+
+def test_sentence_splitter_raises_error_when_token_size_in_overlap_with_sep() -> None:
+    sentence_splitter = SentenceSplitter(
+        chunk_size=20,
+        chunk_overlap=5,
+        secondary_chunking_regex="[^\,]+[,]",
+        separator=" ",
+    )
+    # This is ok
+    sentence_splitter.split_text_with_overlaps("This is fine. No problems.")
+
+    # This has the same failure scenario as the previous test
+    # but should be okay because it can split by the separator
+    sentence_splitter.split_text_with_overlaps(
+        "This is a sentence hand-crafted to be very very bad for the sentence splitter, since the secondary_chunking_regex won't get the resulting splits small enough"  # noqa: E501
+    )


### PR DESCRIPTION
…sentence is still too large

# Description

Fixes #6834 but I'd like confirmation that this is correct.

When `SentenceSplitter.split_text_with_overlaps` encounters a sentence that is longer than the `chunk_size`, it will try splitting it by the `secondary_chunking_regex` option. It will then check those pieces to see if they are too long and, if necessary, do another fallback to `separator`.

The issue in #6834 is when the pieces from `secondary_chunking_regex` are less than the `chunk_size` (good) but larger than `chunk_size - overlap`. That infinite loops.

Additionally, there's a weird case where the `separator` might not actually save us, so I added a check there as well.

**question**: Is it correct to be checking `effective_chunk_size - self._chunk_overlap` instead of `effective_chunk_size` in these places?

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
