### PR TITLE
fix condense engine streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## Unreleased
+
+### Bug Fixes / Nits
+- fix streaming for condense chat engine (#6958)
+
 ## [v0.7.10] - 2023-07-17
 
 ### New Features

--- a/docs/examples/chat_engine/chat_engine_condense_question.ipynb
+++ b/docs/examples/chat_engine/chat_engine_condense_question.ipynb
@@ -99,7 +99,7 @@
    },
    "outputs": [],
    "source": [
-    "chat_engine = index.as_chat_engine(verbose=True)"
+    "chat_engine = index.as_chat_engine(chat_mode=\"condense_question\", verbose=True)"
    ]
   },
   {

--- a/docs/examples/chat_engine/chat_engine_condense_question.ipynb
+++ b/docs/examples/chat_engine/chat_engine_condense_question.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "18e20fbc-056b-44ac-b1fc-2d34b8e99bcc",
    "metadata": {},
@@ -10,6 +11,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "b99eea02-429c-40e4-99be-b82a89c8d070",
    "metadata": {},
@@ -18,6 +20,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "34d34fcc-e247-4d55-ab16-c3d633e2385a",
    "metadata": {
@@ -30,6 +33,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f1c3cbc6-98a8-4e0e-98eb-3c7fa09ba79f",
    "metadata": {},
@@ -39,6 +43,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "b314f279-bf7f-4e67-9f66-ebf783f08d38",
    "metadata": {
@@ -49,6 +54,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "1778820a-4c58-4b2f-8b1a-3d6f1f49995d",
    "metadata": {
@@ -74,6 +80,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e58d7ad9-d246-477e-acac-894ad5402f24",
    "metadata": {
@@ -96,6 +103,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "63a4259d-89b5-49f8-b158-9eba5353d6f5",
    "metadata": {},
@@ -145,6 +153,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "67021e64-8665-4338-9fb4-c0f1d6361092",
    "metadata": {},
@@ -235,6 +244,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "c2c68de8-af58-4f7e-8759-19fc072873fd",
    "metadata": {},
@@ -296,6 +306,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "a65ad1a2",
    "metadata": {},
@@ -305,7 +316,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "id": "ad272dfe",
    "metadata": {},
    "outputs": [],
@@ -314,7 +325,7 @@
     "from llama_index.llms import OpenAI\n",
     "\n",
     "service_context = ServiceContext.from_defaults(\n",
-    "    llm=OpenAI(model=\"gpt-3.5-turbo-0613\", temperature=0)\n",
+    "    llm=OpenAI(model=\"gpt-3.5-turbo\", temperature=0)\n",
     ")\n",
     "\n",
     "data = SimpleDirectoryReader(input_dir=\"../data/paul_graham/\").load_data()\n",
@@ -324,17 +335,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "id": "22605caa",
    "metadata": {},
    "outputs": [],
    "source": [
-    "chat_engine = index.as_chat_engine(verbose=True)"
+    "chat_engine = index.as_chat_engine(chat_mode=\"condense_question\", verbose=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 6,
    "id": "250abd43",
    "metadata": {},
    "outputs": [
@@ -342,32 +353,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "After YC, Paul Graham continued to inspire,\n",
-      "With his wisdom and insights, he aimed higher.\n",
-      "He wrote essays and books, sharing his knowledge,\n",
-      "Guiding entrepreneurs through their startup college.\n",
-      "\n",
-      "He founded a startup incubator, Y Combinator,\n",
-      "Nurturing ideas and fostering innovation galore.\n",
-      "Investing in startups, helping them grow,\n",
-      "Supporting founders, giving them a glow.\n",
-      "\n",
-      "Paul Graham's influence extended far and wide,\n",
-      "As he championed the startup ecosystem with pride.\n",
-      "His words resonated, his advice was gold,\n",
-      "Empowering entrepreneurs, making them bold.\n",
-      "\n",
-      "So, after YC, Paul Graham's journey did not cease,\n",
-      "He continued to shape the startup world with ease.\n",
-      "A visionary, a mentor, a guiding light,\n",
-      "Paul Graham's impact shines ever so bright."
+      "Querying with: What did Paul Graham do after leaving YC?\n",
+      "After leaving YC, Paul Graham started painting and focused on improving his skills in that area. He then started writing essays again and began working on Lisp."
      ]
     }
    ],
    "source": [
-    "response = chat_engine.stream_chat(\n",
-    "    \"What did Paul Graham do after YC? Write a poem with your answer\"\n",
-    ")\n",
+    "response = chat_engine.stream_chat(\"What did Paul Graham do after YC?\")\n",
     "for token in response.response_gen:\n",
     "    print(token, end=\"\")"
    ]
@@ -375,7 +367,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5e92a544",
+   "id": "e0dbf8ff",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -397,7 +389,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,

--- a/llama_index/chat_engine/condense_question.py
+++ b/llama_index/chat_engine/condense_question.py
@@ -1,4 +1,5 @@
 import logging
+from threading import Thread
 from typing import Any, List, Optional, Type
 
 from llama_index.chat_engine.types import (
@@ -6,7 +7,7 @@ from llama_index.chat_engine.types import (
     BaseChatEngine,
     StreamingAgentChatResponse,
 )
-from llama_index.chat_engine.utils import response_gen_with_chat_history
+from llama_index.chat_engine.utils import response_gen_from_query_engine
 from llama_index.indices.query.base import BaseQueryEngine
 from llama_index.indices.service_context import ServiceContext
 from llama_index.llms.base import ChatMessage, MessageRole
@@ -131,12 +132,20 @@ class CondenseQuestionChatEngine(BaseChatEngine):
     def _get_tool_output_from_response(
         self, query: str, response: RESPONSE_TYPE
     ) -> ToolOutput:
-        return ToolOutput(
-            content=str(response),
-            tool_name="query_engine",
-            raw_input={"query": query},
-            raw_output=response,
-        )
+        if isinstance(response, StreamingResponse):
+            return ToolOutput(
+                content="",
+                tool_name="query_engine",
+                raw_input={"query": query},
+                raw_output=response,
+            )
+        else:
+            return ToolOutput(
+                content=str(response),
+                tool_name="query_engine",
+                raw_input={"query": query},
+                raw_output=response,
+            )
 
     def chat(
         self, message: str, chat_history: Optional[List[ChatMessage]] = None
@@ -218,12 +227,15 @@ class CondenseQuestionChatEngine(BaseChatEngine):
             and query_response.response_gen is not None
         ):
             # override the generator to include writing to chat history
+            self._memory.put(ChatMessage(role=MessageRole.USER, content=message))
             response = StreamingAgentChatResponse(
-                chat_stream=response_gen_with_chat_history(
-                    message, self._memory, query_response.response_gen
-                ),
+                chat_stream=response_gen_from_query_engine(query_response.response_gen),
                 sources=[tool_output],
             )
+            thread = Thread(
+                target=response.write_response_to_history, args=(self._memory,)
+            )
+            thread.start()
         else:
             raise ValueError("Streaming is not enabled. Please use chat() instead.")
         return response
@@ -309,12 +321,15 @@ class CondenseQuestionChatEngine(BaseChatEngine):
         ):
             # override the generator to include writing to chat history
             # TODO: query engine does not support async generator yet
+            self._memory.put(ChatMessage(role=MessageRole.USER, content=message))
             response = StreamingAgentChatResponse(
-                chat_stream=response_gen_with_chat_history(
-                    message, self._memory, query_response.response_gen
-                ),
+                chat_stream=response_gen_from_query_engine(query_response.response_gen),
                 sources=[tool_output],
             )
+            thread = Thread(
+                target=response.write_response_to_history, args=(self._memory,)
+            )
+            thread.start()
         else:
             raise ValueError("Streaming is not enabled. Please use achat() instead.")
         return response

--- a/llama_index/chat_engine/types.py
+++ b/llama_index/chat_engine/types.py
@@ -47,16 +47,22 @@ class StreamingAgentChatResponse:
                 "chat_stream is None. Cannot write to history without chat_stream."
             )
 
-        final_message = None
-        for chat in self.chat_stream:
-            final_message = chat.message
-            self._is_function = (
-                final_message.additional_kwargs.get("function_call", None) is not None
-            )
-            self._queue.put_nowait(chat.delta)
+        # try/except to prevent hanging on error
+        try:
+            final_message = None
+            for chat in self.chat_stream:
+                final_message = chat.message
+                self._is_function = (
+                    final_message.additional_kwargs.get("function_call", None)
+                    is not None
+                )
+                self._queue.put_nowait(chat.delta)
 
-        if final_message is not None:
-            memory.put(final_message)
+            if final_message is not None:
+                memory.put(final_message)
+        except Exception as e:
+            print("Error reading response: ", e)
+            pass
 
         self._is_done = True
 
@@ -67,16 +73,22 @@ class StreamingAgentChatResponse:
                 "history without achat_stream."
             )
 
-        final_message = None
-        async for chat in self.achat_stream:
-            final_message = chat.message
-            self._is_function = (
-                final_message.additional_kwargs.get("function_call", None) is not None
-            )
-            self._queue.put_nowait(chat.delta)
+        # try/except to prevent hanging on error
+        try:
+            final_message = None
+            async for chat in self.achat_stream:
+                final_message = chat.message
+                self._is_function = (
+                    final_message.additional_kwargs.get("function_call", None)
+                    is not None
+                )
+                self._queue.put_nowait(chat.delta)
 
-        if final_message is not None:
-            memory.put(final_message)
+            if final_message is not None:
+                memory.put(final_message)
+        except Exception as e:
+            print("Error reading response: ", e)
+            pass
 
         self._is_done = True
 

--- a/llama_index/chat_engine/utils.py
+++ b/llama_index/chat_engine/utils.py
@@ -4,20 +4,14 @@ from llama_index.llms.base import (
     ChatResponse,
     ChatResponseGen,
 )
-from llama_index.memory import BaseMemory
 from llama_index.types import TokenGen
 
 
-def response_gen_with_chat_history(
-    message: str, memory: BaseMemory, response_gen: TokenGen
-) -> ChatResponseGen:
+def response_gen_from_query_engine(response_gen: TokenGen) -> ChatResponseGen:
     response_str = ""
     for token in response_gen:
         response_str += token
         yield ChatResponse(
-            role=MessageRole.ASSISTANT, content=response_str, delta=token
+            message=ChatMessage(role=MessageRole.ASSISTANT, content=response_str),
+            delta=token,
         )
-
-    # Record response
-    memory.put(ChatMessage(role=MessageRole.USER, content=message))
-    memory.put(ChatMessage(role=MessageRole.ASSISTANT, content=response_str))


### PR DESCRIPTION
# Description

The condense chat engine was a) not starting a thread for streaming and b) calling `str()` on the query response outputs, removing any chance of streaming

This PR fixes both of those issues.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] Tested with the notebook
- [x] I stared at the code and made sure it makes sense
