### PR TITLE
tune prompt to get rid of KeyError in SubQ engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## Unreleased
+
+### Bug Fixes / Nits
+- tune prompt to get rid of KeyError in SubQ engine (#7039)
+
 ## [0.7.12] - 2023-07-25
 
 ### New Features

--- a/llama_index/question_gen/openai_generator.py
+++ b/llama_index/question_gen/openai_generator.py
@@ -19,7 +19,8 @@ You are a world class state of the art agent.
 
 You have access to multiple tools, each representing a different data source or API.
 Each of the tools has a name and a description, formatted as a JSON dictionary.
-The keys of the dictionary are the names of the tools and the values are the descriptions.
+The keys of the dictionary are the names of the tools and the values are the \
+descriptions.
 Your purpose is to help answer a complex user question by generating a list of sub \
 questions that can be answered by the tools.
 

--- a/llama_index/question_gen/openai_generator.py
+++ b/llama_index/question_gen/openai_generator.py
@@ -18,7 +18,8 @@ DEFAULT_OPENAI_SUB_QUESTION_PROMPT_TMPL = """\
 You are a world class state of the art agent.
 
 You have access to multiple tools, each representing a different data source or API.
-Each of the tools has a name and a description, formatted as JSON.
+Each of the tools has a name and a description, formatted as a JSON dictionary.
+The keys of the dictionary are the names of the tools and the values are the descriptions.
 Your purpose is to help answer a complex user question by generating a list of sub \
 questions that can be answered by the tools.
 
@@ -27,6 +28,7 @@ These are the guidelines you consider when completing your task:
 * The sub questions should be relevant to the user question 
 * The sub questions should be answerable by the tools provided
 * You can generate multiple sub questions for each tool
+* Tools must be specified by their name, not their description
 * You don't need to use a tool if you don't think it's relevant
 
 Output the list of sub questions by calling the SubQuestionList function.


### PR DESCRIPTION
# Description

I was finding that the SubQuestionQueryEngine was running into a `KeyError` on [this line](https://github.com/jerryjliu/llama_index/blob/main/llama_index/query_engine/sub_question_query_engine.py#L222) because the LLM was specifying the tool to use by it's description rather than it's tool name.

Making the Question Generation prompt here more explicit about how the tool names/description JSON is structured and how it should specify the tool.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
