### PR TITLE
fix(readers): Fix non-ASCII JSON Reader bug

### DIFF
--- a/llama_index/readers/json.py
+++ b/llama_index/readers/json.py
@@ -81,7 +81,7 @@ class JSONReader(BaseReader):
             if self.levels_back is None:
                 # If levels_back isn't set, we just format and make each
                 # line an embedding
-                json_output = json.dumps(data, indent=0)
+                json_output = json.dumps(data, indent=0, ensure_ascii=False)
                 lines = json_output.split("\n")
                 useful_lines = [
                     line for line in lines if not re.match(r"^[{}\[\],]*$", line)


### PR DESCRIPTION
# Description
Includes `ensure_ascii=False` in [JSONReader](https://github.com/jerryjliu/llama_index/blob/a541cbf2631aa4736d45432e3e932f2ac295a6ec/llama_index/readers/json.py#L50) in order to handle non-ASCII inputs properly

Fixes #7084 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
It has been tested that this JSON file
```JSON
[
  {
    "text": "Для интересующихся:  прогнал natasha через тесты factRuEval-2016 (первая дорожка, сущности типа персона, организация, гео) и получил более-менее приемлимые результаты (при loc=locorg, overall P=0.81, R=0.52, F1=0.6348)Можно всё это повторить, совершенно бесплатно, без смс и регистрации: https://gist.github.com/dveselov/af9bc55b4be16fe1fe92d4b5347f1027",
    "time": "21.12.2016 04:05:54 UTC+04:00",
    "author": "Dima Veselov"
  }
]
```
is ingested and the text is loaded/rendered properly as follows (without the `\\u` indicating raw bytes)
![JSONIssueFix](https://github.com/jerryjliu/llama_index/assets/13381361/db7f7ad7-bddc-4cd4-aa1a-1ebf8f65df78)


Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
(Since the test corresponds to ASCII related issues which are visual in nature and cannot be equality-checked, I'm not sure how to add a new unit test/notebook here)
# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
