### PR TITLE
Add 'restore index ' section to RedisIndexDemo doc.

### DIFF
--- a/docs/examples/vector_stores/RedisIndexDemo.ipynb
+++ b/docs/examples/vector_stores/RedisIndexDemo.ipynb
@@ -139,6 +139,28 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "ce335c9a",
+   "metadata": {},
+   "source": [
+    "You can process your files individually using [SimpleDirectoryReader]([Title](https://gpt-index.readthedocs.io/en/latest/examples/data_connectors/simple_directory_reader.html)):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f67cb2a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loader = SimpleDirectoryReader(\"../data/paul_graham\")\n",
+    "documents = loader.load_data()\n",
+    "for file in loader.input_files:\n",
+    "    print(file)\n",
+    "    # Here is where you would do any preprocessing"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "id": "dd270925",
@@ -226,7 +248,6 @@
    "source": [
     "from llama_index.storage.storage_context import StorageContext\n",
     "\n",
-    "\n",
     "vector_store = RedisVectorStore(\n",
     "    index_name=\"pg_essays\",\n",
     "    index_prefix=\"llama\",\n",
@@ -238,13 +259,86 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "b481dc47",
+   "metadata": {},
+   "source": [
+    "With logging on, it prints out the following:\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53288b66",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "INFO:llama_index.vector_stores.redis:Creating index pg_essays\n",
+    "Creating index pg_essays\n",
+    "INFO:llama_index.vector_stores.redis:Added 15 documents to index pg_essays\n",
+    "Added 15 documents to index pg_essays\n",
+    "INFO:llama_index.vector_stores.redis:Saving index to disk in background"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e02256f9",
+   "metadata": {},
+   "source": [
+    "Now you can browse these index in redis-cli and read/write it as Redis hash. It looks like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf1fb5d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "$ redis-cli\n",
+    "127.0.0.1:6379> keys *\n",
+    " 1) \"llama/vector_0f125320-f5cf-40c2-8462-aefc7dbff490\"\n",
+    " 2) \"llama/vector_bd667698-4311-4a67-bb8b-0397b03ec794\"\n",
+    "127.0.0.1:6379> HGETALL \"llama/vector_bd667698-4311-4a67-bb8b-0397b03ec794\"\n",
+    "..."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "405d445f",
+   "metadata": {},
+   "source": [
+    "### Handle duplicated index\n",
+    "\n",
+    "Regardless of whether overwrite=True is used in RedisVectorStore(), the process of generating the index and storing data in Redis still takes time. Currently, it is necessary to implement your own logic to manage duplicate indexes. One possible approach is to set a flag in Redis to indicate the readiness of the index. If the flag is set, you can bypass the index generation step and directly load the index from Redis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "218e612a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import redis\n",
+    "r = redis.Redis()\n",
+    "index_name = \"pg_essays\"\n",
+    "r.set(f\"added:{index_name}\", \"true\")\n",
+    "\n",
+    "# Later in code\n",
+    "if r.get(f\"added:{index_name}\"):\n",
+    "    # Skip to deploy your index, restore it. Please see \"Restore index from Redis\" section below. "
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "id": "04304299-fc3e-40a0-8600-f50c3292767e",
    "metadata": {},
    "source": [
     "# Query the data\n",
-    "Now that we have our document stored in the index, we can ask questions against the index. The index will use the data stored in itself as the knowledge base for chatgpt."
+    "Now that we have our document stored in the index, we can ask questions against the index. The index will use the data stored in itself as the knowledge base for ChatGPT. The default setting for as_query_engine() utilizes OpenAI embeddings and ChatGPT as the language model. Therefore, an OpenAI key is required unless you opt for a customized or local language model."
    ]
   },
   {
@@ -358,6 +452,60 @@
    ],
    "source": [
     "!docker exec -it redis-vecdb ls /data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c8849ba",
+   "metadata": {},
+   "source": [
+    "### Restore index from Redis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "95817a85",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "redisURL = \"redis://localhost:6379\"\n",
+    "index_name = \"pg_essays\"\n",
+    "vector_store = RedisVectorStore(\n",
+    "        index_name=index_name,\n",
+    "        index_prefix=\"llama\",\n",
+    "        redis_url=redisURL,\n",
+    "        overwrite=True,\n",
+    "    )\n",
+    "index = VectorStoreIndex.from_vector_store(vector_store=vector_store)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b12c9f2",
+   "metadata": {},
+   "source": [
+    "Now you can reuse your index as discussed above."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "437dc580",
+   "metadata": {},
+   "source": [
+    "pgQuery = index.as_query_engine()\n",
+    "pgQuery.query(\"What is the meaning of life?\")\n",
+    "# or\n",
+    "pgRetriever = index.as_retriever()\n",
+    "pgRetriever.retrieve(\"What is the meaning of life?\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e43b185f",
+   "metadata": {},
+   "source": [
+    "Learn more about [query_engine](https://gpt-index.readthedocs.io/en/latest/core_modules/query_modules/query_engine/root.html)  and [retriveve]([Title](https://gpt-index.readthedocs.io/en/latest/core_modules/query_modules/retriever/usage_pattern.html))."
    ]
   },
   {


### PR DESCRIPTION
# Description

As mentioned in ticket #6978, I have included detailed information and example codes in the RedisIndexDemo. This demonstration illustrates how to restore an existing index from Redis.

Fixes # (issue)

https://github.com/jerryjliu/llama_index/issues/6978

## Type of Change

- [✔️ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [✔️ ] I 've browse the documentation in Markdown browser mode, of which code added are tested end-to-end.

# Suggested Checklist:

- [ ✔️ ] I don't commit anything relate to code. It just documentation update.
