### PR TITLE
feat: optmization of KG index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added HotpotQADistractor benchmark evaluator (#7034)
 - Add metadata filter and delete support for LanceDB (#7048)
 - Use MetadataFilters in opensearch (#7005)
+- Added `kg_triplet_extract_fn` to customize how KGs are built (#7068)
 
 ### Bug Fixes / Nits
 - Fix string formatting in context chat engine (#7050)

--- a/llama_index/indices/knowledge_graph/base.py
+++ b/llama_index/indices/knowledge_graph/base.py
@@ -80,10 +80,7 @@ class KnowledgeGraphIndex(BaseIndex[KG]):
             )
         )
         self._max_object_length = max_object_length
-        if kg_triplet_extract_fn is not None:
-            self._extract_triplets = kg_triplet_extract_fn
-        else:
-            self._extract_triplets = self._llm_extract_triplets
+        self._kg_triplet_extract_fn = kg_triplet_extract_fn
 
         super().__init__(
             nodes=nodes,
@@ -117,6 +114,12 @@ class KnowledgeGraphIndex(BaseIndex[KG]):
             kwargs["retriever_mode"] = KGRetrieverMode.HYBRID
 
         return KGTableRetriever(self, **kwargs)
+
+    def _extract_triplets(self, text: str) -> List[Tuple[str, str, str]]:
+        if self._kg_triplet_extract_fn is not None:
+            return self._kg_triplet_extract_fn(text)
+        else:
+            return self._llm_extract_triplets(text)
 
     def _llm_extract_triplets(self, text: str) -> List[Tuple[str, str, str]]:
         """Extract keywords from text."""

--- a/llama_index/indices/knowledge_graph/base.py
+++ b/llama_index/indices/knowledge_graph/base.py
@@ -9,7 +9,7 @@ existing keywords in the table.
 """
 
 import logging
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 from llama_index.constants import GRAPH_STORE_KEY
 from llama_index.data_structs.data_structs import KG
@@ -37,8 +37,16 @@ class KnowledgeGraphIndex(BaseIndex[KG]):
         kg_triple_extract_template (KnowledgeGraphPrompt): The prompt to use for
             extracting triplets.
         max_triplets_per_chunk (int): The maximum number of triplets to extract.
+        service_context (Optional[ServiceContext]): The service context to use.
+        storage_context (Optional[StorageContext]): The storage context to use.
         graph_store (Optional[GraphStore]): The graph store to use.
         show_progress (bool): Whether to show tqdm progress bars. Defaults to False.
+        include_embeddings (bool): Whether to include embeddings in the index.
+            Defaults to False.
+        max_object_length (int): The maximum length of the object in a triplet.
+            Defaults to 128.
+        kg_triplet_extract_fn (Optional[Callable]): The function to use for
+            extracting triplets. Defaults to None.
 
     """
 
@@ -54,6 +62,8 @@ class KnowledgeGraphIndex(BaseIndex[KG]):
         max_triplets_per_chunk: int = 10,
         include_embeddings: bool = False,
         show_progress: bool = False,
+        max_object_length: int = 128,
+        kg_triplet_extract_fn: Optional[Callable] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize params."""
@@ -69,6 +79,11 @@ class KnowledgeGraphIndex(BaseIndex[KG]):
                 max_knowledge_triplets=self.max_triplets_per_chunk
             )
         )
+        self._max_object_length = max_object_length
+        if kg_triplet_extract_fn is not None:
+            self._extract_triplets = kg_triplet_extract_fn
+        else:
+            self._extract_triplets = self._llm_extract_triplets
 
         super().__init__(
             nodes=nodes,
@@ -103,16 +118,20 @@ class KnowledgeGraphIndex(BaseIndex[KG]):
 
         return KGTableRetriever(self, **kwargs)
 
-    def _extract_triplets(self, text: str) -> List[Tuple[str, str, str]]:
+    def _llm_extract_triplets(self, text: str) -> List[Tuple[str, str, str]]:
         """Extract keywords from text."""
         response = self._service_context.llm_predictor.predict(
             self.kg_triple_extract_template,
             text=text,
         )
-        return self._parse_triplet_response(response)
+        return self._parse_triplet_response(
+            response, max_length=self._max_object_length
+        )
 
     @staticmethod
-    def _parse_triplet_response(response: str) -> List[Tuple[str, str, str]]:
+    def _parse_triplet_response(
+        response: str, max_length: int = 128
+    ) -> List[Tuple[str, str, str]]:
         knowledge_strs = response.strip().split("\n")
         results = []
         for text in knowledge_strs:
@@ -122,6 +141,15 @@ class KnowledgeGraphIndex(BaseIndex[KG]):
             tokens = text[1:-1].split(",")
             if len(tokens) != 3:
                 continue
+
+            if any(len(s.encode("utf-8")) > max_length for s in tokens):
+                # We count byte-length instead of len() for UTF-8 chars,
+                # will skip if any of the tokens are too long.
+                # This is normally due to a poorly formatted triplet
+                # extraction, in more serious KG building cases
+                # we'll need NLP models to better extract triplets.
+                continue
+
             subj, pred, obj = map(str.strip, tokens)
             if not subj or not pred or not obj:
                 # skip partial triplets


### PR DESCRIPTION
- added object length limiation fo triplet extaction
- added triplet extract function option to enable non-llm based extractor `*`

`*` for this, I just add a callable optional argument to avoid extra layer of abstractions brought to llama index, what do you think, please? @logan-markewich , while this could potentially be done within llama index as the approach will some time to be "*extract with both LLM and bert, then evaluate and compare the two to decide which to use*", thus a new abstraction would make this easier to be implemented and we could create some extractors out of the box for users.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
