### PR TITLE
Updated response mode docs

### DIFF
--- a/docs/core_modules/query_modules/query_engine/response_modes.md
+++ b/docs/core_modules/query_modules/query_engine/response_modes.md
@@ -3,22 +3,41 @@
 Right now, we support the following options:
 
 - `refine`: ***create and refine*** an answer by sequentially going through each retrieved text chunk. 
-    This makes a separate LLM call per Node/retrieved chunk. The first chunk is used in a query using the 
-    `text_qa_template` prompt. Then the answer and the next chunk (and the original question) are used 
-    in another query with the `refine_template` prompt. And so on until all chunks have been parsed.
+    This makes a separate LLM call per Node/retrieved chunk. 
+
+    **Details:** the first chunk is used in a query using the 
+    `text_qa_template` prompt. Then the answer and the next chunk (as well as the original question) are used 
+    in another query with the `refine_template` prompt. And so on until all chunks have been parsed. 
+
+    If a chunk is too large to fit within the window (considering the prompt size), it is splitted using a `TokenTextSplitter`
+    (allowing some text overlap between chunks) and the (new) additional chunks are considered as chunks
+    of the original chunks collection (and thus queried with the `refine_template` as well).
+
     Good for more detailed answers.
-- `compact` (default): ***compact*** the prompt during each LLM call by stuffing as 
-    many text (concatenated from the retrieved chunks) that can fit within the maximum prompt size. 
+- `compact` (default): similar to `refine` but ***compact*** (concatenate) the chunks beforehand, resulting in less LLM calls.
+
+    **Details:** stuff as many text (concatenated/packed from the retrieved chunks) that can fit within the context window 
+    (considering the maximum prompt size between `text_qa_template` and `refine_template`).
     If the text is too long to fit in one prompt, it is splitted in as many parts as needed 
-    (using a `TokenTextSplitter`). Each text part is considered a "chunk" and is sent to the 
-    ***create and refine*** synthesizer. In short, it is like `refine`, but with less LLM calls.
-- `tree_summarize`: Given a set of text chunks and the query, recursively construct a tree 
-    and return the root node as the response. All retrieved chunks/nodes are concatenated and then
-    splitted to fit the context window using the `text_qa_template` prompt, resulting in as many new "chunks".
-    Each of these chunks are queried against the `text_qa_template` prompt, giving as many answers. If there is
-    only one answer, then it's the final answer. If there are more than one answer, these themselves are 
-    considered as chunks and sent recursively to the `tree_summarize` process (concatenated/splitted-to-fit/queried).
-    Good for summarization purposes.
+    (using a `TokenTextSplitter` and thus allowing some overlap between text chunks). 
+    
+    Each text part is considered a "chunk" and is sent to the `refine` synthesizer. 
+    
+    In short, it is like `refine`, but with less LLM calls.
+- `tree_summarize`: Query the LLM using the `text_qa_template` prompt as many times as needed so that all concatenated chunks
+   have been queried, resulting in as many answers that are themselves recursively used as chunks in a `tree_summarize` LLM call 
+   and so on, until there's only one chunk left, and thus only one final answer.
+
+   **Details:** concatenate the chunks as much as possible to fit within the context window using the `text_qa_template` prompt, 
+   and split them if needed (again with a `TokenTextSplitter` and some text overlap). Then, query each resulting chunk/split against 
+   `text_qa_template` (there is no ***refine*** query !) and get as many answers. 
+   
+   If there is only one answer (because there was only one chunk), then it's the final answer. 
+   
+   If there are more than one answer, these themselves are considered as chunks and sent recursively 
+   to the `tree_summarize` process (concatenated/splitted-to-fit/queried).
+   
+   Good for summarization purposes.
 - `simple_summarize`: Truncates all text chunks to fit into a single LLM prompt. Good for quick
     summarization purposes, but may lose detail due to truncation.
 - `no_text`: Only runs the retriever to fetch the nodes that would have been sent to the LLM, 

--- a/docs/core_modules/query_modules/query_engine/response_modes.md
+++ b/docs/core_modules/query_modules/query_engine/response_modes.md
@@ -1,20 +1,33 @@
 # Response Modes
 
 Right now, we support the following options:
-- `default`: "create and refine" an answer by sequentially going through each retrieved `Node`; 
-    This makes a separate LLM call per Node. Good for more detailed answers.
-- `compact`: "compact" the prompt during each LLM call by stuffing as 
-    many `Node` text chunks that can fit within the maximum prompt size. If there are 
-    too many chunks to stuff in one prompt, "create and refine" an answer by going through
-    multiple prompts.
-- `tree_summarize`: Given a set of `Node` objects and the query, recursively construct a tree 
-    and return the root node as the response. Good for summarization purposes.
+
+- `refine`: ***create and refine*** an answer by sequentially going through each retrieved text chunk. 
+    This makes a separate LLM call per Node/retrieved chunk. The first chunk is used in a query using the 
+    `text_qa_template` prompt. Then the answer and the next chunk (and the original question) are used 
+    in another query with the `refine_template` prompt. And so on until all chunks have been parsed.
+    Good for more detailed answers.
+- `compact` (default): ***compact*** the prompt during each LLM call by stuffing as 
+    many text (concatenated from the retrieved chunks) that can fit within the maximum prompt size. 
+    If the text is too long to fit in one prompt, it is splitted in as many parts as needed 
+    (using a `TokenTextSplitter`). Each text part is considered a "chunk" and is sent to the 
+    ***create and refine*** synthesizer. In short, it is like `refine`, but with less LLM calls.
+- `tree_summarize`: Given a set of text chunks and the query, recursively construct a tree 
+    and return the root node as the response. All retrieved chunks/nodes are concatenated and then
+    splitted to fit the context window using the `text_qa_template` prompt, resulting in as many new "chunks".
+    Each of these chunks are queried against the `text_qa_template` prompt, giving as many answers. If there is
+    only one answer, then it's the final answer. If there are more than one answer, these themselves are 
+    considered as chunks and sent recursively to the `tree_summarize` process (concatenated/splitted-to-fit/queried).
+    Good for summarization purposes.
+- `simple_summarize`: Truncates all text chunks to fit into a single LLM prompt. Good for quick
+    summarization purposes, but may lose detail due to truncation.
 - `no_text`: Only runs the retriever to fetch the nodes that would have been sent to the LLM, 
     without actually sending them. Then can be inspected by checking `response.source_nodes`.
