### PR TITLE
add hybrid search to columns

### DIFF
--- a/docs/core_modules/data_modules/storage/vector_stores.md
+++ b/docs/core_modules/data_modules/storage/vector_stores.md
@@ -11,29 +11,29 @@ They can be persisted to (and loaded from) disk by calling `vector_store.persist
 LlamaIndex supports over 20 different vector store options.
 We are actively adding more integrations and improving feature coverage for each.
 
-| Vector Store    | Type                | Metadata Filtering | Delete | Store Documents | Async |
-| --------------- | ------------------- | ------------------ | ------ | --------------- | ----- |
-| Pinecone        | cloud               | ✓                  | ✓      | ✓               |       |
-| Weaviate        | self-hosted / cloud |                    | ✓      | ✓               |       |
-| Postgres        | self-hosted / cloud | ✓                  | ✓      | ✓               | ✓     |
-| Qdrant          | self-hosted / cloud | ✓                  | ✓      | ✓               |       |
-| Chroma          | self-hosted         | ✓                  | ✓      | ✓               |       |
-| Milvus / Zilliz | self-hosted / cloud |                    | ✓      | ✓               |       |
-| Typesense       | self-hosted / cloud | ✓                  | ✓      | ✓               |       |
-| Supabase        | self-hosted / cloud | ✓                  |        | ✓               |       |
-| MongoDB Atlas   | self-hosted / cloud | ✓                  | ✓      | ✓               |       |
-| Redis           | self-hosted / cloud | ✓                  | ✓      | ✓               |       |
-| Deeplake        | self-hosted / cloud | ✓                  | ✓      | ✓               |       |
-| OpenSearch      | self-hosted / cloud | ✓                  | ✓      | ✓               |       |
-| DynamoDB        | cloud               |                    | ✓      |                 |       |
-| LanceDB         | cloud               | ✓                  | ✓      | ✓               |       |
-| Metal           | cloud               | ✓                  | ✓      | ✓               |       |
-| MyScale         | cloud               |                    |        | ✓               |       |
-| Tair            | cloud               | ✓                  | ✓      | ✓               |       |
-| Simple          | in-memory           |                    | ✓      |                 |       |
-| FAISS           | in-memory           |                    |        |                 |       |
-| ChatGPT Retrieval Plugin  | aggregator          |                    | ✓      | ✓               |       |
-| DocArray        | aggregator          | ✓                  | ✓      | ✓               |       |
+| Vector Store             | Type                | Metadata Filtering | Hybrid Search | Delete | Store Documents | Async |
+|--------------------------|---------------------|--------------------|---------------|--------|-----------------|-------|
+| Pinecone                 | cloud               | ✓                  | ✓             | ✓      | ✓               |       |
+| Weaviate                 | self-hosted / cloud |                    | ✓             | ✓      | ✓               |       |
+| Postgres                 | self-hosted / cloud | ✓                  |               | ✓      | ✓               | ✓     |
+| Qdrant                   | self-hosted / cloud | ✓                  |               | ✓      | ✓               |       |
+| Chroma                   | self-hosted         | ✓                  |               | ✓      | ✓               |       |
+| Milvus / Zilliz          | self-hosted / cloud |                    |               | ✓      | ✓               |       |
+| Typesense                | self-hosted / cloud | ✓                  |               | ✓      | ✓               |       |
+| Supabase                 | self-hosted / cloud | ✓                  |               |        | ✓               |       |
+| MongoDB Atlas            | self-hosted / cloud | ✓                  |               | ✓      | ✓               |       |
+| Redis                    | self-hosted / cloud | ✓                  |               | ✓      | ✓               |       |
+| Deeplake                 | self-hosted / cloud | ✓                  |               | ✓      | ✓               |       |
+| OpenSearch               | self-hosted / cloud | ✓                  |               | ✓      | ✓               |       |
+| DynamoDB                 | cloud               |                    |               | ✓      |                 |       |
+| LanceDB                  | cloud               | ✓                  |               | ✓      | ✓               |       |
+| Metal                    | cloud               | ✓                  |               | ✓      | ✓               |       |
+| MyScale                  | cloud               |                    |               |        | ✓               |       |
+| Tair                     | cloud               | ✓                  |               | ✓      | ✓               |       |
+| Simple                   | in-memory           |                    |               | ✓      |                 |       |
+| FAISS                    | in-memory           |                    |               |        |                 |       |
+| ChatGPT Retrieval Plugin | aggregator          |                    |               | ✓      | ✓               |       |
+| DocArray                 | aggregator          | ✓                  |               | ✓      | ✓               |       |
 
 For more details, see [Vector Store Integrations](/community/integrations/vector_stores.md).
 


### PR DESCRIPTION
# Description

Just a simple change to add a column to the vector db table in the docs

Side note -- we should probably be more strict on vector db integrations going forward. If a DB supports hybrid search or metadata filtering, we should be sure support is added for it in llama-index before merging. I'm sure other DBs support these features, and we just haven't implemented them.