### PR TITLE
Chat buffer should return last messages, not first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## Unreleased
+
+### Bug Fixes / Nits
+- Fix returned order of messages in large chat memory (#6979) 
+
 ## [v0.7.11] - 2023-07-19
 
 ### New Features

--- a/llama_index/memory/chat_memory_buffer.py
+++ b/llama_index/memory/chat_memory_buffer.py
@@ -56,7 +56,7 @@ class ChatMemoryBuffer(BaseMemory):
         if token_count > self.token_limit:
             return []
 
-        return self.chat_history[:message_count]
+        return self.chat_history[-message_count:]
 
     def get_all(self) -> List[ChatMessage]:
         """Get all chat history."""

--- a/tests/memory/test_chat_memory_buffer.py
+++ b/tests/memory/test_chat_memory_buffer.py
@@ -27,7 +27,7 @@ def test_set() -> None:
 def test_max_tokens() -> None:
     memory = ChatMemoryBuffer.from_defaults(chat_history=[CHAT_MESSAGE], token_limit=5)
 
-    memory.put(ChatMessage(role=MessageRole.USER, content="test message2"))
+    memory.put(CHAT_MESSAGE)
     assert len(memory.get()) == 2
 
     # do we limit properly
@@ -39,4 +39,6 @@ def test_max_tokens() -> None:
     assert len(memory.get_all()) == 4
 
     # does get return in the correct order?
+    memory.put(ChatMessage(role=MessageRole.USER, content="test message2"))
     assert memory.get()[-1].content == "test message2"
+    assert len(memory.get()) == 2


### PR DESCRIPTION
# Description

Chat buffer should return last messages, not first.
At the code above (lines 43 and 51) message_str calculated as ``chat_history[-message_count:]``, but at the end of function will be returned ``chat_history[:message_count]``. The is a bug, that prevent to send new messages to llm

Fixes # (issue)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
