### PR TITLE
Add source_nodes to chat response.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Validate openai key on init (#6940)
 - Added async embeddings and async RetrieverQueryEngine (#6587)
 - Added async `aquery` and `async_add` to PGVectorStore (#7031)
+- Added `.source_nodes` attribute to chat engine and agent responses (#7029)
 
 ### Bug Fixes / Nits
 - Fix achat memory initialization for data agents (#7000)

--- a/llama_index/chat_engine/condense_question.py
+++ b/llama_index/chat_engine/condense_question.py
@@ -186,10 +186,7 @@ class CondenseQuestionChatEngine(BaseChatEngine):
             ChatMessage(role=MessageRole.ASSISTANT, content=str(query_response))
         )
 
-        return AgentChatResponse(
-            response=str(query_response),
-            sources=[tool_output]
-        )
+        return AgentChatResponse(response=str(query_response), sources=[tool_output])
 
     def stream_chat(
         self, message: str, chat_history: Optional[List[ChatMessage]] = None
@@ -233,7 +230,7 @@ class CondenseQuestionChatEngine(BaseChatEngine):
             self._memory.put(ChatMessage(role=MessageRole.USER, content=message))
             response = StreamingAgentChatResponse(
                 chat_stream=response_gen_from_query_engine(query_response.response_gen),
-                sources=[tool_output]
+                sources=[tool_output],
             )
             thread = Thread(
                 target=response.write_response_to_history, args=(self._memory,)

--- a/llama_index/chat_engine/condense_question.py
+++ b/llama_index/chat_engine/condense_question.py
@@ -188,8 +188,7 @@ class CondenseQuestionChatEngine(BaseChatEngine):
 
         return AgentChatResponse(
             response=str(query_response),
-            sources=[tool_output],
-            source_nodes=query_response.source_nodes
+            sources=[tool_output]
         )
 
     def stream_chat(
@@ -234,8 +233,7 @@ class CondenseQuestionChatEngine(BaseChatEngine):
             self._memory.put(ChatMessage(role=MessageRole.USER, content=message))
             response = StreamingAgentChatResponse(
                 chat_stream=response_gen_from_query_engine(query_response.response_gen),
-                sources=[tool_output],
-                source_nodes=query_response.source_nodes
+                sources=[tool_output]
             )
             thread = Thread(
                 target=response.write_response_to_history, args=(self._memory,)

--- a/llama_index/chat_engine/condense_question.py
+++ b/llama_index/chat_engine/condense_question.py
@@ -186,7 +186,11 @@ class CondenseQuestionChatEngine(BaseChatEngine):
             ChatMessage(role=MessageRole.ASSISTANT, content=str(query_response))
         )
 
-        return AgentChatResponse(response=str(query_response), sources=[tool_output])
+        return AgentChatResponse(
+            response=str(query_response),
+            sources=[tool_output],
+            source_nodes=query_response.source_nodes
+        )
 
     def stream_chat(
         self, message: str, chat_history: Optional[List[ChatMessage]] = None
@@ -231,6 +235,7 @@ class CondenseQuestionChatEngine(BaseChatEngine):
             response = StreamingAgentChatResponse(
                 chat_stream=response_gen_from_query_engine(query_response.response_gen),
                 sources=[tool_output],
+                source_nodes=query_response.source_nodes
             )
             thread = Thread(
                 target=response.write_response_to_history, args=(self._memory,)

--- a/llama_index/chat_engine/types.py
+++ b/llama_index/chat_engine/types.py
@@ -8,6 +8,7 @@ from typing import Generator, List, Optional
 from llama_index.llms.base import ChatMessage, ChatResponseAsyncGen, ChatResponseGen
 from llama_index.memory import BaseMemory
 from llama_index.tools import ToolOutput
+from llama_index.response.schema import Response, StreamingResponse
 from llama_index.schema import NodeWithScore
 
 logger = logging.getLogger(__name__)
@@ -19,7 +20,15 @@ class AgentChatResponse:
 
     response: str = ""
     sources: List[ToolOutput] = field(default_factory=list)
-    source_nodes: List[NodeWithScore] = field(default_factory=list)
+    _nodes: List[NodeWithScore] = None
+    @property
+    def source_nodes(self) -> List[NodeWithScore]:
+        if self._nodes is None:
+            self._nodes = []
+            for tool_output in self.sources:
+                if isinstance(tool_output.raw_output, Response):
+                    self._nodes.extend(tool_output.raw_output.source_nodes)
+        return self._nodes
 
     def __str__(self) -> str:
         return self.response
@@ -31,12 +40,21 @@ class StreamingAgentChatResponse:
 
     response: str = ""
     sources: List[ToolOutput] = field(default_factory=list)
-    source_nodes: List[NodeWithScore] = field(default_factory=list)
+    _nodes: List[NodeWithScore] = None
     chat_stream: Optional[ChatResponseGen] = None
     achat_stream: Optional[ChatResponseAsyncGen] = None
     _queue: queue.Queue = queue.Queue()
     _is_done = False
     _is_function: Optional[bool] = None
+
+    @property
+    def source_nodes(self) -> List[NodeWithScore]:
+        if self._nodes is None:
+            self._nodes = []
+            for tool_output in self.sources:
+                if isinstance(tool_output.raw_output, StreamingResponse):
+                    self._nodes.extend(tool_output.raw_output.source_nodes)
+        return self._nodes
 
     def __str__(self) -> str:
         if self._is_done and not self._queue.empty() and not self._is_function:
@@ -56,8 +74,8 @@ class StreamingAgentChatResponse:
             for chat in self.chat_stream:
                 final_message = chat.message
                 self._is_function = (
-                    final_message.additional_kwargs.get("function_call", None)
-                    is not None
+                        final_message.additional_kwargs.get("function_call", None)
+                        is not None
                 )
                 self._queue.put_nowait(chat.delta)
 
@@ -82,8 +100,8 @@ class StreamingAgentChatResponse:
             async for chat in self.achat_stream:
                 final_message = chat.message
                 self._is_function = (
-                    final_message.additional_kwargs.get("function_call", None)
-                    is not None
+                        final_message.additional_kwargs.get("function_call", None)
+                        is not None
                 )
                 self._queue.put_nowait(chat.delta)
 
@@ -117,28 +135,28 @@ class BaseChatEngine(ABC):
 
     @abstractmethod
     def chat(
-        self, message: str, chat_history: Optional[List[ChatMessage]] = None
+            self, message: str, chat_history: Optional[List[ChatMessage]] = None
     ) -> AgentChatResponse:
         """Main chat interface."""
         pass
 
     @abstractmethod
     def stream_chat(
-        self, message: str, chat_history: Optional[List[ChatMessage]] = None
+            self, message: str, chat_history: Optional[List[ChatMessage]] = None
     ) -> StreamingAgentChatResponse:
         """Stream chat interface."""
         pass
 
     @abstractmethod
     async def achat(
-        self, message: str, chat_history: Optional[List[ChatMessage]] = None
+            self, message: str, chat_history: Optional[List[ChatMessage]] = None
     ) -> AgentChatResponse:
         """Async version of main chat interface."""
         pass
 
     @abstractmethod
     async def astream_chat(
-        self, message: str, chat_history: Optional[List[ChatMessage]] = None
+            self, message: str, chat_history: Optional[List[ChatMessage]] = None
     ) -> StreamingAgentChatResponse:
         """Async version of main chat interface."""
         pass

--- a/llama_index/chat_engine/types.py
+++ b/llama_index/chat_engine/types.py
@@ -8,6 +8,7 @@ from typing import Generator, List, Optional
 from llama_index.llms.base import ChatMessage, ChatResponseAsyncGen, ChatResponseGen
 from llama_index.memory import BaseMemory
 from llama_index.tools import ToolOutput
+from llama_index.schema import NodeWithScore
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +19,7 @@ class AgentChatResponse:
 
     response: str = ""
     sources: List[ToolOutput] = field(default_factory=list)
+    source_nodes: List[NodeWithScore] = field(default_factory=list)
 
     def __str__(self) -> str:
         return self.response
@@ -29,6 +31,7 @@ class StreamingAgentChatResponse:
 
     response: str = ""
     sources: List[ToolOutput] = field(default_factory=list)
+    source_nodes: List[NodeWithScore] = field(default_factory=list)
     chat_stream: Optional[ChatResponseGen] = None
     achat_stream: Optional[ChatResponseAsyncGen] = None
     _queue: queue.Queue = queue.Queue()


### PR DESCRIPTION
# Description

AgentChatResponse and StreamingAgentChatResponse from condensed question give direct access to source nodes, just like Response and StreamingResponse.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
