### PR TITLE
Logan/migrate response synth v2 (redo AGAIN)

### DIFF
--- a/llama_index/bridge/langchain.py
+++ b/llama_index/bridge/langchain.py
@@ -17,6 +17,7 @@ from langchain.prompts.chat import (
     ChatPromptTemplate,
     HumanMessagePromptTemplate,
     BaseMessagePromptTemplate,
+    SystemMessagePromptTemplate,
 )
 
 # chat and memory
@@ -74,6 +75,7 @@ __all__ = [
     "ChatPromptTemplate",
     "HumanMessagePromptTemplate",
     "BaseMessagePromptTemplate",
+    "SystemMessagePromptTemplate",
     "BaseChatMemory",
     "ConversationBufferMemory",
     "ChatMessageHistory",

--- a/llama_index/callbacks/wandb_callback.py
+++ b/llama_index/callbacks/wandb_callback.py
@@ -235,8 +235,9 @@ class WandbCallbackHandler(BaseCallbackHandler):
                 if self._wandb.run:
                     self._wandb.run.log({"trace": root_trace})
                 self._wandb.termlog("Logged trace tree to W&B.")
-        except:  # noqa
-            # Silently ignore errors to not break user code
+        except Exception as e:
+            print(f"Failed to log trace tree to W&B: {e}")
+            # ignore errors to not break user code
             pass
 
     def persist_index(
@@ -435,8 +436,8 @@ class WandbCallbackHandler(BaseCallbackHandler):
         inputs["formatted_prompt"] = outputs.get("formatted_prompt", None)
         outputs.pop("formatted_prompt", None)
 
-        # Get `original_template` from Prompt
-        inputs["template"] = inputs["template"].original_template
+        # Remove template
+        inputs.pop("template", None)
 
         # Make token counts part of span's `metadata`
         def filterByKey(keys: List[str]) -> Dict[str, int]:

--- a/llama_index/llm_predictor/base.py
+++ b/llama_index/llm_predictor/base.py
@@ -105,6 +105,9 @@ class LLMPredictor(BaseLLMPredictor):
         with self.callback_manager.event(
             CBEventType.LLM, payload=self._get_start_payload(prompt, prompt_args)
         ) as event:
+            import pdb
+
+            pdb.set_trace()
             if self._llm.metadata.is_chat_model:
                 messages = prompt.format_messages(llm=self._llm, **prompt_args)
                 chat_response = self._llm.chat(messages=messages)

--- a/llama_index/llm_predictor/base.py
+++ b/llama_index/llm_predictor/base.py
@@ -105,9 +105,6 @@ class LLMPredictor(BaseLLMPredictor):
         with self.callback_manager.event(
             CBEventType.LLM, payload=self._get_start_payload(prompt, prompt_args)
         ) as event:
-            import pdb
-
-            pdb.set_trace()
             if self._llm.metadata.is_chat_model:
                 messages = prompt.format_messages(llm=self._llm, **prompt_args)
                 chat_response = self._llm.chat(messages=messages)

--- a/llama_index/llms/openai.py
+++ b/llama_index/llms/openai.py
@@ -36,7 +36,7 @@ from llama_index.llms.openai_utils import (
 
 
 class OpenAI(LLM, BaseModel):
-    model: str = Field("text-davinci-003")
+    model: str = Field("gpt-3.5-turbo")
     temperature: float = 0.0
     max_tokens: Optional[int] = None
     additional_kwargs: Dict[str, Any] = Field(default_factory=dict)

--- a/llama_index/prompts/chat_prompts.py
+++ b/llama_index/prompts/chat_prompts.py
@@ -14,8 +14,11 @@ TEXT_QA_PROMPT_TMPL_MSGS = [
     SystemMessagePromptTemplate.from_template(
         "You are an expert Q&A system that is trusted around the world.\n"
         "Always answer the question using the provided context information.\n"
-        "Never directly reference the given context in your answer.\n"
-        "Avoid statements like 'Based on the context, ...' or anything along those lines."
+        "Some rules to follow:\n"
+        "1. Never directly reference the given context in your answer.\n"
+        "2. Avoid statements like 'Based on the context, ...' or "
+        "'The context information ...' or anything along "
+        "those lines."
     ),
     HumanMessagePromptTemplate.from_template(
         "Context information is below.\n"
@@ -33,12 +36,10 @@ CHAT_TEXT_QA_PROMPT = RefinePrompt.from_langchain_prompt(CHAT_TEXT_QA_PROMPT_LC)
 # Refine Prompt
 CHAT_REFINE_PROMPT_TMPL_MSGS = [
     SystemMessagePromptTemplate.from_template(
-        "You are an expert Q&A system, that has two modes of operation:\n"
-        "1. Updating an original answer using new context information\n"
-        "2. Repeating the original answer if the context isn't useful\n"
-        "Never mention the orginal answer.\n"
-        "Never directly reference the given context in your answer.\n"
-        "Avoid statements like 'Based on the context, ...' or anything along those lines."
+        "You are an expert Q&A system that follows strict rules:\n"
+        "1. **Rewrite** an original answer using new context information\n"
+        "2. **Repeat** the original answer if the context isn't useful\n"
+        "3. Never mention or reference the orginal answer."
     ),
     HumanMessagePromptTemplate.from_template(
         "We have the opportunity to refine an original answer "

--- a/llama_index/prompts/chat_prompts.py
+++ b/llama_index/prompts/chat_prompts.py
@@ -4,14 +4,44 @@ from llama_index.bridge.langchain import (
     AIMessagePromptTemplate,
     ChatPromptTemplate,
     HumanMessagePromptTemplate,
+    SystemMessagePromptTemplate,
 )
 
 from llama_index.prompts.prompts import RefinePrompt, RefineTableContextPrompt
 
+# text qa prompt
+TEXT_QA_PROMPT_TMPL_MSGS = [
+    SystemMessagePromptTemplate.from_template(
+        "You are an expert Q&A system that is trusted around the world.\n"
+        "Always answer the question using the provided context information.\n"
+        "Never directly reference the given context in your answer.\n"
+        "Avoid statements like 'Based on the context, ...' or anything along those lines."
+    ),
+    HumanMessagePromptTemplate.from_template(
+        "Context information is below.\n"
+        "---------------------\n"
+        "{context_str}\n"
+        "---------------------\n"
+        "Given the context information and not prior knowledge, "
+        "answer the question: {query_str}\n"
+    ),
+]
+
+CHAT_TEXT_QA_PROMPT_LC = ChatPromptTemplate.from_messages(TEXT_QA_PROMPT_TMPL_MSGS)
+CHAT_TEXT_QA_PROMPT = RefinePrompt.from_langchain_prompt(CHAT_TEXT_QA_PROMPT_LC)
+
 # Refine Prompt
 CHAT_REFINE_PROMPT_TMPL_MSGS = [
+    SystemMessagePromptTemplate.from_template(
+        "You are an expert Q&A system, that has two modes of operation:\n"
+        "1. Updating an original answer using new context information\n"
+        "2. Repeating the original answer if the context isn't useful\n"
+        "Never mention the orginal answer.\n"
+        "Never directly reference the given context in your answer.\n"
+        "Avoid statements like 'Based on the context, ...' or anything along those lines."
+    ),
     HumanMessagePromptTemplate.from_template(
-        "We have the opportunity to refine the above answer "
+        "We have the opportunity to refine an original answer "
         "(only if needed) with some more context below.\n"
         "------------\n"
         "{context_msg}\n"

--- a/llama_index/prompts/default_prompt_selectors.py
+++ b/llama_index/prompts/default_prompt_selectors.py
@@ -1,15 +1,30 @@
 """Prompt selectors."""
 from llama_index.prompts.chat_prompts import (
+    CHAT_TEXT_QA_PROMPT,
     CHAT_REFINE_PROMPT,
     CHAT_REFINE_TABLE_CONTEXT_PROMPT,
 )
 from llama_index.prompts.default_prompts import (
+    DEFAULT_TEXT_QA_PROMPT,
     DEFAULT_REFINE_PROMPT,
     DEFAULT_REFINE_TABLE_CONTEXT_PROMPT,
 )
 from llama_index.prompts.prompt_selector import PromptSelector, is_chat_model
 from llama_index.prompts.prompt_type import PromptType
-from llama_index.prompts.prompts import RefinePrompt, RefineTableContextPrompt
+from llama_index.prompts.prompts import (
+    QuestionAnswerPrompt,
+    RefinePrompt,
+    RefineTableContextPrompt,
+)
+
+DEFAULT_TEXT_QA_PROMPT_SEL_LC = PromptSelector(
+    default_prompt=DEFAULT_TEXT_QA_PROMPT.get_langchain_prompt(),
+    conditionals=[(is_chat_model, CHAT_TEXT_QA_PROMPT.get_langchain_prompt())],
+)
+DEFAULT_TEXT_QA_PROMPT_SEL = QuestionAnswerPrompt(
+    langchain_prompt_selector=DEFAULT_TEXT_QA_PROMPT_SEL_LC,
+    prompt_type=PromptType.QUESTION_ANSWER,
+)
 
 DEFAULT_REFINE_PROMPT_SEL_LC = PromptSelector(
     default_prompt=DEFAULT_REFINE_PROMPT.get_langchain_prompt(),

--- a/llama_index/query_engine/router_query_engine.py
+++ b/llama_index/query_engine/router_query_engine.py
@@ -269,7 +269,7 @@ class ToolRetrieverRouterQueryEngine(BaseQueryEngine):
         self.service_context = service_context or ServiceContext.from_defaults()
         self._summarizer = summarizer or TreeSummarize(
             service_context=self.service_context,
-            text_qa_template=DEFAULT_TEXT_QA_PROMPT,
+            text_qa_template=DEFAULT_TEXT_QA_PROMPT_SEL,
         )
         self._retriever = retriever
 

--- a/llama_index/query_engine/router_query_engine.py
+++ b/llama_index/query_engine/router_query_engine.py
@@ -8,7 +8,7 @@ from llama_index.indices.base_retriever import BaseRetriever
 from llama_index.indices.query.base import BaseQueryEngine
 from llama_index.indices.query.schema import QueryBundle
 from llama_index.indices.service_context import ServiceContext
-from llama_index.prompts.default_prompts import DEFAULT_TEXT_QA_PROMPT
+from llama_index.prompts.default_prompt_selectors import DEFAULT_TEXT_QA_PROMPT_SEL
 from llama_index.response.schema import RESPONSE_TYPE, Response, StreamingResponse
 from llama_index.response_synthesizers import TreeSummarize
 from llama_index.selectors.llm_selectors import LLMMultiSelector, LLMSingleSelector
@@ -86,7 +86,7 @@ class RouterQueryEngine(BaseQueryEngine):
         self._metadatas = [x.metadata for x in query_engine_tools]
         self._summarizer = summarizer or TreeSummarize(
             service_context=self.service_context,
-            text_qa_template=DEFAULT_TEXT_QA_PROMPT,
+            text_qa_template=DEFAULT_TEXT_QA_PROMPT_SEL,
         )
 
         super().__init__(self.service_context.callback_manager)

--- a/llama_index/response_synthesizers/factory.py
+++ b/llama_index/response_synthesizers/factory.py
@@ -2,11 +2,11 @@ from typing import Optional
 
 from llama_index.callbacks.base import CallbackManager
 from llama_index.indices.service_context import ServiceContext
-from llama_index.prompts.default_prompt_selectors import DEFAULT_REFINE_PROMPT_SEL
-from llama_index.prompts.default_prompts import (
-    DEFAULT_SIMPLE_INPUT_PROMPT,
-    DEFAULT_TEXT_QA_PROMPT,
+from llama_index.prompts.default_prompt_selectors import (
+    DEFAULT_TEXT_QA_PROMPT_SEL,
+    DEFAULT_REFINE_PROMPT_SEL,
 )
+from llama_index.prompts.default_prompts import DEFAULT_SIMPLE_INPUT_PROMPT
 from llama_index.prompts.prompts import (
     QuestionAnswerPrompt,
     RefinePrompt,
@@ -38,7 +38,7 @@ def get_response_synthesizer(
 ) -> BaseSynthesizer:
     """Get a response synthesizer."""
 
-    text_qa_template = text_qa_template or DEFAULT_TEXT_QA_PROMPT
+    text_qa_template = text_qa_template or DEFAULT_TEXT_QA_PROMPT_SEL
     refine_template = refine_template or DEFAULT_REFINE_PROMPT_SEL
     simple_template = simple_template or DEFAULT_SIMPLE_INPUT_PROMPT
 

--- a/llama_index/response_synthesizers/refine.py
+++ b/llama_index/response_synthesizers/refine.py
@@ -3,9 +3,9 @@ from typing import Any, Generator, Optional, Sequence, cast
 
 from llama_index.indices.service_context import ServiceContext
 from llama_index.indices.utils import truncate_text
-from llama_index.prompts.default_prompt_selectors import DEFAULT_REFINE_PROMPT_SEL
-from llama_index.prompts.default_prompts import (
-    DEFAULT_TEXT_QA_PROMPT,
+from llama_index.prompts.default_prompt_selectors import (
+    DEFAULT_TEXT_QA_PROMPT_SEL,
+    DEFAULT_REFINE_PROMPT_SEL,
 )
 from llama_index.prompts.prompts import QuestionAnswerPrompt, RefinePrompt
 from llama_index.response.utils import get_response_text
@@ -27,7 +27,7 @@ class Refine(BaseSynthesizer):
         verbose: bool = False,
     ) -> None:
         super().__init__(service_context=service_context, streaming=streaming)
-        self._text_qa_template = text_qa_template or DEFAULT_TEXT_QA_PROMPT
+        self._text_qa_template = text_qa_template or DEFAULT_TEXT_QA_PROMPT_SEL
         self._refine_template = refine_template or DEFAULT_REFINE_PROMPT_SEL
         self._verbose = verbose
 

--- a/llama_index/response_synthesizers/simple_summarize.py
+++ b/llama_index/response_synthesizers/simple_summarize.py
@@ -1,9 +1,7 @@
 from typing import Any, Generator, Optional, Sequence, cast
 
 from llama_index.indices.service_context import ServiceContext
-from llama_index.prompts.default_prompts import (
-    DEFAULT_TEXT_QA_PROMPT,
-)
+from llama_index.prompts.default_prompt_selectors import DEFAULT_TEXT_QA_PROMPT_SEL
 from llama_index.prompts.prompts import QuestionAnswerPrompt
 from llama_index.response_synthesizers.base import BaseSynthesizer
 from llama_index.types import RESPONSE_TEXT_TYPE
@@ -17,7 +15,7 @@ class SimpleSummarize(BaseSynthesizer):
         streaming: bool = False,
     ) -> None:
         super().__init__(service_context=service_context, streaming=streaming)
-        self._text_qa_template = text_qa_template or DEFAULT_TEXT_QA_PROMPT
+        self._text_qa_template = text_qa_template or DEFAULT_TEXT_QA_PROMPT_SEL
 
     async def aget_response(
         self,

--- a/llama_index/response_synthesizers/tree_summarize.py
+++ b/llama_index/response_synthesizers/tree_summarize.py
@@ -3,7 +3,7 @@ from typing import Any, List, Optional, Sequence
 
 from llama_index.async_utils import run_async_tasks
 from llama_index.indices.service_context import ServiceContext
-from llama_index.prompts.default_prompts import DEFAULT_TEXT_QA_PROMPT
+from llama_index.prompts.default_prompt_selectors import DEFAULT_TEXT_QA_PROMPT_SEL
 from llama_index.prompts.prompt_type import PromptType
 from llama_index.prompts.prompts import QuestionAnswerPrompt, SummaryPrompt
 from llama_index.response_synthesizers.base import BaseSynthesizer
@@ -32,7 +32,7 @@ class TreeSummarize(BaseSynthesizer):
         verbose: bool = False,
     ) -> None:
         super().__init__(service_context=service_context, streaming=streaming)
-        self._text_qa_template = text_qa_template or DEFAULT_TEXT_QA_PROMPT
+        self._text_qa_template = text_qa_template or DEFAULT_TEXT_QA_PROMPT_SEL
         self._use_async = use_async
         self._verbose = verbose
 


### PR DESCRIPTION
# Description

This PR migrates the response synthesizer to use GPT-3.5-Turbo. In addition, some other changes are included

- remove templates from the wandb callback
- stop silently failing on the wandb callback
- stop using `from_prompt` in tree summarize (this was destroying the chat message template) 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Tested on tons of response modes and top k's
- [x] I stared at the code and made sure it makes sense
