### PR TITLE
add context chat engine

### DIFF
--- a/docs/core_modules/query_modules/chat_engines/modules.md
+++ b/docs/core_modules/query_modules/chat_engines/modules.md
@@ -3,14 +3,15 @@
 We provide a few simple implementations to start, with more sophisticated modes coming soon!  
 
 More specifically, the `SimpleChatEngine` does not make use of a knowledge base, 
-whereas `CondenseQuestionChatEngine` and `ReActChatEngine` make use of a query engine over knowledge base.
+whereas all others make use of a query engine over knowledge base.
 
 ```{toctree}
 ---
 maxdepth: 1
 ---
-Simple Chat Engine </examples/chat_engine/chat_engine_repl.ipynb>
 ReAct Chat Engine </examples/chat_engine/chat_engine_react.ipynb>
 OpenAI Chat Engine </examples/chat_engine/chat_engine_openai.ipynb>
+Context Chat Engine </examples/chat_engine/chat_engine_context.ipynb>
 Condense Question Chat Engine </examples/chat_engine/chat_engine_condense_question.ipynb>
+Simple Chat Engine </examples/chat_engine/chat_engine_repl.ipynb>
 ```

--- a/docs/core_modules/query_modules/chat_engines/usage_pattern.md
+++ b/docs/core_modules/query_modules/chat_engines/usage_pattern.md
@@ -38,9 +38,18 @@ chat_engine = index.as_chat_engine(
     verbose=True
 )
 ```
-> Note: you can access different chat engines by specifying the `chat_mode` as a kwarg. `condense_question` corresponds to `CondenseQuestionChatEngine`, `react` corresponds to `ReActChatEngine`.
+> Note: you can access different chat engines by specifying the `chat_mode` as a kwarg. `condense_question` corresponds to `CondenseQuestionChatEngine`, `react` corresponds to `ReActChatEngine`, `context` corresponds to a `ContextChatEngine`.
 
 > Note: While the high-level API optimizes for ease-of-use, it does *NOT* expose full range of configurability.  
+
+#### Available Chat Modes
+
+- `best` - Turn the query engine into a tool, for use with a `ReAct` data agent or an `OpenAI` data agent, depending on what your LLM supports. `OpenAI` data agents require `gpt-3.5-turbo` or `gpt-4` as they use the function calling API from OpenAI.
+- `context` - Retrieve nodes from the index using every user message. The retrieved text is inserted into the system prompt, so that the chat engine can either respond naturally or use the context from the query engine.
+- `condense_question` - Look at the chat history and re-write the user message to be a query for the index. Return the response after reading the response from the query engine.
+- `simple` - A simple chat with the LLM directly, no query engine involved.
+- `react` - Same as `best`, but forces a `ReAct` data agent.
+- `openai` - Same as `best`, but forces an `OpenAI` data agent.
 
 ### Low-Level Composition API
 
@@ -86,8 +95,6 @@ chat_engine = CondenseQuestionChatEngine.from_defaults(
     verbose=True
 )
 ```
-
-
 
 ### Streaming
 To enable streaming, you simply need to call the `stream_chat` endpoint instead of the `chat` endpoint. 

--- a/llama_index/chat_engine/__init__.py
+++ b/llama_index/chat_engine/__init__.py
@@ -1,7 +1,5 @@
 from llama_index.chat_engine.condense_question import CondenseQuestionChatEngine
+from llama_index.chat_engine.context import ContextChatEngine
 from llama_index.chat_engine.simple import SimpleChatEngine
 
-__all__ = [
-    "SimpleChatEngine",
-    "CondenseQuestionChatEngine",
-]
+__all__ = ["SimpleChatEngine", "CondenseQuestionChatEngine", "ContextChatEngine"]

