### PR TITLE
fixes load from persisted faiss index file

### DIFF
--- a/docs/examples/vector_stores/FaissIndexDemo.ipynb
+++ b/docs/examples/vector_stores/FaissIndexDemo.ipynb
@@ -115,7 +115,7 @@
    "source": [
     "# load index from disk\n",
     "vector_store = FaissVectorStore.from_persist_dir(\"./storage\")\n",
-    "storage_context = StorageContext.from_defaults(vector_store=vector_store)\n",
+    "storage_context = StorageContext.from_defaults(vector_store=vector_store, persist_dir=\"./storage\")\n",
     "index = load_index_from_storage(storage_context=storage_context)"
    ]
   },

--- a/docs/examples/vector_stores/FaissIndexDemo.ipynb
+++ b/docs/examples/vector_stores/FaissIndexDemo.ipynb
@@ -115,7 +115,9 @@
    "source": [
     "# load index from disk\n",
     "vector_store = FaissVectorStore.from_persist_dir(\"./storage\")\n",
-    "storage_context = StorageContext.from_defaults(vector_store=vector_store, persist_dir=\"./storage\")\n",
+    "storage_context = StorageContext.from_defaults(\n",
+    "    vector_store=vector_store, persist_dir=\"./storage\"\n",
+    ")\n",
     "index = load_index_from_storage(storage_context=storage_context)"
    ]
   },


### PR DESCRIPTION
# Description

I have updated the documentation notebook so that it allows both save and load from a FAISS index vector store.
I noticed that when following the Faiss index vector store documentation, that I would get the following error, and the data wouldn't get properly loaded back. Without persist_dir as an option, the index is initialised as empty.
<img width="1252" alt="image" src="https://github.com/jerryjliu/llama_index/assets/19593920/5daea1ef-12a0-45cf-ad93-9ae53d45f8f1">


Fixes #3511

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
When the persist_dir is added, the index gets correctly loaded
<img width="975" alt="image" src="https://github.com/jerryjliu/llama_index/assets/19593920/ecfc310e-fcaa-4add-b1db-7da995f035be">



- [x] I stared at the code and made sure it makes sense


Hope this helps!
