### PR TITLE
fix astream_chat for chat engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - add `flush=True` when printing agent/chat engine response stream (#7129)
 - Added `Azure AD` support to the `AzureOpenAI` class (#7127)
 - Update LLM question generator prompt to mention JSON markdown (#7105)
+- Fixed `astream_chat` in chat engines (#7139)
 
 ## [0.7.17] - 2023-08-02
 

--- a/llama_index/chat_engine/context.py
+++ b/llama_index/chat_engine/context.py
@@ -212,7 +212,7 @@ class ContextChatEngine(BaseChatEngine):
         all_messages = prefix_messages + self._memory.get()
 
         chat_response = StreamingAgentChatResponse(
-            chat_stream=self._llm.stream_chat(all_messages),
+            achat_stream=await self._llm.astream_chat(all_messages),
             sources=[
                 ToolOutput(
                     tool_name="retriever",

--- a/llama_index/chat_engine/simple.py
+++ b/llama_index/chat_engine/simple.py
@@ -116,7 +116,7 @@ class SimpleChatEngine(BaseChatEngine):
         all_messages = self._prefix_messages + self._memory.get()
 
         chat_response = StreamingAgentChatResponse(
-            chat_stream=self._llm.stream_chat(all_messages)
+            achat_stream=await self._llm.astream_chat(all_messages)
         )
         thread = Thread(
             target=lambda x: asyncio.run(chat_response.awrite_response_to_history(x)),


### PR DESCRIPTION
# Description

Chat engines were not correctly setting achat_stream in the agent response, resulting in value errors.

Fixes https://github.com/jerryjliu/llama_index/issues/7131

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested in a notebook
- [x] I stared at the code and made sure it makes sense
