### PR TITLE
improve context engine string formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## Unreleased
+
+### Bug Fixes / Nits
+- Fix string formatting in context chat engine (#7050)
+
 ## [0.7.13] - 2023-07-26
 
 ### New Features


### PR DESCRIPTION
# Description

If the retrieved context has any special characters, it will mess up the string formatting for the system prompt.

This change skips the formatting in favour of appending strings.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense
