### PR TITLE
FIxed: current message not sent to first llm call in achat

### DIFF
--- a/llama_index/agent/openai_agent.py
+++ b/llama_index/agent/openai_agent.py
@@ -210,9 +210,11 @@ class BaseOpenAIAgent(BaseAgent):
     ) -> AgentChatResponse:
         if chat_history is not None:
             self._memory.set(chat_history)
-        all_messages = self._prefix_messages + self._memory.get()
+
         tools, functions = self._init_chat(message)
         sources = []
+        
+        all_messages = self._prefix_messages + self._memory.get()
 
         # TODO: Support forced function call
         chat_response = await self._llm.achat(all_messages, functions=functions)


### PR DESCRIPTION
# Description

You should first _init_chat (add current message to memory) and only than get messages from memory )

Fixes # (issue)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
