### PR TITLE
Adding support for encoding argument on SimpleDirectoryReader

### DIFF
--- a/docs/examples/data_connectors/simple_directory_reader.ipynb
+++ b/docs/examples/data_connectors/simple_directory_reader.ipynb
@@ -176,6 +176,8 @@
     "            (Optional; overrides input_dir, exclude)\n",
     "        exclude (List): glob of python file paths to exclude (Optional)\n",
     "        exclude_hidden (bool): Whether to exclude hidden files (dotfiles).\n",
+    "        encoding (str): Encoding of the files.\n",
+    "            Default is utf-8.\n",
     "        errors (str): how encoding and decoding errors are to be handled,\n",
     "                see https://docs.python.org/3/library/functions.html#open\n",
     "        recursive (bool): Whether to recursively search in subdirectories.\n",

--- a/llama_index/readers/file/base.py
+++ b/llama_index/readers/file/base.py
@@ -47,6 +47,8 @@ class SimpleDirectoryReader(BaseReader):
             (Optional; overrides input_dir, exclude)
         exclude (List): glob of python file paths to exclude (Optional)
         exclude_hidden (bool): Whether to exclude hidden files (dotfiles).
+        encoding (str): Encoding of the files.
+            Default is utf-8.
         errors (str): how encoding and decoding errors are to be handled,
               see https://docs.python.org/3/library/functions.html#open
         recursive (bool): Whether to recursively search in subdirectories.
@@ -73,6 +75,7 @@ class SimpleDirectoryReader(BaseReader):
         exclude_hidden: bool = True,
         errors: str = "ignore",
         recursive: bool = False,
+        encoding: str = "utf-8",
         filename_as_id: bool = False,
         required_exts: Optional[List[str]] = None,
         file_extractor: Optional[Dict[str, BaseReader]] = None,
@@ -86,6 +89,7 @@ class SimpleDirectoryReader(BaseReader):
             raise ValueError("Must provide either `input_dir` or `input_files`.")
 
         self.errors = errors
+        self.encoding = encoding
 
         self.exclude = exclude
         self.recursive = recursive
@@ -206,7 +210,9 @@ class SimpleDirectoryReader(BaseReader):
                 documents.extend(docs)
             else:
                 # do standard read
-                with open(input_file, "r", errors=self.errors, encoding="utf8") as f:
+                with open(
+                    input_file, "r", errors=self.errors, encoding=self.encoding
+                ) as f:
                     data = f.read()
 
                 doc = Document(text=data, metadata=metadata or {})

--- a/tests/readers/test_file.py
+++ b/tests/readers/test_file.py
@@ -318,7 +318,7 @@ def test_specifying_encoding() -> None:
             f.write("test2â")
         with open(f"{tmp_dir}/test3.txt", "w", encoding="latin-1") as f:
             f.write("test3ã")
-        with open(f"{tmp_dir}/test5.json", "w", encoding="latin-1") as f:
+        with open(f"{tmp_dir}/test4.json", "w", encoding="latin-1") as f:
             f.write('{"test_1á": {"test_2ã": ["â"]}}')
 
         reader = SimpleDirectoryReader(
@@ -331,7 +331,7 @@ def test_specifying_encoding() -> None:
             f"{tmp_dir}/test1.txt",
             f"{tmp_dir}/test2.txt",
             f"{tmp_dir}/test3.txt",
-            f"{tmp_dir}/test5.json",
+            f"{tmp_dir}/test4.json",
         ]
 
         # check paths. Split handles path_part_X doc_ids from md and json files

--- a/tests/readers/test_file.py
+++ b/tests/readers/test_file.py
@@ -2,6 +2,7 @@
 
 from tempfile import TemporaryDirectory
 from typing import Any, Dict
+
 import pytest
 
 from llama_index.readers.file.base import SimpleDirectoryReader
@@ -299,6 +300,37 @@ def test_filename_as_doc_id() -> None:
             f"{tmp_dir}/test2.txt",
             f"{tmp_dir}/test3.txt",
             f"{tmp_dir}/test4.md",
+            f"{tmp_dir}/test5.json",
+        ]
+
+        # check paths. Split handles path_part_X doc_ids from md and json files
+        for doc in documents:
+            assert str(doc.node_id).split("_part")[0] in doc_paths
+
+
+def test_specifying_encoding() -> None:
+    """Test if file metadata is added to Document."""
+    # test file_metadata
+    with TemporaryDirectory() as tmp_dir:
+        with open(f"{tmp_dir}/test1.txt", "w", encoding="latin-1") as f:
+            f.write("test1á")
+        with open(f"{tmp_dir}/test2.txt", "w", encoding="latin-1") as f:
+            f.write("test2â")
+        with open(f"{tmp_dir}/test3.txt", "w", encoding="latin-1") as f:
+            f.write("test3ã")
+        with open(f"{tmp_dir}/test5.json", "w", encoding="latin-1") as f:
+            f.write('{"test_1á": {"test_2ã": ["â"]}}')
+
+        reader = SimpleDirectoryReader(
+            tmp_dir, filename_as_id=True, errors="strict", encoding="latin-1"
+        )
+
+        documents = reader.load_data()
+
+        doc_paths = [
+            f"{tmp_dir}/test1.txt",
+            f"{tmp_dir}/test2.txt",
+            f"{tmp_dir}/test3.txt",
             f"{tmp_dir}/test5.json",
         ]
 


### PR DESCRIPTION
# Description

This allows users to pass on the encoding they want to use to open the files in a given directory.
Having this would remove the need to convert files into a specific encoding to get them to work and also avoid potentially unnoticed data loss by loading documents with the wrong encoding.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Added new unit/integration tests

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
