### PR TITLE
feature(TextSplit): add metadata field to TextSplit

### DIFF
--- a/llama_index/langchain_helpers/text_splitter.py
+++ b/llama_index/langchain_helpers/text_splitter.py
@@ -1,12 +1,11 @@
 """Text splitter implementations."""
 from dataclasses import dataclass
-from typing import Callable, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
-from llama_index.constants import DEFAULT_CHUNK_OVERLAP, DEFAULT_CHUNK_SIZE
 from llama_index.bridge.langchain import TextSplitter
-
 from llama_index.callbacks.base import CallbackManager
 from llama_index.callbacks.schema import CBEventType, EventPayload
+from llama_index.constants import DEFAULT_CHUNK_OVERLAP, DEFAULT_CHUNK_SIZE
 from llama_index.utils import globals_helper
 
 
@@ -21,6 +20,7 @@ class TextSplit:
 
     text_chunk: str
     num_char_overlap: Optional[int] = None
+    metadata: Optional[Dict[str, Any]] = None
 
 
 class TokenTextSplitter(TextSplitter):

--- a/llama_index/node_parser/node_utils.py
+++ b/llama_index/node_parser/node_utils.py
@@ -9,13 +9,14 @@ from llama_index.langchain_helpers.text_splitter import (
     TextSplitter,
     TokenTextSplitter,
 )
-from llama_index.schema import Document, ImageDocument
 from llama_index.schema import (
     BaseNode,
-    NodeRelationship,
+    Document,
+    ImageDocument,
     ImageNode,
-    TextNode,
     MetadataMode,
+    NodeRelationship,
+    TextNode,
 )
 from llama_index.utils import truncate_text
 
@@ -69,11 +70,17 @@ def get_nodes_from_document(
             end_char_idx = index_counter - text_split.num_char_overlap + len(text_chunk)
         index_counter += len(text_chunk) + 1
 
+        node_metadata = {}
+        if include_metadata:
+            node_metadata = document.metadata
+            if text_split.metadata is not None:
+                node_metadata.update(text_split.metadata)
+
         if isinstance(document, ImageDocument):
             image_node = ImageNode(
                 text=text_chunk,
                 embedding=document.embedding,
-                metadata=document.metadata if include_metadata else {},
+                metadata=node_metadata,
                 start_char_idx=start_char_idx,
                 end_char_idx=end_char_idx,
                 image=document.image,
@@ -88,7 +95,7 @@ def get_nodes_from_document(
                 embedding=document.embedding,
                 start_char_idx=start_char_idx,
                 end_char_idx=end_char_idx,
-                metadata=document.metadata if include_metadata else {},
+                metadata=node_metadata,
                 excluded_embed_metadata_keys=document.excluded_embed_metadata_keys,
                 excluded_llm_metadata_keys=document.excluded_llm_metadata_keys,
                 metadata_seperator=document.metadata_seperator,


### PR DESCRIPTION
# Description

Sometimes it needed to add more granular metadata per node. The changes adds `metadata` field to `TextSplit`.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
