### PR TITLE
updates for 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features
 - specify `embed_model="local"` to use default local embbeddings in the service context (#6806)
 - Add async `acall` endpoint to `BasePydanticProgram` (defaults to sync version). Implement for `OpenAIPydanticProgram`
+- Add support for chroma v0.4.0 (#6937)
 
 ### Bug Fixes / Nits
 - fix null metadata for searching existing vector dbs (#6912)

--- a/docs/community/integrations/vector_stores.md
+++ b/docs/community/integrations/vector_stores.md
@@ -207,8 +207,8 @@ import chromadb
 from llama_index.vector_stores import ChromaVectorStore
 
 # Creating a Chroma client
-# By default, Chroma will operate purely in-memory.
-chroma_client = chromadb.Client()
+# EphemeralClient operates purely in-memory, PersistentClient will also save to disk
+chroma_client = chromadb.EphemeralClient()
 chroma_collection = chroma_client.create_collection("quickstart")
 
 # construct vector store

--- a/docs/examples/vector_stores/ChromaIndexDemo.ipynb
+++ b/docs/examples/vector_stores/ChromaIndexDemo.ipynb
@@ -70,20 +70,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "b3df0b97",
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install llama-index\n",
-    "!pip install chromadb\n",
-    "!pip install sentence-transformers\n",
-    "!pip install pydantic==1.10.11"
+    "# !pip install llama-index chromadb --quiet\n",
+    "# !pip install chromadb\n",
+    "# !pip install sentence-transformers\n",
+    "# !pip install pydantic==1.10.11"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
    "id": "d48af8e1",
    "metadata": {},
    "outputs": [],
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 3,
    "id": "374a148b",
    "metadata": {},
    "outputs": [],
@@ -117,10 +117,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 4,
    "id": "667f3cb3-ce18-48d5-b9aa-bfc1a1f0f0f6",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/jeff/.pyenv/versions/3.10.10/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    },
     {
      "data": {
       "text/markdown": [
@@ -137,7 +145,7 @@
    ],
    "source": [
     "# create client and a new collection\n",
-    "chroma_client = chromadb.Client()\n",
+    "chroma_client = chromadb.EphemeralClient()\n",
     "chroma_collection = chroma_client.create_collection(\"quickstart\")\n",
     "\n",
     "# define embedding function\n",
@@ -174,14 +182,12 @@
     "\n",
     "Extending the previous example, if you want to save to disk, simply initialize the Chroma client and pass the directory where you want the data to be saved to. \n",
     "\n",
-    "`Caution`: Chroma makes a best-effort to automatically save data to disk, however multiple in-memory clients can stomp each other's work. As a best practice, only have one client per path running at any given time.\n",
-    "\n",
-    "`Protip`: Sometimes you can call `db.persist()` to force a save. "
+    "`Caution`: Chroma makes a best-effort to automatically save data to disk, however multiple in-memory clients can stomp each other's work. As a best practice, only have one client per path running at any given time."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 5,
    "id": "9c3a56a5",
    "metadata": {},
    "outputs": [
@@ -189,7 +195,7 @@
      "data": {
       "text/markdown": [
        "<b>\n",
-       "Growing up, the author wrote short stories, programmed on an IBM 1401, and wrote programs on a TRS-80 microcomputer. He also took painting classes at Harvard and worked as a de facto studio assistant for a painter. He also tried to start a company to put art galleries online, and wrote software to build online stores.</b>"
+       "The author grew up taking painting classes at Harvard and freelancing as a Lisp hacker. He also wrote a book on Lisp and moved to New York to be closer to his teacher, Idelle Weber.</b>"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -201,11 +207,8 @@
    ],
    "source": [
     "# save to disk\n",
-    "from chromadb.config import Settings\n",
     "\n",
-    "db = chromadb.Client(\n",
-    "    Settings(chroma_db_impl=\"duckdb+parquet\", persist_directory=\"./chroma_db\")\n",
-    ")\n",
+    "db = chromadb.PersistentClient(path=\"./chroma_db\")\n",
     "chroma_collection = db.get_or_create_collection(\"quickstart\")\n",
     "vector_store = ChromaVectorStore(chroma_collection=chroma_collection)\n",
     "storage_context = StorageContext.from_defaults(vector_store=vector_store)\n",
@@ -213,12 +216,9 @@
     "index = VectorStoreIndex.from_documents(\n",
     "    documents, storage_context=storage_context, service_context=service_context\n",
     ")\n",
-    "db.persist()\n",
     "\n",
     "# load from disk\n",
-    "db2 = chromadb.Client(\n",
-    "    Settings(chroma_db_impl=\"duckdb+parquet\", persist_directory=\"./chroma_db\")\n",
-    ")\n",
+    "db2 = chromadb.PersistentClient(path=\"./chroma_db\")\n",
     "chroma_collection = db2.get_or_create_collection(\"quickstart\")\n",
     "vector_store = ChromaVectorStore(chroma_collection=chroma_collection)\n",
     "storage_context = StorageContext.from_defaults(vector_store=vector_store)\n",
@@ -253,39 +253,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 6,
    "id": "d6c9bd64",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:chromadb.telemetry.posthog:Anonymized telemetry enabled. See https://docs.trychroma.com/telemetry for more information.\n",
-      "Anonymized telemetry enabled. See https://docs.trychroma.com/telemetry for more information.\n",
-      "Anonymized telemetry enabled. See https://docs.trychroma.com/telemetry for more information.\n",
-      "INFO:llama_index.token_counter.token_counter:> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
-      "> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
-      "> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
-      "INFO:llama_index.token_counter.token_counter:> [build_index_from_nodes] Total embedding token usage: 17038 tokens\n",
-      "> [build_index_from_nodes] Total embedding token usage: 17038 tokens\n",
-      "> [build_index_from_nodes] Total embedding token usage: 17038 tokens\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# create the chroma client and add our data\n",
     "import chromadb\n",
-    "from chromadb.config import Settings\n",
     "\n",
-    "remote_db = chromadb.Client(\n",
-    "    Settings(\n",
-    "        chroma_api_impl=\"rest\",\n",
-    "        chroma_server_host=\"localhost\",\n",
-    "        chroma_server_http_port=\"8000\",\n",
-    "    )\n",
-    ")\n",
-    "remote_db.reset()  # resets the database\n",
+    "remote_db = chromadb.HttpClient()\n",
     "chroma_collection = remote_db.get_or_create_collection(\"quickstart\")\n",
     "vector_store = ChromaVectorStore(chroma_collection=chroma_collection)\n",
     "storage_context = StorageContext.from_defaults(vector_store=vector_store)\n",
@@ -297,33 +273,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 7,
    "id": "88e10c26",
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:llama_index.token_counter.token_counter:> [retrieve] Total LLM token usage: 0 tokens\n",
-      "> [retrieve] Total LLM token usage: 0 tokens\n",
-      "> [retrieve] Total LLM token usage: 0 tokens\n",
-      "INFO:llama_index.token_counter.token_counter:> [retrieve] Total embedding token usage: 8 tokens\n",
-      "> [retrieve] Total embedding token usage: 8 tokens\n",
-      "> [retrieve] Total embedding token usage: 8 tokens\n",
-      "INFO:llama_index.token_counter.token_counter:> [get_response] Total LLM token usage: 1874 tokens\n",
-      "> [get_response] Total LLM token usage: 1874 tokens\n",
-      "> [get_response] Total LLM token usage: 1874 tokens\n",
-      "INFO:llama_index.token_counter.token_counter:> [get_response] Total embedding token usage: 0 tokens\n",
-      "> [get_response] Total embedding token usage: 0 tokens\n",
-      "> [get_response] Total embedding token usage: 0 tokens\n"
-     ]
-    },
-    {
      "data": {
       "text/markdown": [
        "<b>\n",
-       "The author grew up writing essays, learning Italian, exploring Florence, painting people, working with computers, studying at RISD, living in a rent-controlled apartment, building an online store builder, editing code, publishing essays online, writing essays, working on spam filters, cooking for groups, buying a building, and attending parties.</b>"
+       "Growing up, the author wrote short stories, programmed on an IBM 1401, and wrote programs on a TRS-80 microcomputer. He also took painting classes at Harvard and worked as a de facto studio assistant for a painter. He also tried to start a company to put art galleries online, and wrote software to build online stores.</b>"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -357,7 +315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 8,
    "id": "d9411826",
    "metadata": {},
    "outputs": [
@@ -365,7 +323,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'node_info': '{\"start\": 0, \"end\": 4040, \"_node_type\": \"1\"}', 'relationships': '{\"1\": \"a0294b91-ff5f-45fe-b249-5596a18cc952\", \"3\": \"95771df1-9ec9-4128-9a11-ac92b768e2e3\"}', 'document_id': 'a0294b91-ff5f-45fe-b249-5596a18cc952', 'doc_id': 'a0294b91-ff5f-45fe-b249-5596a18cc952', 'ref_doc_id': 'a0294b91-ff5f-45fe-b249-5596a18cc952', 'author': 'Paul Graham'}\n",
+      "{'_node_content': '{\"id_\": \"be08c8bc-f43e-4a71-ba64-e525921a8319\", \"embedding\": null, \"metadata\": {}, \"excluded_embed_metadata_keys\": [], \"excluded_llm_metadata_keys\": [], \"relationships\": {\"1\": {\"node_id\": \"2cbecdbb-0840-48b2-8151-00119da0995b\", \"node_type\": null, \"metadata\": {}, \"hash\": \"4c702b4df575421e1d1af4b1fd50511b226e0c9863dbfffeccb8b689b8448f35\"}, \"3\": {\"node_id\": \"6a75604a-fa76-4193-8f52-c72a7b18b154\", \"node_type\": null, \"metadata\": {}, \"hash\": \"d6c408ee1fbca650fb669214e6f32ffe363b658201d31c204e85a72edb71772f\"}}, \"hash\": \"b4d0b960aa09e693f9dc0d50ef46a3d0bf5a8fb3ac9f3e4bcf438e326d17e0d8\", \"text\": \"\", \"start_char_idx\": 0, \"end_char_idx\": 4050, \"text_template\": \"{metadata_str}\\\\n\\\\n{content}\", \"metadata_template\": \"{key}: {value}\", \"metadata_seperator\": \"\\\\n\"}', 'author': 'Paul Graham', 'doc_id': '2cbecdbb-0840-48b2-8151-00119da0995b', 'document_id': '2cbecdbb-0840-48b2-8151-00119da0995b', 'ref_doc_id': '2cbecdbb-0840-48b2-8151-00119da0995b'}\n",
       "count before 20\n",
       "count after 19\n"
      ]
@@ -406,7 +364,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.10.10"
   },
   "vscode": {
    "interpreter": {

--- a/docs/examples/vector_stores/chroma_auto_retriever.ipynb
+++ b/docs/examples/vector_stores/chroma_auto_retriever.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "d48af8e1",
    "metadata": {},
    "outputs": [],
@@ -30,6 +30,34 @@
     "\n",
     "logging.basicConfig(stream=sys.stdout, level=logging.INFO)\n",
     "logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "bf49ac18",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:numexpr.utils:Note: NumExpr detected 12 cores but \"NUMEXPR_MAX_THREADS\" not set, so enforcing safe limit of 8.\n",
+      "Note: NumExpr detected 12 cores but \"NUMEXPR_MAX_THREADS\" not set, so enforcing safe limit of 8.\n",
+      "INFO:numexpr.utils:NumExpr defaulting to 8 threads.\n",
+      "NumExpr defaulting to 8 threads.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# set up OpenAI\n",
+    "import os\n",
+    "import getpass\n",
+    "\n",
+    "os.environ[\"OPENAI_API_KEY\"] = getpass.getpass(\"OpenAI API Key:\")\n",
+    "import openai\n",
+    "\n",
+    "openai.api_key = os.environ[\"OPENAI_API_KEY\"]"
    ]
   },
   {
@@ -53,57 +81,12 @@
      "output_type": "stream",
      "text": [
       "INFO:chromadb.telemetry.posthog:Anonymized telemetry enabled. See https://docs.trychroma.com/telemetry for more information.\n",
-      "Anonymized telemetry enabled. See https://docs.trychroma.com/telemetry for more information.\n",
-      "Anonymized telemetry enabled. See https://docs.trychroma.com/telemetry for more information.\n",
-      "INFO:chromadb:Running Chroma using direct local API.\n",
-      "Running Chroma using direct local API.\n",
-      "Running Chroma using direct local API.\n",
-      "INFO:numexpr.utils:Note: NumExpr detected 12 cores but \"NUMEXPR_MAX_THREADS\" not set, so enforcing safe limit of 8.\n",
-      "Note: NumExpr detected 12 cores but \"NUMEXPR_MAX_THREADS\" not set, so enforcing safe limit of 8.\n",
-      "Note: NumExpr detected 12 cores but \"NUMEXPR_MAX_THREADS\" not set, so enforcing safe limit of 8.\n",
-      "INFO:numexpr.utils:NumExpr defaulting to 8 threads.\n",
-      "NumExpr defaulting to 8 threads.\n",
-      "NumExpr defaulting to 8 threads.\n",
-      "WARNING:chromadb:Using embedded DuckDB without persistence: data will be transient\n",
-      "Using embedded DuckDB without persistence: data will be transient\n",
-      "Using embedded DuckDB without persistence: data will be transient\n",
-      "INFO:clickhouse_connect.driver.ctypes:Successfully imported ClickHouse Connect C data optimizations\n",
-      "Successfully imported ClickHouse Connect C data optimizations\n",
-      "Successfully imported ClickHouse Connect C data optimizations\n",
-      "INFO:clickhouse_connect.driver.ctypes:Successfully import ClickHouse Connect C/Numpy optimizations\n",
-      "Successfully import ClickHouse Connect C/Numpy optimizations\n",
-      "Successfully import ClickHouse Connect C/Numpy optimizations\n",
-      "INFO:clickhouse_connect.json_impl:Using python library for writing JSON byte strings\n",
-      "Using python library for writing JSON byte strings\n",
-      "Using python library for writing JSON byte strings\n",
-      "WARNING:chromadb.api.models.Collection:No embedding_function provided, using default embedding function: SentenceTransformerEmbeddingFunction\n",
-      "No embedding_function provided, using default embedding function: SentenceTransformerEmbeddingFunction\n",
-      "No embedding_function provided, using default embedding function: SentenceTransformerEmbeddingFunction\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/suo/miniconda3/envs/llama/lib/python3.9/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:sentence_transformers.SentenceTransformer:Load pretrained SentenceTransformer: all-MiniLM-L6-v2\n",
-      "Load pretrained SentenceTransformer: all-MiniLM-L6-v2\n",
-      "Load pretrained SentenceTransformer: all-MiniLM-L6-v2\n",
-      "INFO:sentence_transformers.SentenceTransformer:Use pytorch device: cpu\n",
-      "Use pytorch device: cpu\n",
-      "Use pytorch device: cpu\n"
+      "Anonymized telemetry enabled. See https://docs.trychroma.com/telemetry for more information.\n"
      ]
     }
    ],
    "source": [
-    "chroma_client = chromadb.Client()\n",
+    "chroma_client = chromadb.EphemeralClient()\n",
     "chroma_collection = chroma_client.create_collection(\"quickstart\")"
    ]
   },
@@ -168,7 +151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "ba1558b3",
    "metadata": {
     "tags": []
@@ -181,30 +164,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "id": "35369eda",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:llama_index.token_counter.token_counter:> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
-      "> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
-      "> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
-      "INFO:llama_index.token_counter.token_counter:> [build_index_from_nodes] Total embedding token usage: 211 tokens\n",
-      "> [build_index_from_nodes] Total embedding token usage: 211 tokens\n",
-      "> [build_index_from_nodes] Total embedding token usage: 211 tokens\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "index = VectorStoreIndex(nodes, storage_context=storage_context)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "id": "bedbb693-725f-478f-be26-fa7180ea38b2",
    "metadata": {},
    "outputs": [],
@@ -233,7 +203,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "id": "eeb18e9c",
    "metadata": {},
    "outputs": [
@@ -241,31 +211,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:llama_index.indices.vector_store.auto_retriever.auto_retriever:Using query str: celebrities\n",
+      "INFO:llama_index.indices.vector_store.retrievers.auto_retriever.auto_retriever:Using query str: celebrities\n",
       "Using query str: celebrities\n",
-      "Using query str: celebrities\n",
-      "INFO:llama_index.indices.vector_store.auto_retriever.auto_retriever:Using filters: {'country': 'United States'}\n",
+      "INFO:llama_index.indices.vector_store.retrievers.auto_retriever.auto_retriever:Using filters: {'country': 'United States'}\n",
       "Using filters: {'country': 'United States'}\n",
-      "Using filters: {'country': 'United States'}\n",
-      "INFO:llama_index.indices.vector_store.auto_retriever.auto_retriever:Using top_k: 2\n",
-      "Using top_k: 2\n",
-      "Using top_k: 2\n",
-      "INFO:llama_index.token_counter.token_counter:> [retrieve] Total LLM token usage: 0 tokens\n",
-      "> [retrieve] Total LLM token usage: 0 tokens\n",
-      "> [retrieve] Total LLM token usage: 0 tokens\n",
-      "INFO:llama_index.token_counter.token_counter:> [retrieve] Total embedding token usage: 3 tokens\n",
-      "> [retrieve] Total embedding token usage: 3 tokens\n",
-      "> [retrieve] Total embedding token usage: 3 tokens\n"
+      "INFO:llama_index.indices.vector_store.retrievers.auto_retriever.auto_retriever:Using top_k: 2\n",
+      "Using top_k: 2\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "[NodeWithScore(node=Node(text='Angelina Jolie is an American actress, filmmaker, and humanitarian. She has received numerous awards for her acting and is known for her philanthropic work.', doc_id='7389c8ad-2feb-4cf3-a8da-6c0f08c0f222', embedding=None, doc_hash='1171ef7bb1b89283a1012fecb0ea7a831a0e38c2ed6fac9fbfdd62ad64063934', extra_info={'category': 'Entertainment', 'country': 'United States'}, node_info={}, relationships={}), score=0.3262841090927262),\n",
-       " NodeWithScore(node=Node(text='Michael Jordan is a retired professional basketball player, widely regarded as one of the greatest basketball players of all time.', doc_id='da13fc89-72cb-401e-8445-9b9680372fbf', embedding=None, doc_hash='44c17458239bdba3c72f8ed6ac12e096b4c7965f6b5154d74b7a10484dad16a4', extra_info={'category': 'Sports', 'country': 'United States'}, node_info={}, relationships={}), score=0.3734403491142674)]"
+       "[NodeWithScore(node=TextNode(id_='b2ab3b1a-5731-41ec-b884-405016de5a34', embedding=None, metadata={'category': 'Entertainment', 'country': 'United States'}, excluded_embed_metadata_keys=[], excluded_llm_metadata_keys=[], relationships={}, hash='28e1d0d600908a5e9f0c388f0d49b0cd58920dc13e4f2743becd135ac0f18799', text='Angelina Jolie is an American actress, filmmaker, and humanitarian. She has received numerous awards for her acting and is known for her philanthropic work.', start_char_idx=None, end_char_idx=None, text_template='{metadata_str}\\n\\n{content}', metadata_template='{key}: {value}', metadata_seperator='\\n'), score=0.32621567877748514),\n",
+       " NodeWithScore(node=TextNode(id_='e0104b6a-676a-4c83-95b7-b018cb8b39b2', embedding=None, metadata={'category': 'Sports', 'country': 'United States'}, excluded_embed_metadata_keys=[], excluded_llm_metadata_keys=[], relationships={}, hash='7456e8d70b089c3830424e49b2a03c8d6d3f5cd0de42b0669a8ee518eca01012', text='Michael Jordan is a retired professional basketball player, widely regarded as one of the greatest basketball players of all time.', start_char_idx=None, end_char_idx=None, text_template='{metadata_str}\\n\\n{content}', metadata_template='{key}: {value}', metadata_seperator='\\n'), score=0.3734030955060519)]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -276,53 +237,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "51f00cde",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:llama_index.indices.vector_store.auto_retriever.auto_retriever:Using query str: Sports celebrities\n",
-      "Using query str: Sports celebrities\n",
-      "Using query str: Sports celebrities\n",
-      "INFO:llama_index.indices.vector_store.auto_retriever.auto_retriever:Using filters: {'category': 'Sports', 'country': 'United States'}\n",
-      "Using filters: {'category': 'Sports', 'country': 'United States'}\n",
-      "Using filters: {'category': 'Sports', 'country': 'United States'}\n",
-      "INFO:llama_index.indices.vector_store.auto_retriever.auto_retriever:Using top_k: 2\n",
-      "Using top_k: 2\n",
-      "Using top_k: 2\n",
-      "INFO:llama_index.token_counter.token_counter:> [retrieve] Total LLM token usage: 0 tokens\n",
-      "> [retrieve] Total LLM token usage: 0 tokens\n",
-      "> [retrieve] Total LLM token usage: 0 tokens\n",
-      "INFO:llama_index.token_counter.token_counter:> [retrieve] Total embedding token usage: 2 tokens\n",
-      "> [retrieve] Total embedding token usage: 2 tokens\n",
-      "> [retrieve] Total embedding token usage: 2 tokens\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[NodeWithScore(node=Node(text='Michael Jordan is a retired professional basketball player, widely regarded as one of the greatest basketball players of all time.', doc_id='da13fc89-72cb-401e-8445-9b9680372fbf', embedding=None, doc_hash='44c17458239bdba3c72f8ed6ac12e096b4c7965f6b5154d74b7a10484dad16a4', extra_info={'category': 'Sports', 'country': 'United States'}, node_info={}, relationships={}), score=0.3328886457329614)]"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "retriever.retrieve(\"Tell me about Sports celebrities from United States\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b8387a0e",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -341,7 +262,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.10.10"
   },
   "vscode": {
    "interpreter": {

--- a/docs/examples/vector_stores/chroma_metadata_filter.ipynb
+++ b/docs/examples/vector_stores/chroma_metadata_filter.ipynb
@@ -35,6 +35,34 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "898a8d42",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:numexpr.utils:Note: NumExpr detected 12 cores but \"NUMEXPR_MAX_THREADS\" not set, so enforcing safe limit of 8.\n",
+      "Note: NumExpr detected 12 cores but \"NUMEXPR_MAX_THREADS\" not set, so enforcing safe limit of 8.\n",
+      "INFO:numexpr.utils:NumExpr defaulting to 8 threads.\n",
+      "NumExpr defaulting to 8 threads.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# set up OpenAI\n",
+    "import os\n",
+    "import getpass\n",
+    "\n",
+    "os.environ[\"OPENAI_API_KEY\"] = getpass.getpass(\"OpenAI API Key:\")\n",
+    "import openai\n",
+    "\n",
+    "openai.api_key = os.environ[\"OPENAI_API_KEY\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
    "id": "0ce3143d-198c-4dd2-8e5a-c5cdf94f017a",
    "metadata": {},
    "outputs": [],
@@ -44,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "667f3cb3-ce18-48d5-b9aa-bfc1a1f0f0f6",
    "metadata": {},
    "outputs": [
@@ -53,52 +81,18 @@
      "output_type": "stream",
      "text": [
       "INFO:chromadb.telemetry.posthog:Anonymized telemetry enabled. See https://docs.trychroma.com/telemetry for more information.\n",
-      "Anonymized telemetry enabled. See https://docs.trychroma.com/telemetry for more information.\n",
-      "INFO:chromadb:Running Chroma using direct local API.\n",
-      "Running Chroma using direct local API.\n",
-      "INFO:numexpr.utils:Note: NumExpr detected 12 cores but \"NUMEXPR_MAX_THREADS\" not set, so enforcing safe limit of 8.\n",
-      "Note: NumExpr detected 12 cores but \"NUMEXPR_MAX_THREADS\" not set, so enforcing safe limit of 8.\n",
-      "INFO:numexpr.utils:NumExpr defaulting to 8 threads.\n",
-      "NumExpr defaulting to 8 threads.\n",
-      "WARNING:chromadb:Using embedded DuckDB without persistence: data will be transient\n",
-      "Using embedded DuckDB without persistence: data will be transient\n",
-      "INFO:clickhouse_connect.driver.ctypes:Successfully imported ClickHouse Connect C data optimizations\n",
-      "Successfully imported ClickHouse Connect C data optimizations\n",
-      "INFO:clickhouse_connect.driver.ctypes:Successfully import ClickHouse Connect C/Numpy optimizations\n",
-      "Successfully import ClickHouse Connect C/Numpy optimizations\n",
-      "INFO:clickhouse_connect.json_impl:Using python library for writing JSON byte strings\n",
-      "Using python library for writing JSON byte strings\n",
-      "WARNING:chromadb.api.models.Collection:No embedding_function provided, using default embedding function: SentenceTransformerEmbeddingFunction\n",
-      "No embedding_function provided, using default embedding function: SentenceTransformerEmbeddingFunction\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/suo/miniconda3/envs/llama/lib/python3.9/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:sentence_transformers.SentenceTransformer:Load pretrained SentenceTransformer: all-MiniLM-L6-v2\n",
-      "Load pretrained SentenceTransformer: all-MiniLM-L6-v2\n",
-      "INFO:sentence_transformers.SentenceTransformer:Use pytorch device: cpu\n",
-      "Use pytorch device: cpu\n"
+      "Anonymized telemetry enabled. See https://docs.trychroma.com/telemetry for more information.\n"
      ]
     }
    ],
    "source": [
-    "chroma_client = chromadb.Client()\n",
+    "chroma_client = chromadb.EphemeralClient()\n",
     "chroma_collection = chroma_client.create_collection(\"quickstart\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "0a2bcc07",
    "metadata": {},
    "outputs": [],
@@ -110,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "68cbd239-880e-41a3-98d8-dbb3fab55431",
    "metadata": {},
    "outputs": [],
@@ -143,7 +137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "ba1558b3",
    "metadata": {
     "tags": []
@@ -159,21 +153,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "35369eda",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:llama_index.token_counter.token_counter:> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
-      "> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
-      "INFO:llama_index.token_counter.token_counter:> [build_index_from_nodes] Total embedding token usage: 39 tokens\n",
-      "> [build_index_from_nodes] Total embedding token usage: 39 tokens\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "index = VectorStoreIndex(nodes, storage_context=storage_context)"
    ]
@@ -185,19 +168,9 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:llama_index.token_counter.token_counter:> [retrieve] Total LLM token usage: 0 tokens\n",
-      "> [retrieve] Total LLM token usage: 0 tokens\n",
-      "INFO:llama_index.token_counter.token_counter:> [retrieve] Total embedding token usage: 5 tokens\n",
-      "> [retrieve] Total embedding token usage: 5 tokens\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
-       "[NodeWithScore(node=Node(text='director: Francis Ford Coppola\\ntheme: Mafia\\n\\nThe Godfather', doc_id='d73abd97-ae46-4046-a6c2-012e46be7459', embedding=None, doc_hash='208e5a6c4e8f182d28af5293fb3d975531cf8ce3cf6b1e47cb64744d96f6285f', extra_info={'director': 'Francis Ford Coppola', 'theme': 'Mafia'}, node_info={}, relationships={}), score=0.37088084637164886)]"
+       "[NodeWithScore(node=TextNode(id_='f743c41d-d7a8-484f-b138-6da80b6febb1', embedding=None, metadata={'director': 'Francis Ford Coppola', 'theme': 'Mafia'}, excluded_embed_metadata_keys=[], excluded_llm_metadata_keys=[], relationships={}, hash='81cf4b9e847ba42e83fc401e31af8e17d629f0d5cf9c0c320ec7ac69dd0257e1', text='The Godfather', start_char_idx=None, end_char_idx=None, text_template='{metadata_str}\\n\\n{content}', metadata_template='{key}: {value}', metadata_seperator='\\n'), score=0.37105196590093725)]"
       ]
      },
      "execution_count": 9,
@@ -214,14 +187,6 @@
     "retriever = index.as_retriever(filters=filters)\n",
     "retriever.retrieve(\"What is inception about?\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "eeb18e9c",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -240,7 +205,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.10.10"
   },
   "vscode": {
    "interpreter": {

--- a/docs/getting_started/customization.rst
+++ b/docs/getting_started/customization.rst
@@ -49,7 +49,7 @@ In this tutorial, we show the most common customizations with the `starter examp
     from llama_index.vector_stores import ChromaVectorStore
     from llama_index import StorageContext
 
-    chroma_client = chromadb.Client()
+    chroma_client = chromadb.PersistentClient()
     chroma_collection = chroma_client.create_collection("quickstart")
     vector_store = ChromaVectorStore(chroma_collection=chroma_collection)
     storage_context = StorageContext.from_defaults(vector_store=vector_store)

--- a/llama_index/readers/chroma.py
+++ b/llama_index/readers/chroma.py
@@ -37,19 +37,17 @@ class ChromaReader(BaseReader):
 
         if collection_name is None:
             raise ValueError("Please provide a collection name.")
-        from chromadb.config import Settings
+        # from chromadb.config import Settings
 
-        self._client = chromadb.Client(
-            Settings(
-                chroma_api_impl=chroma_api_impl,
-                chroma_db_impl=chroma_db_impl or "chromadb.db.duckdb.DuckDB",
-                chroma_server_host=host,
-                chroma_server_http_port=port,
-                persist_directory=persist_directory
-                if persist_directory
-                else "./chroma",
+        if persist_directory is not None:
+            self._client = chromadb.PersistentClient(
+                path=persist_directory if persist_directory else "./chroma",
             )
-        )
+        elif (host is not None) or (port is not None):
+            self._client = chromadb.HttpClient(
+                host=host,
+                port=port,
+            )
 
         self._collection = self._client.get_collection(collection_name)
 

--- a/llama_index/vector_stores/chroma.py
+++ b/llama_index/vector_stores/chroma.py
@@ -3,7 +3,7 @@ import logging
 import math
 from typing import Any, List, cast
 
-from llama_index.schema import TextNode, MetadataMode
+from llama_index.schema import MetadataMode, TextNode
 from llama_index.utils import truncate_text
 from llama_index.vector_stores.types import (
     MetadataFilters,
@@ -13,9 +13,9 @@ from llama_index.vector_stores.types import (
     VectorStoreQueryResult,
 )
 from llama_index.vector_stores.utils import (
+    legacy_metadata_dict_to_node,
     metadata_dict_to_node,
     node_to_metadata_dict,
-    legacy_metadata_dict_to_node,
 )
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
** This should land Monday the 17th ** 

Chroma is upgrading from `0.3.29` to `0.4.0`. `0.4.0` is easier to build, more durable, faster, smaller, and more extensible. This comes with a few changes:

1. A simplified and improved client setup. Instead of having to remember weird settings, users can just do `EphemeralClient`, `PersistentClient` or `HttpClient` (the underlying direct `Client` implementation is also still accessible)

2. We migrated data stores away from `duckdb` and `clickhouse`. This changes the api for the `PersistentClient` that used to reference `chroma_db_impl="duckdb+parquet"`. Now we simply set `is_persistent=true`. `is_persistent` is set for you to `true` if you use `PersistentClient`. 

3. Because we migrated away from `duckdb` and `clickhouse` - this also means that users need to migrate their data into the new layout and schema. Chroma is committed to providing extension notification and tooling around any schema and data migrations (for example - this PR!). 

After upgrading to `0.4.0` - if users try to access their data that was stored in the previous regime, the system will throw an `Exception` and instruct them how to use the migration assistant to migrate their data. The migration assitant is a pip installable CLI: `pip install chroma_migrate`. And is runnable by calling `chroma_migrate` 

-- TODO ADD here is a short video demonstrating how it works. 

Please reference the readme at [chroma-core/chroma-migrate](https://github.com/chroma-core/chroma-migrate) to see a full write-up of our philosophy on migrations as well as more details about this particular migration. 

Please direct any users facing issues upgrading to our Discord channel called [#get-help](https://discord.com/channels/1073293645303795742/1129200523111841883). We have also created a [email listserv](https://airtable.com/shrHaErIs1j9F97BE) to notify developers directly in the future about breaking changes. 

TODO
- [x] Migrated any `duckdb+parquet` strings to the new format
- [ ] Notified users about the breaking change (this PR, other suggestions?)
- [x] Move pypi target away from feature-branch and to `0.4.0` after `0.4.0` is released. 
- [x] We need to merge in a more flexible range for `fastapi` to the chroma branch - as is in-progress here https://github.com/chroma-core/chroma/pull/807