-    The response object is covered in more detail in Section 5.
-- `accumulate`: Given a set of `Node` objects and the query, apply the query to each `Node` text
+- `accumulate`: Given a set of text chunks and the query, apply the query to each text
     chunk while accumulating the responses into an array. Returns a concatenated string of all
     responses. Good for when you need to run the same query separately against each text
     chunk.
+- `compact_accumulate`: The same as accumulate, but will "compact" each LLM prompt similar to
+    `compact`, and run the same query against each text chunk.
 
 See [Response Synthesizer](/core_modules/query_modules/response_synthesizers/root.md) to learn more.

--- a/docs/core_modules/query_modules/response_synthesizers/usage_pattern.md
+++ b/docs/core_modules/query_modules/response_synthesizers/usage_pattern.md
@@ -33,22 +33,41 @@ Response synthesizers are typically specified through a `response_mode` kwarg se
 Several response synthesizers are implemented already in LlamaIndex:
 
 - `refine`: ***create and refine*** an answer by sequentially going through each retrieved text chunk. 
-    This makes a separate LLM call per Node/retrieved chunk. The first chunk is used in a query using the 
-    `text_qa_template` prompt. Then the answer and the next chunk (and the original question) are used 
-    in another query with the `refine_template` prompt. And so on until all chunks have been parsed.
+    This makes a separate LLM call per Node/retrieved chunk. 
+
+    **Details:** the first chunk is used in a query using the 
+    `text_qa_template` prompt. Then the answer and the next chunk (as well as the original question) are used 
+    in another query with the `refine_template` prompt. And so on until all chunks have been parsed. 
+
+    If a chunk is too large to fit within the window (considering the prompt size), it is splitted using a `TokenTextSplitter`
+    (allowing some text overlap between chunks) and the (new) additional chunks are considered as chunks
+    of the original chunks collection (and thus queried with the `refine_template` as well).
+
     Good for more detailed answers.
-- `compact` (default): ***compact*** the prompt during each LLM call by stuffing as 
-    many text (concatenated from the retrieved chunks) that can fit within the maximum prompt size. 
+- `compact` (default): similar to `refine` but ***compact*** (concatenate) the chunks beforehand, resulting in less LLM calls.
+
+    **Details:** stuff as many text (concatenated/packed from the retrieved chunks) that can fit within the context window 
+    (considering the maximum prompt size between `text_qa_template` and `refine_template`).
     If the text is too long to fit in one prompt, it is splitted in as many parts as needed 
-    (using a `TokenTextSplitter`). Each text part is considered a "chunk" and is sent to the 
-    ***create and refine*** synthesizer. In short, it is like `refine`, but with less LLM calls.
-- `tree_summarize`: Given a set of text chunks and the query, recursively construct a tree 
-    and return the root node as the response. All retrieved chunks/nodes are concatenated and then
-    splitted to fit the context window using the `text_qa_template` prompt, resulting in as many new "chunks".
-    Each of these chunks are queried against the `text_qa_template` prompt, giving as many answers. If there is
-    only one answer, then it's the final answer. If there are more than one answer, these themselves are 
-    considered as chunks and sent recursively to the `tree_summarize` process (concatenated/splitted-to-fit/queried).
-    Good for summarization purposes.
+    (using a `TokenTextSplitter` and thus allowing some overlap between text chunks). 
+    
+    Each text part is considered a "chunk" and is sent to the `refine` synthesizer. 
+    
+    In short, it is like `refine`, but with less LLM calls.
+- `tree_summarize`: Query the LLM using the `text_qa_template` prompt as many times as needed so that all concatenated chunks
+   have been queried, resulting in as many answers that are themselves recursively used as chunks in a `tree_summarize` LLM call 
+   and so on, until there's only one chunk left, and thus only one final answer.
+
+   **Details:** concatenate the chunks as much as possible to fit within the context window using the `text_qa_template` prompt, 
+   and split them if needed (again with a `TokenTextSplitter` and some text overlap). Then, query each resulting chunk/split against 
+   `text_qa_template` (there is no ***refine*** query !) and get as many answers. 
+   
+   If there is only one answer (because there was only one chunk), then it's the final answer. 
+   
+   If there are more than one answer, these themselves are considered as chunks and sent recursively 
+   to the `tree_summarize` process (concatenated/splitted-to-fit/queried).
+   
+   Good for summarization purposes.
 - `simple_summarize`: Truncates all text chunks to fit into a single LLM prompt. Good for quick
     summarization purposes, but may lose detail due to truncation.
 - `no_text`: Only runs the retriever to fetch the nodes that would have been sent to the LLM, 


### PR DESCRIPTION
# Description

Added details about the first three main response modes (how they work). 

With the previously given description, it was particularly difficult to understand how the "tree summarize" mode was working under the hood. I hope this clarifies a bit.

The response modes probably deserve even more explanations as the differences are sometimes subtle and it's not always clear how it will impact the whole process.

Also replicated the "response mode" section of "response synthesizers" chapter in "query engine" chapter (was outdated).

## Type of Change
- [x] doc update/standardisation
