### PR TITLE
Increase default temperature to 0.1

### DIFF
--- a/llama_index/llms/anthropic.py
+++ b/llama_index/llms/anthropic.py
@@ -31,7 +31,7 @@ class Anthropic(LLM):
     def __init__(
         self,
         model: str = "claude-2",
-        temperature: float = 0.0,
+        temperature: float = 0.1,
         max_tokens: int = 512,
         base_url: Optional[str] = None,
         timeout: Optional[float] = None,

--- a/llama_index/llms/azure_openai.py
+++ b/llama_index/llms/azure_openai.py
@@ -33,7 +33,7 @@ class AzureOpenAI(OpenAI):
         self,
         model: str = "gpt-35-turbo",
         engine: Optional[str] = None,
-        temperature: float = 0.0,
+        temperature: float = 0.1,
         max_tokens: Optional[int] = None,
         additional_kwargs: Optional[Dict[str, Any]] = None,
         max_retries: int = 10,

--- a/llama_index/llms/llama_api.py
+++ b/llama_index/llms/llama_api.py
@@ -24,7 +24,7 @@ class LlamaAPI(CustomLLM):
     def __init__(
         self,
         model: str = "llama-13b-chat",
-        temperature: float = 0.0,
+        temperature: float = 0.1,
         max_tokens: int = DEFAULT_NUM_OUTPUTS,
         additional_kwargs: Optional[Dict[str, Any]] = None,
         api_key: Optional[str] = None,

--- a/llama_index/llms/openai.py
+++ b/llama_index/llms/openai.py
@@ -40,7 +40,7 @@ class OpenAI(LLM):
     def __init__(
         self,
         model: str = "text-davinci-003",
-        temperature: float = 0.0,
+        temperature: float = 0.1,
         max_tokens: Optional[int] = None,
         additional_kwargs: Optional[Dict[str, Any]] = None,
         max_retries: int = 10,


### PR DESCRIPTION
# Description

Setting the temperature to zero by default is likely a bad idea, and is very restrictive to the token generation. Increasing slightly should allow for higher quality responses.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