--- a/llama_index/chat_engine/context.py
+++ b/llama_index/chat_engine/context.py
@@ -1,0 +1,236 @@
+import asyncio
+from threading import Thread
+from typing import Any, List, Optional, Type
+
+from llama_index.chat_engine.types import (
+    AgentChatResponse,
+    BaseChatEngine,
+    StreamingAgentChatResponse,
+    ToolOutput,
+)
+from llama_index.indices.service_context import ServiceContext
+from llama_index.llm_predictor.base import LLMPredictor
+from llama_index.llms.base import LLM, ChatMessage
+from llama_index.memory import BaseMemory, ChatMemoryBuffer
+from llama_index.indices.base_retriever import BaseRetriever
+from llama_index.schema import MetadataMode
+
+
+DEFAULT_CONTEXT_TEMPALTE = (
+    "Context information is below."
+    "\n--------------------\n"
+    "{context_str}"
+    "\n--------------------\n"
+    "{{system_prompt}}"
+)
+
+
+class ContextChatEngine(BaseChatEngine):
+    """Context Chat Engine.
+
+    Uses a retriever to retrieve a context, set the context in the system prompt,
+    and then uses an LLM to generate a response, for a fluid chat experience.
+    """
+
+    def __init__(
+        self,
+        retriever: BaseRetriever,
+        llm: LLM,
+        memory: BaseMemory,
+        prefix_messages: List[ChatMessage],
+        context_template: Optional[str] = None,
+    ) -> None:
+        self._retriever = retriever
+        self._llm = llm
+        self._memory = memory
+        self._prefix_messages = prefix_messages
+        self._context_template = context_template or DEFAULT_CONTEXT_TEMPALTE
+
+    @classmethod
+    def from_defaults(
+        cls,
+        retriever: BaseRetriever,
+        service_context: Optional[ServiceContext] = None,
+        chat_history: Optional[List[ChatMessage]] = None,
+        memory: Optional[BaseMemory] = None,
+        memory_cls: Type[BaseMemory] = ChatMemoryBuffer,
+        system_prompt: Optional[str] = None,
+        prefix_messages: Optional[List[ChatMessage]] = None,
+        **kwargs: Any,
+    ) -> "ContextChatEngine":
+        """Initialize a ContextChatEngine from default parameters."""
+        service_context = service_context or ServiceContext.from_defaults()
+        if not isinstance(service_context.llm_predictor, LLMPredictor):
+            raise ValueError("llm_predictor must be a LLMPredictor instance")
+        llm = service_context.llm_predictor.llm
+
+        chat_history = chat_history or []
+        memory = memory or memory_cls.from_defaults(chat_history=chat_history)
+
+        if system_prompt is not None:
+            if prefix_messages is not None:
+                raise ValueError(
+                    "Cannot specify both system_prompt and prefix_messages"
+                )
+            prefix_messages = [ChatMessage(content=system_prompt, role="system")]
+
+        prefix_messages = prefix_messages or []
+
+        return cls(retriever, llm=llm, memory=memory, prefix_messages=prefix_messages)
+
+    def _generate_context(self, message: str) -> str:
+        """Generate context information from a message."""
+        nodes = self._retriever.retrieve(message)
+        context_str = "\n\n".join(
+            [n.node.get_content(metadata_mode=MetadataMode.LLM).strip() for n in nodes]
+        )
+
+        return self._context_template.format(context_str=context_str)
+
+    async def _agenerate_context(self, message: str) -> str:
+        """Generate context information from a message."""
+        nodes = await self._retriever.aretrieve(message)
+        context_str = "\n\n".join(
+            [n.node.get_content(metadata_mode=MetadataMode.LLM).strip() for n in nodes]
+        )
+
+        return self._context_template.format(context_str=context_str)
+
+    def _get_prefix_messages_with_context(
+        self, context_str_template: str
+    ) -> List[ChatMessage]:
+        """Get the prefix messages with context"""
+
+        # ensure we grab the user-configured system prompt
+        system_prompt = ""
+        prefix_messages = self._prefix_messages
+        if (
+            len(self._prefix_messages) != 0
+            and self._prefix_messages[0].role == "system"
+        ):
+            system_prompt = str(self._prefix_messages[0].content)
+            prefix_messages = self._prefix_messages[1:]
+
+        context_str = context_str_template.format(system_prompt=system_prompt)
+        return [ChatMessage(content=context_str, role="system")] + prefix_messages
+
+    def chat(
+        self, message: str, chat_history: Optional[List[ChatMessage]] = None
+    ) -> AgentChatResponse:
+        if chat_history is not None:
+            self._memory.set(chat_history)
+        self._memory.put(ChatMessage(content=message, role="user"))
+
+        context_str_template = self._generate_context(message)
+        prefix_messages = self._get_prefix_messages_with_context(context_str_template)
+        all_messages = prefix_messages + self._memory.get()
+
+        chat_response = self._llm.chat(all_messages)
+        ai_message = chat_response.message
+        self._memory.put(ai_message)
+
+        return AgentChatResponse(
+            response=str(chat_response.message.content),
+            sources=[
+                ToolOutput(
+                    tool_name="retriever",
+                    content=str(prefix_messages[0]),
+                    raw_input={"message": message},
+                    raw_output=prefix_messages[0],
+                )
+            ],
+        )
+
+    def stream_chat(
+        self, message: str, chat_history: Optional[List[ChatMessage]] = None
+    ) -> StreamingAgentChatResponse:
+        if chat_history is not None:
+            self._memory.set(chat_history)
+        self._memory.put(ChatMessage(content=message, role="user"))
+
+        context_str_template = self._generate_context(message)
+        prefix_messages = self._get_prefix_messages_with_context(context_str_template)
+        all_messages = prefix_messages + self._memory.get()
+
+        chat_response = StreamingAgentChatResponse(
+            chat_stream=self._llm.stream_chat(all_messages),
+            sources=[
+                ToolOutput(
+                    tool_name="retriever",
+                    content=str(prefix_messages[0]),
+                    raw_input={"message": message},
+                    raw_output=prefix_messages[0],
+                )
+            ],
+        )
+        thread = Thread(
+            target=chat_response.write_response_to_history, args=(self._memory,)
+        )
+        thread.start()
+
+        return chat_response
+
+    async def achat(
+        self, message: str, chat_history: Optional[List[ChatMessage]] = None
+    ) -> AgentChatResponse:
+        if chat_history is not None:
+            self._memory.set(chat_history)
+        self._memory.put(ChatMessage(content=message, role="user"))
+
+        context_str_template = await self._agenerate_context(message)
+        prefix_messages = self._get_prefix_messages_with_context(context_str_template)
+        all_messages = prefix_messages + self._memory.get()
+
+        chat_response = await self._llm.achat(all_messages)
+        ai_message = chat_response.message
+        self._memory.put(ai_message)
+
+        return AgentChatResponse(
+            response=str(chat_response.message.content),
+            sources=[
+                ToolOutput(
+                    tool_name="retriever",
+                    content=str(prefix_messages[0]),
+                    raw_input={"message": message},
+                    raw_output=prefix_messages[0],
+                )
+            ],
+        )
+
+    async def astream_chat(
+        self, message: str, chat_history: Optional[List[ChatMessage]] = None
+    ) -> StreamingAgentChatResponse:
+        if chat_history is not None:
+            self._memory.set(chat_history)
+        self._memory.put(ChatMessage(content=message, role="user"))
+
+        context_str_template = await self._agenerate_context(message)
+        prefix_messages = self._get_prefix_messages_with_context(context_str_template)
+        all_messages = prefix_messages + self._memory.get()
+
+        chat_response = StreamingAgentChatResponse(
+            chat_stream=self._llm.stream_chat(all_messages),
+            sources=[
+                ToolOutput(
+                    tool_name="retriever",
+                    content=str(prefix_messages[0]),
+                    raw_input={"message": message},
+                    raw_output=prefix_messages[0],
+                )
+            ],
+        )
+        thread = Thread(
+            target=lambda x: asyncio.run(chat_response.awrite_response_to_history(x)),
+            args=(self._memory,),
+        )
+        thread.start()
+
+        return chat_response
+
+    def reset(self) -> None:
+        self._memory.reset()
+
+    @property
+    def chat_history(self) -> List[ChatMessage]:
+        """Get chat history."""
+        return self._memory.get_all()

