### PR TITLE
add kwargs to from_tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug Fixes / Nits
 - Added `model_name` to LLMMetadata (#6911)
 - Fallback to retriever service context in query engines (#6911)
+- Fixed `as_chat_engine()` ValueError with extra kwargs (#6971
 
 ## [v0.7.10.post1] - 2023-07-18
 

--- a/llama_index/agent/openai_agent.py
+++ b/llama_index/agent/openai_agent.py
@@ -3,7 +3,7 @@ import json
 import time
 from abc import abstractmethod
 from threading import Thread
-from typing import Callable, List, Optional, Tuple, Type
+from typing import Any, Callable, List, Optional, Tuple, Type
 
 from llama_index.agent.types import BaseAgent
 from llama_index.callbacks.base import CallbackManager
@@ -367,6 +367,7 @@ class OpenAIAgent(BaseOpenAIAgent):
         callback_manager: Optional[CallbackManager] = None,
         system_prompt: Optional[str] = None,
         prefix_messages: Optional[List[ChatMessage]] = None,
+        **kwargs: Any,
     ) -> "OpenAIAgent":
         tools = tools or []
         chat_history = chat_history or []

--- a/llama_index/agent/react/base.py
+++ b/llama_index/agent/react/base.py
@@ -1,6 +1,6 @@
 # ReAct agent
 
-from typing import List, Optional, Sequence, Tuple, cast
+from typing import Any, List, Optional, Sequence, Tuple, cast
 
 from llama_index.agent.react.formatter import ReActChatFormatter
 from llama_index.agent.react.output_parser import ReActOutputParser
@@ -66,6 +66,7 @@ class ReActAgent(BaseAgent):
         output_parser: Optional[ReActOutputParser] = None,
         callback_manager: Optional[CallbackManager] = None,
         verbose: bool = False,
+        **kwargs: Any,
     ) -> "ReActAgent":
         tools = tools or []
         chat_history = chat_history or []


### PR DESCRIPTION
# Description

`as_chat_engine` breaks when extra kwargs are passed, because the agents are being passed kwargs they don't use.

Just a quick change to allow these things to be passed nicely.

Fixes https://github.com/jerryjliu/llama_index/issues/6967

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

