### PR TITLE
OpenAIAgent callback_manager bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## Unreleased
+
+### Bug Fixes / Nits
+- Fix for `AttributeError: 'OpenAIAgent' object has no attribute 'callback_manager'` by calling super constructor within `BaseOpenAIAgent`
+
 ## [0.7.21] - 2023-08-07
 
 ### New Features

--- a/docs/examples/agent/openai_agent_with_query_engine.ipynb
+++ b/docs/examples/agent/openai_agent_with_query_engine.ipynb
@@ -25,16 +25,7 @@
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/suo/miniconda3/envs/llama/lib/python3.9/site-packages/deeplake/util/check_latest_version.py:32: UserWarning: A newer version of deeplake (3.6.7) is available. It's recommended that you update to the latest version using `pip install -U deeplake`.\n",
-      "  warnings.warn(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from llama_index import (\n",
     "    SimpleDirectoryReader,\n",
@@ -182,7 +173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "42a1bce0-b398-4937-9008-6cee04368ac4",
    "metadata": {
     "tags": []
@@ -194,20 +185,7 @@
      "text": [
       "===== Entering Chat REPL =====\n",
       "Type \"exit\" to exit.\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stdin",
-     "output_type": "stream",
-     "text": [
-      "Human:  Compare and contrast Lyft and Uber's revenue growth in 2021, then give an analysis\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\n",
       "=== Calling Function ===\n",
       "Calling function: lyft_10k with args: {\n",
       "  \"input\": \"What was Lyft's revenue growth in 2021?\"\n",
@@ -216,20 +194,13 @@
       "Lyft's revenue growth in 2021 was 36%.\n",
       "========================\n",
       "=== Calling Function ===\n",
-      "Calling function: uber_10k with args: \n",
-      "{\n",
+      "Calling function: uber_10k with args: {\n",
       "  \"input\": \"What was Uber's revenue growth in 2021?\"\n",
       "}\n",
       "Got output: \n",
       "Uber's revenue growth in 2021 was 57%.\n",
       "========================\n",
-      "Assistant: In 2021, both Lyft and Uber experienced significant revenue growth. Lyft's revenue grew by 36%, while Uber's revenue grew by 57%. \n",
-      "\n",
-      "The higher revenue growth rate of Uber indicates that it had a stronger performance in terms of generating revenue compared to Lyft. This could be attributed to several factors, including Uber's larger market presence and global reach. Uber operates in more countries and cities compared to Lyft, which allows it to capture a larger customer base and generate more revenue.\n",
-      "\n",
-      "However, it's important to note that revenue growth alone does not provide a complete picture of a company's financial performance. Other factors such as profitability, market share, and operational efficiency also play a crucial role in assessing the overall success of a company.\n",
-      "\n",
-      "In terms of revenue growth, Uber outperformed Lyft in 2021. However, a comprehensive analysis would require considering other financial metrics and factors to get a complete understanding of the two companies' performance in the market.\n",
+      "Assistant: Lyft's revenue growth in 2021 was 36%, while Uber's revenue growth in 2021 was 57%.\n",
       "\n"
      ]
     }
@@ -237,14 +208,6 @@
    "source": [
     "agent.chat_repl()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0873463d-4790-4c17-bfe9-2ece610fe4b3",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -263,7 +226,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/llama_index/agent/openai_agent.py
+++ b/llama_index/agent/openai_agent.py
@@ -80,6 +80,7 @@ class BaseOpenAIAgent(BaseAgent):
         max_function_calls: int = DEFAULT_MAX_FUNCTION_CALLS,
         callback_manager: Optional[CallbackManager] = None,
     ) -> None:
+        super().__init__(callback_manager=callback_manager)
         self._llm = llm
         self._llm.callback_manager = callback_manager or CallbackManager([])
         self._memory = memory


### PR DESCRIPTION
# Description

Started seeing the following error when using `OpenAIAgent` constructed with `OpenAIAgent.from_tools`:

```
  File ".../llama_index/indices/query/base.py", line 23, in query
    with self.callback_manager.as_trace("query"):
         ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'OpenAIAgent' object has no attribute 'callback_manager'
```

Turns out the super constructor for the `BaseQueryEngine` class wasn't being called. Adding a explicit call to the super constructor with the `callback_manager` attribute so the attribute is set.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?


- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
