### PR TITLE
global variable for callbacks

### DIFF
--- a/docs/examples/callbacks/WandbCallbackHandler.ipynb
+++ b/docs/examples/callbacks/WandbCallbackHandler.ipynb
@@ -108,7 +108,8 @@
    "outputs": [],
    "source": [
     "from llama_index import set_global_eval_handler\n",
-    "set_global_eval_handler(\"wandb\", run_args={\"project\": \"llamaindex\"})"
+    "set_global_eval_handler(\"wandb\", run_args={\"project\": \"llamaindex\"})\n",
+    "wandb_callback = llama_index.global_eval_handler"
    ]
   },
   {

--- a/docs/examples/callbacks/WandbCallbackHandler.ipynb
+++ b/docs/examples/callbacks/WandbCallbackHandler.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "c0d8b66c",
    "metadata": {},
@@ -68,7 +67,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "e6feb252",
    "metadata": {},
@@ -87,7 +85,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "8790f4c7",
    "metadata": {},
@@ -96,21 +93,50 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "8a32b984-772e-4832-945e-cb6fc7be9e0b",
+   "metadata": {},
+   "source": [
+    "**Option 1**: Set Global Evaluation Handler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a3b9d22-cd67-4fb5-9785-254e58179a02",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index import set_global_eval_handler\n",
+    "set_global_eval_handler(\"wandb\", run_args={\"project\": \"llamaindex\"})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0645550-0585-4d3f-b075-32905552b2c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "service_context = ServiceContext.from_defaults(llm=llm)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1755516-f8ad-458e-b52f-f7665c023e43",
+   "metadata": {},
+   "source": [
+    "**Option 2**: Manually Configure Callback Handler\n",
+    "\n",
+    "Also configure a debugger handler for extra notebook visibility."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "13f2b759",
+   "id": "defa9155-daca-4a8f-8ca6-87d1ee98f084",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[34m\u001b[1mwandb\u001b[0m: Streaming LlamaIndex events to W&B at https://wandb.ai/ayut/llamaindex/runs/js7j48l9\n",
-      "\u001b[34m\u001b[1mwandb\u001b[0m: `WandbCallbackHandler` is currently in beta.\n",
-      "\u001b[34m\u001b[1mwandb\u001b[0m: Please report any issues to https://github.com/wandb/wandb/issues with the tag `llamaindex`.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "llama_debug = LlamaDebugHandler(print_trace_on_end=True)\n",
     "\n",
@@ -122,13 +148,13 @@
     "wandb_callback = WandbCallbackHandler(run_args=run_args)\n",
     "\n",
     "callback_manager = CallbackManager([llama_debug, wandb_callback])\n",
+    "\n",
     "service_context = ServiceContext.from_defaults(\n",
     "    callback_manager=callback_manager, llm=llm\n",
     ")"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "c4cf969a",
    "metadata": {},
@@ -137,7 +163,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "a4a7c101",
    "metadata": {},
@@ -192,7 +217,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "0a948efc",
    "metadata": {},
@@ -219,7 +243,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "7ed156a6",
    "metadata": {},
@@ -260,7 +283,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "ae4de4a9",
    "metadata": {},
@@ -310,7 +332,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "d7250272",
    "metadata": {},
@@ -449,7 +470,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "60aa7e5f",
    "metadata": {},
@@ -533,7 +553,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "cda70171",
    "metadata": {},
@@ -560,7 +579,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "ff60da73",
    "metadata": {},
@@ -610,7 +628,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "b30ddfc9",
    "metadata": {},
@@ -661,7 +678,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "c49ff101",
    "metadata": {},
@@ -698,7 +714,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,

--- a/llama_index/__init__.py
+++ b/llama_index/__init__.py
@@ -132,10 +132,12 @@ from llama_index.token_counter.mock_embed_model import MockEmbedding
 # vellum
 from llama_index.llm_predictor.vellum import VellumPredictor, VellumPromptRegistry
 
+# import global eval handler
+from llama_index.callbacks.global_eval_handlers import set_global_eval_handler
+
 # best practices for library logging:
 # https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library
 logging.getLogger(__name__).addHandler(NullHandler())
-
 
 __all__ = [
     "StorageContext",
@@ -221,7 +223,13 @@ __all__ = [
     "QueryBundle",
     "get_response_synthesizer",
     "set_global_service_context",
+    "set_global_eval_handler",
 ]
+
+# eval global toggle
+from llama_index.callbacks.base_handler import BaseCallbackHandler  # noqa: E402
+
+global_eval_handler: Optional[BaseCallbackHandler] = None
 
 # NOTE: keep for backwards compatibility
 SQLContextBuilder = SQLDocumentContextBuilder

--- a/llama_index/callbacks/aim.py
+++ b/llama_index/callbacks/aim.py
@@ -6,7 +6,7 @@ try:
 except ModuleNotFoundError:
     Run, Text = None, None
 
-from llama_index.callbacks.base import BaseCallbackHandler
+from llama_index.callbacks.base_handler import BaseCallbackHandler
 from llama_index.callbacks.schema import CBEventType, EventPayload
 
 logger = logging.getLogger(__name__)

--- a/llama_index/callbacks/llama_debug.py
+++ b/llama_index/callbacks/llama_debug.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from datetime import datetime
 from typing import Dict, List, Any, Optional
 
-from llama_index.callbacks.base import BaseCallbackHandler
+from llama_index.callbacks.base_handler import BaseCallbackHandler
 from llama_index.callbacks.schema import (
     CBEvent,
     CBEventType,

--- a/llama_index/callbacks/open_inference_callback.py
+++ b/llama_index/callbacks/open_inference_callback.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, TypeVar
 
-from llama_index.callbacks.base import BaseCallbackHandler
+from llama_index.callbacks.base_handler import BaseCallbackHandler
 from llama_index.callbacks.schema import CBEventType, EventPayload
 
 if TYPE_CHECKING:

--- a/llama_index/callbacks/token_counting.py
+++ b/llama_index/callbacks/token_counting.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional
 from llama_index.utils import globals_helper
-from llama_index.callbacks.base import BaseCallbackHandler
+from llama_index.callbacks.base_handler import BaseCallbackHandler
 from llama_index.callbacks.schema import CBEventType
 
 

--- a/llama_index/callbacks/wandb_callback.py
+++ b/llama_index/callbacks/wandb_callback.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional, Sequence, Union, TYPE_CHECKING, Tu
 from collections import defaultdict
 from datetime import datetime
 
-from llama_index.callbacks.base import BaseCallbackHandler
+from llama_index.callbacks.base_handler import BaseCallbackHandler
 from llama_index.callbacks.schema import (
     CBEvent,
     CBEventType,


### PR DESCRIPTION
This PR adds a `global_eval_handler` variable, that can be set through `set_global_eval_handler()`. What this does is it always gets injected into the Callback Manager if specified.


Thought: should I make the global_eval_handler plural? 