--- a/llama_index/chat_engine/types.py
+++ b/llama_index/chat_engine/types.py
@@ -178,6 +178,13 @@ class ChatMode(str, Enum):
     then query the query engine for a response.
     """
 
+    CONTEXT = "context"
+    """Corresponds to `ContextChatEngine`.
+    
+    First retrieve text from the index using the user's message, then use the context
+    in the system prompt to generate a response.
+    """
+
     REACT = "react"
     """Corresponds to `ReActAgent`.
     

--- a/llama_index/indices/base.py
+++ b/llama_index/indices/base.py
@@ -367,6 +367,14 @@ class BaseIndex(Generic[IS], ABC):
                 query_engine=query_engine,
                 **kwargs,
             )
+        elif chat_mode == ChatMode.CONTEXT:
+            from llama_index.chat_engine import ContextChatEngine
+
+            return ContextChatEngine.from_defaults(
+                retriever=self.as_retriever(**kwargs),
+                **kwargs,
+            )
+
         elif chat_mode in [ChatMode.REACT, ChatMode.OPENAI]:
             # NOTE: lazy import
             from llama_index.agent import OpenAIAgent, ReActAgent


### PR DESCRIPTION
# Description

Add a `ContextChatEngine` that always uses the index and inserts retrieved text into the system prompt.

This is a little better than all current chat engines, because it requires a single LLM call and the chat engine can respond to both normal interactions and knowledge base queries.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
