### PR TITLE
OpenInferenceCallbackHandler uses node IDs rather than hashes

### DIFF
--- a/llama_index/callbacks/open_inference_callback.py
+++ b/llama_index/callbacks/open_inference_callback.py
@@ -208,11 +208,11 @@ class OpenInferenceCallbackHandler(BaseCallbackHandler):
             for node_with_score in payload[EventPayload.NODES]:
                 node = node_with_score.node
                 score = node_with_score.score
-                self._trace_data.query_data.node_ids.append(node.hash)
+                self._trace_data.query_data.node_ids.append(node.node_id)
                 self._trace_data.query_data.scores.append(score)
                 self._trace_data.node_datas.append(
                     NodeData(
-                        id=node.hash,
+                        id=node.node_id,
                         node_text=node.text,
                     )
                 )

--- a/llama_index/callbacks/open_inference_callback.py
+++ b/llama_index/callbacks/open_inference_callback.py
@@ -217,9 +217,13 @@ class OpenInferenceCallbackHandler(BaseCallbackHandler):
                     )
                 )
         elif event_type is CBEventType.LLM:
-            self._trace_data.query_data.response_text = str(
-                payload.get(EventPayload.RESPONSE, "")
-            ) or str(payload.get(EventPayload.COMPLETION, ""))
+            if chat_response := payload.get(EventPayload.RESPONSE):
+                response_text = chat_response.message.content
+            elif completion_response := payload.get(EventPayload.COMPLETION):
+                response_text = completion_response.text
+            else:
+                response_text = ""
+            self._trace_data.query_data.response_text = response_text
         elif event_type is CBEventType.EMBEDDING:
             self._trace_data.query_data.query_embedding = payload[
                 EventPayload.EMBEDDINGS


### PR DESCRIPTION
# Description

Change the `OpenInferenceCallbackHandler` to use node IDs rather than node hashes. Node hashes were originally chosen because of an issue reading in legacy LlamaIndex persisted indexes, but the node IDs work with newer versions.

This issue was initially investigated [here](https://github.com/jerryjliu/llama_index/issues/7101), where we found that the issue disppear after re-indexing with a newer version of LlamaIndex.

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
