### PR TITLE
add embeddings to embeddings callback hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### New Features
 - Add support for chroma v0.4.0 (#6937)
+- Log embedding vectors to callback manager (#6962)
 
 ### Bug Fixes / Nits
 - add more robust embedding timeouts (#6779)

--- a/llama_index/callbacks/schema.py
+++ b/llama_index/callbacks/schema.py
@@ -47,6 +47,7 @@ class EventPayload(str, Enum):
     TEMPLATE = "template"  # template used in LLM call
     QUERY_STR = "query_str"  # query used for query engine
     SUB_QUESTIONS = "sub_questions"  # list of sub question & answer pairs
+    EMBEDDINGS = "embeddings"  # list of embeddings
 
 
 # events that will never have children events

--- a/llama_index/embeddings/base.py
+++ b/llama_index/embeddings/base.py
@@ -226,11 +226,6 @@ class BaseEmbedding:
                     self._aget_text_embeddings(cur_batch_texts)
                 )
                 result_ids.extend(cur_batch_ids)
-                self.callback_manager.on_event_end(
-                    CBEventType.EMBEDDING,
-                    payload={EventPayload.CHUNKS: cur_batch_texts},
-                    event_id=event_id,
-                )
 
         # flatten the results of asyncio.gather, which is a list of embeddings lists
         nested_embeddings = []
@@ -255,6 +250,14 @@ class BaseEmbedding:
         result_embeddings = [
             embedding for embeddings in nested_embeddings for embedding in embeddings
         ]
+        self.callback_manager.on_event_end(
+            CBEventType.EMBEDDING,
+            payload={
+                EventPayload.CHUNKS: [text for _, text in text_queue],
+                EventPayload.EMBEDDINGS: result_embeddings,
+            },
+            event_id=event_id,
+        )
 
         return result_ids, result_embeddings
 

--- a/llama_index/embeddings/base.py
+++ b/llama_index/embeddings/base.py
@@ -253,7 +253,9 @@ class BaseEmbedding:
             embedding for embeddings in nested_embeddings for embedding in embeddings
         ]
 
-        for (event_id, text_batch), embeddings in zip(callback_payloads, nested_embeddings):
+        for (event_id, text_batch), embeddings in zip(
+            callback_payloads, nested_embeddings
+        ):
             self.callback_manager.on_event_end(
                 CBEventType.EMBEDDING,
                 payload={

--- a/llama_index/embeddings/base.py
+++ b/llama_index/embeddings/base.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from llama_index.callbacks.base import CallbackManager
 from llama_index.callbacks.schema import CBEventType, EventPayload
-from llama_index.utils import globals_helper, get_tqdm_iterable
+from llama_index.utils import get_tqdm_iterable, globals_helper
 
 # TODO: change to numpy array
 EMB_TYPE = List
@@ -80,7 +80,10 @@ class BaseEmbedding:
         self._total_tokens_used += query_tokens_count
         self.callback_manager.on_event_end(
             CBEventType.EMBEDDING,
-            payload={EventPayload.CHUNKS: [query]},
+            payload={
+                EventPayload.CHUNKS: [query],
+                EventPayload.EMBEDDINGS: [query_embedding],
+            },
             event_id=event_id,
         )
         return query_embedding
@@ -138,7 +141,10 @@ class BaseEmbedding:
         self._total_tokens_used += text_tokens_count
         self.callback_manager.on_event_end(
             CBEventType.EMBEDDING,
-            payload={EventPayload.CHUNKS: [text]},
+            payload={
+                EventPayload.CHUNKS: [text],
+                EventPayload.EMBEDDINGS: [text_embedding],
+            },
             event_id=event_id,
         )
         return text_embedding
@@ -182,7 +188,10 @@ class BaseEmbedding:
                 result_embeddings.extend(embeddings)
                 self.callback_manager.on_event_end(
                     CBEventType.EMBEDDING,
-                    payload={EventPayload.CHUNKS: cur_batch_texts},
+                    payload={
+                        EventPayload.CHUNKS: cur_batch_texts,
+                        EventPayload.EMBEDDINGS: embeddings,
+                    },
                     event_id=event_id,
                 )
                 cur_batch = []

--- a/llama_index/indices/document_summary/retrievers.py
+++ b/llama_index/indices/document_summary/retrievers.py
@@ -144,24 +144,10 @@ class DocumentSummaryIndexEmbeddingRetriever(BaseRetriever):
         """Get top nodes by similarity to the query."""
         embed_model = self._index.service_context.embed_model
         if query_bundle.embedding is None:
-            event_id = self._index._service_context.callback_manager.on_event_start(
-                CBEventType.EMBEDDING
-            )
             query_bundle.embedding = embed_model.get_agg_embedding_from_queries(
                 query_bundle.embedding_strs
             )
-            self._index._service_context.callback_manager.on_event_end(
-                CBEventType.EMBEDDING,
-                payload={
-                    EventPayload.CHUNKS: query_bundle.embedding_strs,
-                    EventPayload.EMBEDDINGS: [query_bundle.embedding],
-                },
-                event_id=event_id,
-            )
 
-        event_id = self._index._service_context.callback_manager.on_event_start(
-            CBEventType.EMBEDDING
-        )
         id_to_embed_map: Dict[str, List[float]] = {}
         for node in nodes:
             if node.embedding is None:
@@ -176,18 +162,6 @@ class DocumentSummaryIndexEmbeddingRetriever(BaseRetriever):
             result_ids,
             result_embeddings,
         ) = embed_model.get_queued_text_embeddings()
-        self._index._service_context.callback_manager.on_event_end(
-            CBEventType.EMBEDDING,
-            payload={
-                EventPayload.CHUNKS: [
-                    node.get_content(metadata_mode=MetadataMode.EMBED)
-                    for node in nodes
-                    if node.embedding is not None
-                ],
-                EventPayload.EMBEDDINGS: result_embeddings,
-            },
-            event_id=event_id,
-        )
         for new_id, text_embedding in zip(result_ids, result_embeddings):
             id_to_embed_map[new_id] = text_embedding
         node_embeddings = [id_to_embed_map[n.node_id] for n in nodes]

--- a/llama_index/indices/document_summary/retrievers.py
+++ b/llama_index/indices/document_summary/retrievers.py
@@ -179,7 +179,12 @@ class DocumentSummaryIndexEmbeddingRetriever(BaseRetriever):
         self._index._service_context.callback_manager.on_event_end(
             CBEventType.EMBEDDING,
             payload={
-                EventPayload.CHUNKS: [x for x in nodes if node.embedding is not None]
+                EventPayload.CHUNKS: [
+                    node.get_content(metadata_mode=MetadataMode.EMBED)
+                    for node in nodes
+                    if node.embedding is not None
+                ],
+                EventPayload.EMBEDDINGS: result_embeddings,
             },
             event_id=event_id,
         )

--- a/llama_index/indices/document_summary/retrievers.py
+++ b/llama_index/indices/document_summary/retrievers.py
@@ -7,7 +7,6 @@ This module contains retrievers for document summary indices.
 import logging
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-from llama_index.callbacks.schema import CBEventType, EventPayload
 from llama_index.indices.base_retriever import BaseRetriever
 from llama_index.indices.document_summary.base import DocumentSummaryIndex
 from llama_index.indices.query.embedding_utils import get_top_k_embeddings

--- a/llama_index/indices/document_summary/retrievers.py
+++ b/llama_index/indices/document_summary/retrievers.py
@@ -21,7 +21,7 @@ from llama_index.prompts.choice_select import (
     DEFAULT_CHOICE_SELECT_PROMPT,
     ChoiceSelectPrompt,
 )
-from llama_index.schema import NodeWithScore, BaseNode, MetadataMode
+from llama_index.schema import BaseNode, MetadataMode, NodeWithScore
 
 logger = logging.getLogger(__name__)
 
@@ -152,7 +152,10 @@ class DocumentSummaryIndexEmbeddingRetriever(BaseRetriever):
             )
             self._index._service_context.callback_manager.on_event_end(
                 CBEventType.EMBEDDING,
-                payload={EventPayload.CHUNKS: query_bundle.embedding_strs},
+                payload={
+                    EventPayload.CHUNKS: query_bundle.embedding_strs,
+                    EventPayload.EMBEDDINGS: [query_bundle.embedding],
+                },
                 event_id=event_id,
             )
 


### PR DESCRIPTION
# Description

The embeddings callback hook currently returns the embedded text but not the embeddings themselves, which are useful for analysis and debugging of retrieval-augmented systems. I am building a [callback handler](https://github.com/Arize-ai/llama_index/pull/1) that requires access to the embeddings for use with Phoenix.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense.

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes