### PR TITLE
chore: optimization on kg store and index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bug Fixes / Nits
 - Fix string formatting in context chat engine (#7050)
+- Less strict triplet extraction for KGs (#7059)
+- Add configurable limit to KG data retrieved (#7059)
+- Nebula connection improvements (#7059)
 
 ## [0.7.13] - 2023-07-26
 

--- a/llama_index/graph_stores/nebulagraph.py
+++ b/llama_index/graph_stores/nebulagraph.py
@@ -316,7 +316,7 @@ class NebulaGraphStore(GraphStore):
             #       REDUCE(acc = collect(NULL), l in rels | acc + l) AS flattened_rels
             # RETURN
             #   subj,
-            #   REDUCE(acc = subj, l in flattened_rels | acc + ', ' + l ) AS flattened_rels
+            #   REDUCE(acc = subj,l in flattened_rels|acc + ', ' + l) AS flattened_rels
             query = (
                 f"MATCH (s)-[e:`{self._edge_types[0]}`*..{depth}]-() "
                 f"  WHERE id(s) IN $subjs "

--- a/llama_index/graph_stores/nebulagraph.py
+++ b/llama_index/graph_stores/nebulagraph.py
@@ -10,8 +10,8 @@ from llama_index.graph_stores.types import GraphStore
 
 QUOTE = '"'
 RETRY_TIMES = 3
-WAIT_MIN_SECONDS = 0.1
-WAIT_MAX_SECONDS = 20
+WAIT_MIN_SECONDS = 0.5
+WAIT_MAX_SECONDS = 10
 
 logger = logging.getLogger(__name__)
 
@@ -311,9 +311,12 @@ class NebulaGraphStore(GraphStore):
         if len(self._edge_types) == 1:
             # MATCH (s)-[e:follow*..2]-() WHERE id(s) IN ["player100", "player101"]
             #   WITH id(s) AS subj, [rel in e | [rel.degree, dst(rel)] ] AS rels
+            #   WITH
+            #       subj,
+            #       REDUCE(acc = collect(NULL), l in rels | acc + l) AS flattened_rels
             # RETURN
             #   subj,
-            #   REDUCE(acc = collect(NULL), l in rels | acc + l) AS flattened_rels
+            #   REDUCE(acc = subj, l in flattened_rels | acc + ', ' + l ) AS flattened_rels
             query = (
                 f"MATCH (s)-[e:`{self._edge_types[0]}`*..{depth}]-() "
                 f"  WHERE id(s) IN $subjs "
@@ -322,9 +325,13 @@ class NebulaGraphStore(GraphStore):
                 f"[rel IN e | "
                 f"  [rel.`{self._rel_prop_names[0]}`, dst(rel)] "
                 f"] AS rels "
-                f"RETURN "
+                f"WITH "
                 f"  subj,"
                 f"  REDUCE(acc = collect(NULL), l in rels | acc + l)"
+                f"    AS flattened_rels"
+                f" RETURN"
+                f"  subj,"
+                f"  REDUCE(acc = subj, l in flattened_rels | acc + ', ' + l )"
                 f"    AS flattened_rels"
             )
         else:
@@ -333,14 +340,19 @@ class NebulaGraphStore(GraphStore):
             # MATCH (s)-[e:follow|serve*..2]-()
             # WHERE id(s) IN ["player100", "player101"]
             #   WITH id(s) AS subj,
-            # [rel in e | [CASE type(rel)
+            #        [rel in e | [CASE type(rel)
             #     WHEN "follow" THEN rel.degree
             #     WHEN "serve" THEN rel.start_year
             #     END, dst(rel)] ]
             #     AS rels
+            #   WITH
+            #     subj,
+            #     REDUCE(acc = collect(NULL), l in rels | acc + l) AS
+            #       flattened_rels
             # RETURN
             #   subj,
-            #   REDUCE(acc = collect(NULL), l in rels | acc + l) AS flattened_rels
+            #   REDUCE(acc = subj, l in flattened_rels | acc + ', ' + l ) AS
+            #       flattened_rels
             _case_when_string = "".join(
                 [
                     f"WHEN {QUOTE}{edge_type}{QUOTE} THEN rel.`{rel_prop_name}` "
@@ -352,16 +364,21 @@ class NebulaGraphStore(GraphStore):
             query = (
                 f"MATCH (s)-[e:`{'`|`'.join(self._edge_types)}`*..{depth}]-() "
                 f"  WHERE id(s) IN $subjs "
-                f"WITH "
-                f"id(s) AS subj,"
-                f"[rel IN e | "
+                f"  WITH "
+                f"    id(s) AS subj,"
+                f" [rel IN e | "
                 f"  [CASE type(rel) "
                 f"  {_case_when_string}"
                 f"  END, dst(rel)] "
                 f"] AS rels "
+                f"  WITH"
+                f"    subj,"
+                f"    REDUCE(acc = collect(NULL), l in rels | acc + l) AS "
+                f"        flattened_rels"
                 f"RETURN"
                 f"  subj,"
-                f"  REDUCE(acc = collect(NULL), l in rels | acc + l) AS flattened_rels"
+                f"  REDUCE(acc = subj, l in flattened_rels | acc + ', ' + l ) AS "
+                f"      flattened_rels"
             )
         subjs_param = prepare_subjs_param(subjs)
         logger.debug(f"get_flat_rel_map() subjs_param: {subjs}, query: {query}")
@@ -389,7 +406,6 @@ class NebulaGraphStore(GraphStore):
         # SimpleGraphStore.get_rel_map() though.
         # But this makes more sense for multi-hop relation path.
 
-        # lower case subjs
         if subjs is not None:
             subjs = [escape_str(subj) for subj in subjs]
             if len(subjs) == 0:

--- a/llama_index/indices/knowledge_graph/retriever.py
+++ b/llama_index/indices/knowledge_graph/retriever.py
@@ -269,8 +269,8 @@ class KGTableRetriever(BaseRetriever):
         # add relationships as Node
         # TODO: make initial text customizable
         rel_initial_text = (
-            f"The following are knowledge sequence in"
-            f" {self.graph_store_query_depth}-depth "
+            f"The following are knowledge sequence in max depth"
+            f" {self.graph_store_query_depth} "
             f"in the form of "
             f"`subject [predicate, object, predicate_next_hop, object_next_hop ...]`"
         )

--- a/llama_index/indices/knowledge_graph/retriever.py
+++ b/llama_index/indices/knowledge_graph/retriever.py
@@ -66,6 +66,8 @@ class KGTableRetriever(BaseRetriever):
         use_global_node_triplets (bool): Whether to get more keywords(entities) from
             text chunks matched by keywords. This helps introduce more global knowledge.
             While it's more expensive, thus to be turned off by default.
+        max_knowledge_sequence (int): The maximum number of knowledge sequence to
+            include in the response. By default, it's 30.
     """
 
     def __init__(
@@ -79,6 +81,7 @@ class KGTableRetriever(BaseRetriever):
         similarity_top_k: int = 2,
         graph_store_query_depth: int = 2,
         use_global_node_triplets: bool = False,
+        max_knowledge_sequence: int = REL_TEXT_LIMIT,
         **kwargs: Any,
     ) -> None:
         """Initialize params."""
@@ -99,6 +102,7 @@ class KGTableRetriever(BaseRetriever):
         self._graph_store = index.graph_store
         self.graph_store_query_depth = graph_store_query_depth
         self.use_global_node_triplets = use_global_node_triplets
+        self.max_knowledge_sequence = max_knowledge_sequence
 
     def _get_keywords(self, query_str: str) -> List[str]:
         """Extract keywords."""
@@ -226,8 +230,8 @@ class KGTableRetriever(BaseRetriever):
                         rel_texts[j] = ""
             rel_texts = [rel_text for rel_text in rel_texts if rel_text != ""]
 
-            # truncate rel_texts to REL_TEXT_LIMIT
-            rel_texts = rel_texts[:REL_TEXT_LIMIT]
+            # tuncate rel_texts
+            rel_texts = rel_texts[: self.max_knowledge_sequence]
 
         sorted_chunk_indices = sorted(
             list(chunk_indices_count.keys()),
@@ -255,12 +259,18 @@ class KGTableRetriever(BaseRetriever):
                 f"> Querying with idx: {chunk_idx}: "
                 f"{truncate_text(node.get_content(), 80)}"
             )
+        # if no relationship is found, return the nodes found by keywords
+        if not rel_texts:
+            logger.info("> No relationships found, returning nodes found by keywords.")
+            if len(sorted_nodes_with_scores) == 0:
+                logger.info("> No nodes found by keywords, returning empty response.")
+            return sorted_nodes_with_scores
 
         # add relationships as Node
         # TODO: make initial text customizable
         rel_initial_text = (
-            f"The following are knowledge triplets in max depth"
-            f" {self.graph_store_query_depth} "
+            f"The following are knowledge sequence in"
+            f" {self.graph_store_query_depth}-depth "
             f"in the form of "
             f"`subject [predicate, object, predicate_next_hop, object_next_hop ...]`"
         )

--- a/tests/indices/knowledge_graph/test_retrievers.py
+++ b/tests/indices/knowledge_graph/test_retrievers.py
@@ -31,11 +31,7 @@ def test_as_retriever(
     # when include_text is True, the first node is the raw text
     # the second node is the query
     rel_initial_text = (
-        "The following are knowledge triplets "
-        "in the form of (subset, predicate, object):\n"
-    )
-    rel_initial_text = (
-        f"The following are knowledge triplets in max depth"
+        f"The following are knowledge sequence in max depth"
         f" {retriever.graph_store_query_depth} "
         f"in the form of "
         f"`subject [predicate, object, predicate_next_hop, object_next_hop ...]`"
@@ -70,7 +66,7 @@ def test_retrievers(
     nodes = retriever.retrieve(query_bundle)
     assert (
         nodes[1].node.get_content()
-        == "The following are knowledge triplets in max depth 2"
+        == "The following are knowledge sequence in max depth 2"
         " in the form of "
         "`subject [predicate, object, predicate_next_hop, object_next_hop ...]`"
         "\nfoo ['is', 'bar']"
@@ -102,7 +98,7 @@ def test_retriever_no_text(
     nodes = retriever.retrieve(query_bundle)
     assert (
         nodes[0].node.get_content()
-        == "The following are knowledge triplets in max depth 2"
+        == "The following are knowledge sequence in max depth 2"
         " in the form of "
         "`subject [predicate, object, predicate_next_hop, object_next_hop ...]`"
         "\nfoo ['is', 'bar']"
@@ -135,7 +131,7 @@ def test_retrieve_similarity(
     nodes = retriever.retrieve(QueryBundle("foo"))
     assert (
         nodes[1].node.get_content()
-        == "The following are knowledge triplets in max depth 2"
+        == "The following are knowledge sequence in max depth 2"
         " in the form of "
         "`subject [predicate, object, predicate_next_hop, object_next_hop ...]`"
         "\nfoo ['is', 'bar']"


### PR DESCRIPTION
# Description

- optimized NebulaGraph store session reconnection
- optimized Grpah RAG NebulaGraph Store retrieval format, the better format is easier to vis the metadata, too
- optimized triplets extraction impl. when testing local LLM models
- `max_knowledge_sequence` is not an opt-configurable arg for kg retriever, this prevents from the super-node(huge KG context) explode, with a safer default configuration
- fix the case when no KG was retrieved, an empty prompt node was added.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
