### PR TITLE
Tree Summarize + Reduce Hallucination

### DIFF
--- a/llama_index/prompts/chat_prompts.py
+++ b/llama_index/prompts/chat_prompts.py
@@ -7,31 +7,64 @@ from llama_index.bridge.langchain import (
     SystemMessagePromptTemplate,
 )
 
-from llama_index.prompts.prompts import RefinePrompt, RefineTableContextPrompt
+from llama_index.prompts.prompts import (
+    QuestionAnswerPrompt,
+    SummaryPrompt,
+    RefinePrompt,
+    RefineTableContextPrompt,
+)
 
 # text qa prompt
+TEXT_QA_SYSTEM_PROMPT = SystemMessagePromptTemplate.from_template(
+    "You are an expert Q&A system that is trusted around the world.\n"
+    "Always answer the question using the provided context information.\n"
+    "Some rules to follow:\n"
+    "1. Never directly reference the given context in your answer.\n"
+    "2. Avoid statements like 'Based on the context, ...' or "
+    "'The context information ...' or anything along "
+    "those lines."
+)
+
 TEXT_QA_PROMPT_TMPL_MSGS = [
-    SystemMessagePromptTemplate.from_template(
-        "You are an expert Q&A system that is trusted around the world.\n"
-        "Always answer the question using the provided context information.\n"
-        "Some rules to follow:\n"
-        "1. Never directly reference the given context in your answer.\n"
-        "2. Avoid statements like 'Based on the context, ...' or "
-        "'The context information ...' or anything along "
-        "those lines."
-    ),
+    TEXT_QA_SYSTEM_PROMPT,
     HumanMessagePromptTemplate.from_template(
         "Context information is below.\n"
         "---------------------\n"
         "{context_str}\n"
         "---------------------\n"
         "Given the context information and not prior knowledge, "
-        "answer the question: {query_str}\n"
+        "answer the question. If the answer is not in the context, inform "
+        "the user that you can't answer the question.\n"
+        "Question: {query_str}\n"
     ),
 ]
 
 CHAT_TEXT_QA_PROMPT_LC = ChatPromptTemplate.from_messages(TEXT_QA_PROMPT_TMPL_MSGS)
