### PR TITLE
Don't force "python" exec_option in deeplake query

### DIFF
--- a/llama_index/vector_stores/deeplake.py
+++ b/llama_index/vector_stores/deeplake.py
@@ -184,7 +184,7 @@ class DeepLakeVectorStore(VectorStoreBase):
             VectorStoreQueryResult
         """
         query_embedding = cast(List[float], query.query_embedding)
-        exec_option = kwargs.get("exec_option", "python")
+        exec_option = kwargs.get("exec_option")
         data = self.vectorstore.search(
             embedding=query_embedding,
             exec_option=exec_option,


### PR DESCRIPTION
# Description

The current implementation forces "python" exec_option in query. This PR will set exec_option to deeplake VectorStore self exec_option.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
