### PR TITLE
changed superbase upsert named_arg vectors to records

### DIFF
--- a/llama_index/vector_stores/supabase.py
+++ b/llama_index/vector_stores/supabase.py
@@ -4,18 +4,13 @@ from typing import Any, List
 
 from llama_index.constants import DEFAULT_EMBEDDING_DIM
 from llama_index.schema import TextNode
-from llama_index.vector_stores.types import (
-    MetadataFilters,
-    NodeWithEmbedding,
-    VectorStore,
-    VectorStoreQuery,
-    VectorStoreQueryResult,
-)
-from llama_index.vector_stores.utils import (
-    metadata_dict_to_node,
-    node_to_metadata_dict,
-    legacy_metadata_dict_to_node,
-)
+from llama_index.vector_stores.types import (MetadataFilters,
+                                             NodeWithEmbedding, VectorStore,
+                                             VectorStoreQuery,
+                                             VectorStoreQueryResult)
+from llama_index.vector_stores.utils import (legacy_metadata_dict_to_node,
+                                             metadata_dict_to_node,
+                                             node_to_metadata_dict)
 
 logger = logging.getLogger(__name__)
 
@@ -103,7 +98,7 @@ class SupabaseVectorStore(VectorStore):
             data.append((result.id, result.embedding, metadata_dict))
             ids.append(result.id)
 
-        self._collection.upsert(vectors=data)
+        self._collection.upsert(records=data)
 
         return ids
 


### PR DESCRIPTION
# Description

I was trying to do a vector store using llama index and supabase, but the following error occurred. "TypeError: Collection.upsert() got an unexpected keyword argument 'vectors'." So I changed the named arguments from vectors to records and ran the code, and it worked properly. The Dependency has not changed.


Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

The only part I changed was the argument, so I didn't write a new test.

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
