### PR TITLE
Fix source_nodes in chat responses.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Less strict triplet extraction for KGs (#7059)
 - Add configurable limit to KG data retrieved (#7059)
 - Nebula connection improvements (#7059)
+- Bug fix in building source nodes for agent response (#7067)
 
 ## [0.7.13] - 2023-07-26
 

--- a/llama_index/chat_engine/types.py
+++ b/llama_index/chat_engine/types.py
@@ -24,7 +24,7 @@ class AgentChatResponse:
 
     @property
     def source_nodes(self) -> List[NodeWithScore]:
-        if self._nodes is None:
+        if not self._nodes:
             self._nodes = []
             for tool_output in self.sources:
                 if isinstance(tool_output.raw_output, RESPONSE_TYPE):
@@ -50,7 +50,7 @@ class StreamingAgentChatResponse:
 
     @property
     def source_nodes(self) -> List[NodeWithScore]:
-        if self._nodes is None:
+        if not self._nodes:
             self._nodes = []
             for tool_output in self.sources:
                 if isinstance(tool_output.raw_output, RESPONSE_TYPE):

--- a/llama_index/chat_engine/types.py
+++ b/llama_index/chat_engine/types.py
@@ -8,7 +8,7 @@ from typing import Generator, List, Optional
 from llama_index.llms.base import ChatMessage, ChatResponseAsyncGen, ChatResponseGen
 from llama_index.memory import BaseMemory
 from llama_index.tools import ToolOutput
-from llama_index.response.schema import RESPONSE_TYPE
+from llama_index.response.schema import Response, StreamingResponse
 from llama_index.schema import NodeWithScore
 
 logger = logging.getLogger(__name__)
@@ -27,7 +27,7 @@ class AgentChatResponse:
         if not self._nodes:
             self._nodes = []
             for tool_output in self.sources:
-                if isinstance(tool_output.raw_output, RESPONSE_TYPE):
+                if isinstance(tool_output.raw_output, (Response, StreamingResponse)):
                     self._nodes.extend(tool_output.raw_output.source_nodes)
         return self._nodes
 
@@ -53,7 +53,7 @@ class StreamingAgentChatResponse:
         if not self._nodes:
             self._nodes = []
             for tool_output in self.sources:
-                if isinstance(tool_output.raw_output, RESPONSE_TYPE):
+                if isinstance(tool_output.raw_output, (Response, StreamingResponse)):
                     self._nodes.extend(tool_output.raw_output.source_nodes)
         return self._nodes
 


### PR DESCRIPTION
# Description

AgentChatResponse and StreamingAgentResponse had a bug created by #7029. Due to some linting changes, the `if` statement makes it so that the `source_nodes` property is always empty even when there are sources available.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
