### PR TITLE
add flush to agent response stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## Unreleased
+
+### Bug Fixes / Nits
+- add `flush=True` when printing agent/chat engine response stream (#7129)
+
 ## [0.7.17] - 2023-08-02
 
 ### New Features

--- a/llama_index/chat_engine/types.py
+++ b/llama_index/chat_engine/types.py
@@ -131,7 +131,7 @@ class StreamingAgentChatResponse:
 
     def print_response_stream(self) -> None:
         for token in self.response_gen:
-            print(token, end="")
+            print(token, end="", flush=True)
 
 
 class BaseChatEngine(ABC):


### PR DESCRIPTION
# Description

The agent response stream will sometimes not print properly without `flush=True`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