-CHAT_TEXT_QA_PROMPT = RefinePrompt.from_langchain_prompt(CHAT_TEXT_QA_PROMPT_LC)
+CHAT_TEXT_QA_PROMPT = QuestionAnswerPrompt.from_langchain_prompt(CHAT_TEXT_QA_PROMPT_LC)
+
+
+# Tree Summarize
+TREE_SUMMARIZE_PROMPT_TMPL_MSGS = [
+    TEXT_QA_SYSTEM_PROMPT,
+    HumanMessagePromptTemplate.from_template(
+        "Context information from multiple sources is below.\n"
+        "---------------------\n"
+        "{context_str}\n"
+        "---------------------\n"
+        "Given the information from multiple sources and not prior knowledge, "
+        "answer the question. If the answer is not in the context, inform "
+        "the user that you can't answer the question.\n"
+        "Question: {query_str}\n"
+    ),
+]
+
+CHAT_TREE_SUMMARIZE_PROMPT_LC = ChatPromptTemplate.from_messages(
+    TREE_SUMMARIZE_PROMPT_TMPL_MSGS
+)
+CHAT_TREE_SUMMARIZE_PROMPT = SummaryPrompt.from_langchain_prompt(
+    CHAT_TREE_SUMMARIZE_PROMPT_LC
+)
+
 
 # Refine Prompt
 CHAT_REFINE_PROMPT_TMPL_MSGS = [

--- a/llama_index/prompts/default_prompt_selectors.py
+++ b/llama_index/prompts/default_prompt_selectors.py
@@ -1,11 +1,13 @@
 """Prompt selectors."""
 from llama_index.prompts.chat_prompts import (
     CHAT_TEXT_QA_PROMPT,
+    CHAT_TREE_SUMMARIZE_PROMPT,
     CHAT_REFINE_PROMPT,
     CHAT_REFINE_TABLE_CONTEXT_PROMPT,
 )
 from llama_index.prompts.default_prompts import (
     DEFAULT_TEXT_QA_PROMPT,
+    DEFAULT_TREE_SUMMARIZE_PROMPT,
     DEFAULT_REFINE_PROMPT,
     DEFAULT_REFINE_TABLE_CONTEXT_PROMPT,
 )
@@ -24,6 +26,15 @@ DEFAULT_TEXT_QA_PROMPT_SEL_LC = PromptSelector(
 DEFAULT_TEXT_QA_PROMPT_SEL = QuestionAnswerPrompt(
     langchain_prompt_selector=DEFAULT_TEXT_QA_PROMPT_SEL_LC,
     prompt_type=PromptType.QUESTION_ANSWER,
+)
+
+DEFAULT_TREE_SUMMARIZE_PROMPT_SEL_LC = PromptSelector(
+    default_prompt=DEFAULT_TREE_SUMMARIZE_PROMPT.get_langchain_prompt(),
+    conditionals=[(is_chat_model, CHAT_TREE_SUMMARIZE_PROMPT.get_langchain_prompt())],
+)
+DEFAULT_TREE_SUMMARIZE_PROMPT_SEL = QuestionAnswerPrompt(
+    langchain_prompt_selector=DEFAULT_TREE_SUMMARIZE_PROMPT_SEL_LC,
+    prompt_type=PromptType.SUMMARY,
 )
 
 DEFAULT_REFINE_PROMPT_SEL_LC = PromptSelector(

--- a/llama_index/prompts/default_prompts.py
+++ b/llama_index/prompts/default_prompts.py
@@ -101,10 +101,26 @@ DEFAULT_TEXT_QA_PROMPT_TMPL = (
     "{context_str}\n"
     "---------------------\n"
     "Given the context information and not prior knowledge, "
-    "answer the question: {query_str}\n"
+    "answer the question. If the answer is not in the context, inform "
+    "the user that you can't answer the question.\n"
+    "Question: {query_str}\n"
 )
 DEFAULT_TEXT_QA_PROMPT = Prompt(
     DEFAULT_TEXT_QA_PROMPT_TMPL, prompt_type=PromptType.QUESTION_ANSWER
+)
+
+DEFAULT_TREE_SUMMARIZE_TMPL = (
+    "Context information from multiple sources is below.\n"
+    "---------------------\n"
+    "{context_str}\n"
+    "---------------------\n"
+    "Given the information from multiple sources and not prior knowledge, "
+    "answer the question. If the answer is not in the context, inform "
+    "the user that you can't answer the question.\n"
+    "Question: {query_str}\n"
+)
+DEFAULT_TREE_SUMMARIZE_PROMPT = Prompt(
+    DEFAULT_TREE_SUMMARIZE_TMPL, prompt_type=PromptType.SUMMARY
 )
 
 

--- a/llama_index/query_engine/router_query_engine.py
+++ b/llama_index/query_engine/router_query_engine.py
@@ -8,7 +8,9 @@ from llama_index.indices.base_retriever import BaseRetriever
 from llama_index.indices.query.base import BaseQueryEngine
 from llama_index.indices.query.schema import QueryBundle
 from llama_index.indices.service_context import ServiceContext
-from llama_index.prompts.default_prompt_selectors import DEFAULT_TEXT_QA_PROMPT_SEL
+from llama_index.prompts.default_prompt_selectors import (
+    DEFAULT_TREE_SUMMARIZE_PROMPT_SEL,
+)
 from llama_index.response.schema import RESPONSE_TYPE, Response, StreamingResponse
 from llama_index.response_synthesizers import TreeSummarize
 from llama_index.selectors.llm_selectors import LLMMultiSelector, LLMSingleSelector
@@ -90,7 +92,7 @@ class RouterQueryEngine(BaseQueryEngine):
         self._metadatas = [x.metadata for x in query_engine_tools]
         self._summarizer = summarizer or TreeSummarize(
             service_context=self.service_context,
-            text_qa_template=DEFAULT_TEXT_QA_PROMPT_SEL,
+            summary_template=DEFAULT_TREE_SUMMARIZE_PROMPT_SEL,
         )
 
         super().__init__(self.service_context.callback_manager)
@@ -289,7 +291,7 @@ class ToolRetrieverRouterQueryEngine(BaseQueryEngine):
         self.service_context = service_context or ServiceContext.from_defaults()
         self._summarizer = summarizer or TreeSummarize(
             service_context=self.service_context,
-            text_qa_template=DEFAULT_TEXT_QA_PROMPT_SEL,
+            summary_template=DEFAULT_TREE_SUMMARIZE_PROMPT_SEL,
         )
         self._retriever = retriever
 

--- a/llama_index/response_synthesizers/factory.py
+++ b/llama_index/response_synthesizers/factory.py
@@ -4,6 +4,7 @@ from llama_index.callbacks.base import CallbackManager
 from llama_index.indices.service_context import ServiceContext
 from llama_index.prompts.default_prompt_selectors import (
     DEFAULT_TEXT_QA_PROMPT_SEL,
+    DEFAULT_TREE_SUMMARIZE_PROMPT_SEL,
     DEFAULT_REFINE_PROMPT_SEL,
 )
 from llama_index.prompts.default_prompts import DEFAULT_SIMPLE_INPUT_PROMPT
@@ -11,6 +12,7 @@ from llama_index.prompts.prompts import (
     QuestionAnswerPrompt,
     RefinePrompt,
     SimpleInputPrompt,
+    SummaryPrompt,
 )
 from llama_index.response_synthesizers.accumulate import Accumulate
 from llama_index.response_synthesizers.base import BaseSynthesizer
@@ -30,6 +32,7 @@ def get_response_synthesizer(
     service_context: Optional[ServiceContext] = None,
     text_qa_template: Optional[QuestionAnswerPrompt] = None,
     refine_template: Optional[RefinePrompt] = None,
+    summary_template: Optional[SummaryPrompt] = None,
     simple_template: Optional[SimpleInputPrompt] = None,
     response_mode: ResponseMode = ResponseMode.COMPACT,
     callback_manager: Optional[CallbackManager] = None,
@@ -41,6 +44,7 @@ def get_response_synthesizer(
     text_qa_template = text_qa_template or DEFAULT_TEXT_QA_PROMPT_SEL
     refine_template = refine_template or DEFAULT_REFINE_PROMPT_SEL
     simple_template = simple_template or DEFAULT_SIMPLE_INPUT_PROMPT
+    summary_template = summary_template or DEFAULT_TREE_SUMMARIZE_PROMPT_SEL
 
     service_context = service_context or ServiceContext.from_defaults(
         callback_manager=callback_manager
@@ -63,7 +67,7 @@ def get_response_synthesizer(
     elif response_mode == ResponseMode.TREE_SUMMARIZE:
         return TreeSummarize(
             service_context=service_context,
-            text_qa_template=text_qa_template,
+            summary_template=summary_template,
             streaming=streaming,
             use_async=use_async,
         )

--- a/tests/indices/response/test_tree_summarize.py
+++ b/tests/indices/response/test_tree_summarize.py
@@ -29,8 +29,10 @@ def mock_service_context_merge_chunks(
 
 
 def test_tree_summarize(mock_service_context_merge_chunks: ServiceContext) -> None:
-    mock_qa_prompt_tmpl = "{context_str}{query_str}"
-    mock_qa_prompt = Prompt(mock_qa_prompt_tmpl, prompt_type=PromptType.QUESTION_ANSWER)
+    mock_summary_prompt_tmpl = "{context_str}{query_str}"
+    mock_summary_prompt = Prompt(
+        mock_summary_prompt_tmpl, prompt_type=PromptType.SUMMARY
+    )
 
     query_str = "What is?"
     texts = [
@@ -43,7 +45,7 @@ def test_tree_summarize(mock_service_context_merge_chunks: ServiceContext) -> No
     # test sync
     tree_summarize = TreeSummarize(
         service_context=mock_service_context_merge_chunks,
-        text_qa_template=mock_qa_prompt,
+        summary_template=mock_summary_prompt,
     )
     response = tree_summarize.get_response(text_chunks=texts, query_str=query_str)
     assert str(response) == "Text chunk 1\nText chunk 2\nText chunk 3\nText chunk 4"
@@ -52,8 +54,10 @@ def test_tree_summarize(mock_service_context_merge_chunks: ServiceContext) -> No
 def test_tree_summarize_use_async(
     mock_service_context_merge_chunks: ServiceContext,
 ) -> None:
-    mock_qa_prompt_tmpl = "{context_str}{query_str}"
-    mock_qa_prompt = Prompt(mock_qa_prompt_tmpl, prompt_type=PromptType.QUESTION_ANSWER)
+    mock_summary_prompt_tmpl = "{context_str}{query_str}"
+    mock_summary_prompt = Prompt(
+        mock_summary_prompt_tmpl, prompt_type=PromptType.SUMMARY
+    )
 
     query_str = "What is?"
     texts = [
@@ -66,7 +70,7 @@ def test_tree_summarize_use_async(
     # test async
     tree_summarize = TreeSummarize(
         service_context=mock_service_context_merge_chunks,
-        text_qa_template=mock_qa_prompt,
+        summary_template=mock_summary_prompt,
         use_async=True,
     )
     response = tree_summarize.get_response(text_chunks=texts, query_str=query_str)
@@ -77,8 +81,10 @@ def test_tree_summarize_use_async(
 async def test_tree_summarize_async(
     mock_service_context_merge_chunks: ServiceContext,
 ) -> None:
-    mock_qa_prompt_tmpl = "{context_str}{query_str}"
-    mock_qa_prompt = Prompt(mock_qa_prompt_tmpl, prompt_type=PromptType.QUESTION_ANSWER)
+    mock_summary_prompt_tmpl = "{context_str}{query_str}"
+    mock_summary_prompt = Prompt(
+        mock_summary_prompt_tmpl, prompt_type=PromptType.SUMMARY
+    )
 
     query_str = "What is?"
     texts = [
@@ -91,7 +97,7 @@ async def test_tree_summarize_async(
     # test async
     tree_summarize = TreeSummarize(
         service_context=mock_service_context_merge_chunks,
-        text_qa_template=mock_qa_prompt,
+        summary_template=mock_summary_prompt,
     )
     response = await tree_summarize.aget_response(
         text_chunks=texts, query_str=query_str


### PR DESCRIPTION
# Description

This PR adds a specific prompt for `tree_summarize` to give more context to the actual task.

Furthermore, the default `text_qa_templates` are modified to hallucinate less (i.e. inform the model to not make up an answer)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Tested across all response modes
- [x] I stared at the code and made sure it makes sense

