### PR TITLE
improve legacy fallback for existing vector dbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### New Features
 - specify `embed_model="local"` to use default local embbeddings in the service context (#6806)
 
+### Bug Fixes / Nits
+- improve pinecone support for searching existing vector dbs (#6912)
+
 ## [v0.7.8] - 2023-07-13
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - specify `embed_model="local"` to use default local embbeddings in the service context (#6806)
 
 ### Bug Fixes / Nits
-- improve pinecone support for searching existing vector dbs (#6912)
+- fix null metadata for searching existing vector dbs (#6912)
 
 ## [v0.7.8] - 2023-07-13
 

--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -296,7 +296,7 @@ class PineconeVectorStore(VectorStore):
                     "Failed to parse Node metadata, fallback to legacy logic."
                 )
                 metadata, node_info, relationships = legacy_metadata_dict_to_node(
-                    match.metadata, text_key=self._text_key
+                    match.metadata or {}, text_key=self._text_key
                 )
 
                 text = match.metadata[self._text_key]

--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -296,7 +296,7 @@ class PineconeVectorStore(VectorStore):
                     "Failed to parse Node metadata, fallback to legacy logic."
                 )
                 metadata, node_info, relationships = legacy_metadata_dict_to_node(
-                    match.metadata or {}, text_key=self._text_key
+                    match.metadata, text_key=self._text_key
                 )
 
                 text = match.metadata[self._text_key]

--- a/llama_index/vector_stores/utils.py
+++ b/llama_index/vector_stores/utils.py
@@ -69,7 +69,10 @@ def legacy_metadata_dict_to_node(
 ) -> Tuple[dict, dict, dict]:
     """Common logic for loading Node data from metadata dict."""
     # make a copy first
-    metadata = metadata.copy()
+    if metadata is None:
+        metadata = {}
+    else:
+        metadata = metadata.copy()
 
     # load node_info from json string
     node_info_str = metadata.pop("node_info", "")


### PR DESCRIPTION
# Description

Existing pinecone vector dbs may not have metadata, so we should fallback to an empty dict

Fixes https://github.com/jerryjliu/llama_index/issues/6910

Fixes https://github.com/jerryjliu/llama_index/issues/6898

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

