### PR TITLE
improve json parsing

### DIFF
--- a/llama_index/output_parsers/selection.py
+++ b/llama_index/output_parsers/selection.py
@@ -5,6 +5,7 @@ from typing import Any
 from dataclasses_json import DataClassJsonMixin
 
 from llama_index.output_parsers.base import StructuredOutput
+from llama_index.output_parsers.utils import _marshal_llm_to_json
 from llama_index.types import BaseOutputParser
 
 
@@ -47,34 +48,8 @@ class Answer(DataClassJsonMixin):
 
 
 class SelectionOutputParser(BaseOutputParser):
-    def _marshal_llm_to_json(self, output: str) -> str:
-        """Extract a valid JSON object or array from a string.
-        Extracts a substring that represents a valid JSON object or array.
-
-        Args:
-            output: A string that may contain a valid JSON object or array surrounded by
-            extraneous characters or information.
-
-        Returns:
-            A string representing a valid JSON object or array.
-
-        """
-        output = output.strip()
-        left_square = output.find("[")
-        left_brace = output.find("{")
-
-        if left_square < left_brace:
-            left = left_square
-            right = output.rfind("]")
-        else:
-            left = left_brace
-            right = output.rfind("}")
-
-        output = output[left : right + 1]
-        return output
-
     def parse(self, output: str) -> Any:
-        output = self._marshal_llm_to_json(output)
+        output = _marshal_llm_to_json(output)
         json_output = json.loads(output)
         if isinstance(json_output, dict):
             json_output = [json_output]

--- a/llama_index/output_parsers/utils.py
+++ b/llama_index/output_parsers/utils.py
@@ -7,14 +7,39 @@ import yaml
 from llama_index.output_parsers.base import OutputParserException
 
 
-def parse_json_markdown(text: str) -> Any:
-    if "```json" not in text:
-        raise OutputParserException(
-            f"Got invalid return object. Expected markdown code snippet with JSON "
-            f"object, but got:\n{text}"
-        )
+def _marshal_llm_to_json(output: str) -> str:
+    """Extract a valid JSON object or array from a string.
+    Extracts a substring that represents a valid JSON object or array.
 
-    json_string = text.split("```json")[1].strip().strip("```").strip()
+    Args:
+        output: A string that may contain a valid JSON object or array surrounded by
+        extraneous characters or information.
+
+    Returns:
+        A string representing a valid JSON object or array.
+
+    """
+    output = output.strip()
+    left_square = output.find("[")
+    left_brace = output.find("{")
+
+    if left_square < left_brace:
+        left = left_square
+        right = output.rfind("]")
+    else:
+        left = left_brace
+        right = output.rfind("}")
+
+    output = output[left : right + 1]
+    return output
+
+
+def parse_json_markdown(text: str) -> Any:
+    if "```json" in text:
+        json_string = text.split("```json")[1].strip().strip("```").strip()
+    else:
+        json_string = _marshal_llm_to_json(text)
+
     try:
         json_obj = json.loads(json_string)
     except json.JSONDecodeError as e_json:
@@ -26,7 +51,8 @@ def parse_json_markdown(text: str) -> Any:
             json_obj = yaml.safe_load(json_string)
         except yaml.YAMLError as e_yaml:
             raise OutputParserException(
-                f"Got invalid JSON object. Error: {e_json} {e_yaml}"
+                f"Got invalid JSON object. Error: {e_json} {e_yaml}. "
+                f"Got JSON string: {json_string}"
             )
 
     return json_obj


### PR DESCRIPTION
# Description

Our current json parsing for sub-questions is very strict. We can handle the case where the JSON markdown is missing pretty easily. This helps especially for open-source LLMs like llama-2.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense
