### PR TITLE
Update metadata extraction for GPT-3.5

### DIFF
--- a/docs/examples/metadata_extraction/MetadataExtractionSEC.ipynb
+++ b/docs/examples/metadata_extraction/MetadataExtractionSEC.ipynb
@@ -26,7 +26,13 @@
    "source": [
     "import nest_asyncio\n",
     "\n",
-    "nest_asyncio.apply()"
+    "nest_asyncio.apply()\n",
+    "\n",
+    "import os\n",
+    "import openai\n",
+    "\n",
+    "os.environ[\"OPENAI_API_KEY\"] = \"YOUR_API_KEY_HERE\"\n",
+    "openai.api_key = os.environ[\"OPENAI_API_KEY\"]"
    ]
   },
   {
@@ -38,22 +44,21 @@
    },
    "outputs": [],
    "source": [
-    "from llama_index import ListIndex, LLMPredictor\n",
+    "from llama_index import ServiceContext\n",
     "from llama_index.llms import OpenAI\n",
-    "from llama_index import download_loader, VectorStoreIndex, ServiceContext\n",
     "from llama_index.schema import MetadataMode"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 3,
    "id": "a0231dff-7443-46bf-9b9d-759198d3408e",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "llm = OpenAI(temperature=0, model=\"text-davinci-003\", max_tokens=512)"
+    "llm = OpenAI(temperature=0.1, model=\"gpt-3.5-turbo\", max_tokens=512)"
    ]
   },
   {
@@ -70,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 4,
    "id": "3bda151d-6fb8-427e-82fc-0f3bb469d705",
    "metadata": {
     "tags": []
@@ -107,11 +112,11 @@
     "\n",
     "metadata_extractor = MetadataExtractor(\n",
     "    extractors=[\n",
-    "        TitleExtractor(nodes=5),\n",
-    "        QuestionsAnsweredExtractor(questions=3),\n",
+    "        TitleExtractor(nodes=5, llm=llm),\n",
+    "        QuestionsAnsweredExtractor(questions=3, llm=llm),\n",
     "        # EntityExtractor(prediction_threshold=0.5),\n",
-    "        # SummaryExtractor(summaries=[\"prev\", \"self\"]),\n",
-    "        # KeywordExtractor(keywords=10),\n",
+    "        # SummaryExtractor(summaries=[\"prev\", \"self\"], llm=llm),\n",
+    "        # KeywordExtractor(keywords=10, llm=llm),\n",
     "        # CustomExtractor()\n",
     "    ],\n",
     ")\n",
@@ -124,14 +129,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 5,
    "id": "c72c45a9-dcad-4925-b2f7-d25fe5d80c2d",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "from llama_index import SimpleDirectoryReader, DocumentSummaryIndex"
+    "from llama_index import SimpleDirectoryReader"
    ]
   },
   {
@@ -157,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "38a46bf6-9539-4ac2-ad97-eb909992b94d",
    "metadata": {
     "tags": []
@@ -173,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "269f8ecc-489d-435f-9d81-a9c64fd4d400",
    "metadata": {
     "tags": []
@@ -185,7 +190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "8da4d824-d518-4d37-8322-a35adac05157",
    "metadata": {
     "tags": []
@@ -196,11 +201,11 @@
       "text/plain": [
        "{'page_label': '2',\n",
        " 'file_name': '10k-132.pdf',\n",
-       " 'document_title': 'Uber Technologies, Inc. 2019 Annual Report: Revolutionizing Mobility and Logistics Across 69 Countries and 111 Million MAPCs with $65 Billion in Gross Bookings',\n",
-       " 'questions_this_excerpt_can_answer': '\\n\\n1. How many countries does Uber Technologies, Inc. operate in?\\n2. What is the total number of MAPCs served by Uber Technologies, Inc.?\\n3. How much gross bookings did Uber Technologies, Inc. generate in 2019?'}"
+       " 'document_title': 'Exploring the Diverse Landscape of 2019: A Comprehensive Annual Report on Uber Technologies, Inc.',\n",
+       " 'questions_this_excerpt_can_answer': '1. How many countries does Uber operate in?\\n2. What is the total gross bookings of Uber in 2019?\\n3. How many trips did Uber facilitate in 2019?'}"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -211,7 +216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "93e70bfb-6c02-401b-be91-3827f358b22c",
    "metadata": {
     "tags": []
@@ -227,7 +232,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "e3720b40-c50c-4185-aaf4-289ff8ab057e",
    "metadata": {
     "tags": []
@@ -239,7 +244,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "98740f96-afdd-45ff-bcc0-2c50965a7349",
    "metadata": {
     "tags": []
@@ -250,11 +255,11 @@
       "text/plain": [
        "{'page_label': '2',\n",
        " 'file_name': '10k-vFinal.pdf',\n",
-       " 'document_title': \"Lyft, Inc. 2021 Annual Meeting of Stockholders: Filing and Attestation of Management's Assessment Report, Filer Status, Internal Control Assessment, Shell Company Status, Market Value of Common Stock, and Analysis of Historical Financial Performance.\",\n",
-       " 'questions_this_excerpt_can_answer': '\\n\\n1. What is the status of the registrant as an accelerated filer?\\n2. Has the registrant filed a report on and attestation to its management’s assessment of the effectiveness of its internal control over financial reporting?\\n3. What is the total number of shares of Class A and Class B common stock outstanding as of February 22, 2021?'}"
+       " 'document_title': 'Lyft, Inc. Annual Report on Form 10-K for the Fiscal Year Ended December 31, 2020',\n",
+       " 'questions_this_excerpt_can_answer': \"1. Has Lyft, Inc. filed a report on and attestation to its management's assessment of the effectiveness of its internal control over financial reporting under Section 404(b) of the Sarbanes-Oxley Act?\\n2. Is Lyft, Inc. considered a shell company according to Rule 12b-2 of the Exchange Act?\\n3. What was the aggregate market value of Lyft, Inc.'s common stock held by non-affiliates on June 30, 2020?\"}"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -274,7 +279,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "302bb085-86cc-4b76-a452-67bc826b292d",
    "metadata": {
     "tags": []
@@ -306,7 +311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "37dd8992-3716-44da-9309-154fb5946e98",
    "metadata": {
     "tags": []
@@ -345,7 +350,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "b8ff619d-67ed-4263-bfc7-2a7a1b7320e7",
    "metadata": {
     "tags": []
@@ -353,27 +358,31 @@
    "outputs": [],
    "source": [
     "from llama_index import VectorStoreIndex\n",
-    "from llama_index.vector_stores import FaissVectorStore\n",
     "from llama_index.query_engine import SubQuestionQueryEngine\n",
     "from llama_index.tools import QueryEngineTool, ToolMetadata"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 25,
    "id": "028a65d7-8065-4798-acec-1c3486633e14",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "index_no_metadata = VectorStoreIndex(nodes=nodes_no_metadata)\n",
-    "engine_no_metadata = index_no_metadata.as_query_engine(similarity_top_k=10)"
+    "index_no_metadata = VectorStoreIndex(\n",
+    "    nodes=nodes_no_metadata,\n",
+    "    service_context=ServiceContext.from_defaults(llm=OpenAI(model=\"gpt-4\")),\n",
+    ")\n",
+    "engine_no_metadata = index_no_metadata.as_query_engine(\n",
+    "    similarity_top_k=10,\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 26,
    "id": "73ea9e05-ff5a-49b6-8e52-139d156cde47",
    "metadata": {
     "tags": []
@@ -397,7 +406,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 27,
    "id": "fd5a3e51-e252-4e24-bc2b-fbc32ce078dd",
    "metadata": {
     "tags": []
@@ -408,37 +417,23 @@
      "output_type": "stream",
      "text": [
       "Generated 4 sub questions.\n",
-      "\u001b[36;1m\u001b[1;3m[sec_filing_documents] Q: By first identifying and quoting the most relevant sources, what was the cost due to research and development for Uber in 2019 in millions of USD?\n",
-      "\u001b[0m\u001b[33;1m\u001b[1;3m[sec_filing_documents] Q: By first identifying and quoting the most relevant sources, what was the cost due to sales and marketing for Uber in 2019 in millions of USD?\n",
-      "\u001b[0m\u001b[38;5;200m\u001b[1;3m[sec_filing_documents] Q: By first identifying and quoting the most relevant sources, what was the cost due to research and development for Lyft in 2019 in millions of USD?\n",
-      "\u001b[0m\u001b[32;1m\u001b[1;3m[sec_filing_documents] Q: By first identifying and quoting the most relevant sources, what was the cost due to sales and marketing for Lyft in 2019 in millions of USD?\n",
-      "\u001b[0m\u001b[38;5;200m\u001b[1;3m[sec_filing_documents] A: \n",
-      "\n",
-      "According to the excerpt from page_label: 69 and file_name: 10k-132.pdf, the cost due to research and development for Lyft in 2019 was 15% of total revenue, or $1.5 billion in millions of USD.\n",
-      "\u001b[0m\u001b[33;1m\u001b[1;3m[sec_filing_documents] A: \n",
-      "\n",
-      "According to the excerpt from page_label 66 of the 10k-132.pdf document, the cost due to sales and marketing for Uber in 2019 was $397.8 million in thousands of USD, or $397,800,000 in millions of USD. This cost was primarily attributable to continued investments within Uber's non-Rides offerings and an increase in corporate overhead as the business grows.\n",
-      "\u001b[0m\u001b[36;1m\u001b[1;3m[sec_filing_documents] A: \n",
-      "\n",
-      "According to the excerpt from page 69 of the document 10k-132.pdf, research and development expenses for Uber in 2019 were $909.1 million in thousands of USD, which equates to $909.1 million in millions of USD. This was 9% of the total costs and expenses for the year, and accounted for 34% of the total revenue.\n",
-      "\u001b[0m\u001b[32;1m\u001b[1;3m[sec_filing_documents] A: \n",
-      "\n",
-      "According to the excerpt from page_label 72 of the 10k-vFinal.pdf document, the cost due to sales and marketing for Lyft in 2019 was $275.1 million in thousands of USD. This can be seen in the following excerpt: \n",
-      "\n",
-      "\"Sales and marketing $ 196,437 $ 194,184 $ 163,858 $ 180,951 $ 275,129 \n",
-      "Year Ended December 31,2019 to 2020 \n",
-      "% Change2018 to 2019 \n",
-      "% Change\"\n",
-      "\u001b[0mAnswer: \n",
-      "{\n",
-      "    \"Uber\": {\n",
-      "        \"Research and Development\": 909.1,\n",
-      "        \"Sales and Marketing\": 397.8\n",
-      "    },\n",
-      "    \"Lyft\": {\n",
-      "        \"Research and Development\": 1.5,\n",
-      "        \"Sales and Marketing\": 275.1\n",
-      "    }\n",
+      "\u001b[36;1m\u001b[1;3m[sec_filing_documents] Q: What was the cost due to research and development for Uber in 2019\n",
+      "\u001b[0m\u001b[33;1m\u001b[1;3m[sec_filing_documents] Q: What was the cost due to sales and marketing for Uber in 2019\n",
+      "\u001b[0m\u001b[38;5;200m\u001b[1;3m[sec_filing_documents] Q: What was the cost due to research and development for Lyft in 2019\n",
+      "\u001b[0m\u001b[32;1m\u001b[1;3m[sec_filing_documents] Q: What was the cost due to sales and marketing for Lyft in 2019\n",
+      "\u001b[0m\u001b[33;1m\u001b[1;3m[sec_filing_documents] A: The cost due to sales and marketing for Uber in 2019 was $814,122 in thousands.\n",
+      "\u001b[0m\u001b[36;1m\u001b[1;3m[sec_filing_documents] A: The cost due to research and development for Uber in 2019 was $1,505,640 in thousands.\n",
+      "\u001b[0m\u001b[38;5;200m\u001b[1;3m[sec_filing_documents] A: The cost of research and development for Lyft in 2019 was $1,505,640 in thousands.\n",
+      "\u001b[0m\u001b[32;1m\u001b[1;3m[sec_filing_documents] A: The cost due to sales and marketing for Lyft in 2019 was $814,122 in thousands.\n",
+      "\u001b[0m{\n",
+      "  \"Uber\": {\n",
+      "    \"Research and Development\": 1505.64,\n",
+      "    \"Sales and Marketing\": 814.122\n",
+      "  },\n",
+      "  \"Lyft\": {\n",
+      "    \"Research and Development\": 1505.64,\n",
+      "    \"Sales and Marketing\": 814.122\n",
+      "  }\n",
       "}\n"
      ]
     }
@@ -462,7 +457,7 @@
    "id": "e9dafdad-c18c-4e0f-8a35-b691ca73e1f2",
    "metadata": {},
    "source": [
-    "**RESULT**: As we can see, the QnA agent does not seem to know where to look for the right documents. As a result it gets only 1/4 of the subquestions right."
+    "**RESULT**: As we can see, the QnA agent does not seem to know where to look for the right documents. As a result it gets the Lyft and Uber data completely mixed up."
    ]
   },
   {
@@ -476,7 +471,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 18,
    "id": "97f00a18-e9e6-47db-bef5-cbf5bb5016be",
    "metadata": {
     "tags": []
@@ -490,12 +485,7 @@
       " [Excerpt from document]\n",
       "page_label: 65\n",
       "file_name: 10k-132.pdf\n",
-      "document_title: Uber Technologies, Inc. 2019 Annual Report: Revolutionizing Mobility and Logistics Across 69 Countries and 111 Million MAPCs with $65 Billion in Gross Bookings\n",
-      "questions_this_excerpt_can_answer: \n",
-      "\n",
-      "1. What is Uber Technologies, Inc.'s definition of Adjusted EBITDA?\n",
-      "2. How much did Adjusted EBITDA change from 2017 to 2018?\n",
-      "3. How much did Adjusted EBITDA change from 2018 to 2019?\n",
+      "document_title: Exploring the Diverse Landscape of 2019: A Comprehensive Annual Report on Uber Technologies, Inc.\n",
       "Excerpt:\n",
       "-----\n",
       "See the section titled “Reconciliations of Non-GAAP Financial Measures” for our definition and a \n",
@@ -517,20 +507,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "id": "c7d255de-3034-4035-93bc-45d535ce1700",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "index = VectorStoreIndex(nodes=uber_nodes + lyft_nodes)\n",
-    "engine = index.as_query_engine(similarity_top_k=10)"
+    "index = VectorStoreIndex(\n",
+    "    nodes=uber_nodes + lyft_nodes,\n",
+    "    service_context=ServiceContext.from_defaults(llm=OpenAI(model=\"gpt-4\")),\n",
+    ")\n",
+    "engine = index.as_query_engine(\n",
+    "    similarity_top_k=10,\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "id": "bbe42516-a2ca-4986-9012-cb15682323f5",
    "metadata": {
     "tags": []
@@ -554,7 +549,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 24,
    "id": "f48ac2d9-58e9-4b98-9bad-b8ce1eea7934",
    "metadata": {
     "tags": []
@@ -565,32 +560,23 @@
      "output_type": "stream",
      "text": [
       "Generated 4 sub questions.\n",
-      "\u001b[36;1m\u001b[1;3m[sec_filing_documents] Q: By first identifying and quoting the most relevant sources, what was the cost due to research and development for Uber in 2019 in millions of USD?\n",
-      "\u001b[0m\u001b[33;1m\u001b[1;3m[sec_filing_documents] Q: By first identifying and quoting the most relevant sources, what was the cost due to sales and marketing for Uber in 2019 in millions of USD?\n",
-      "\u001b[0m\u001b[38;5;200m\u001b[1;3m[sec_filing_documents] Q: By first identifying and quoting the most relevant sources, what was the cost due to research and development for Lyft in 2019 in millions of USD?\n",
-      "\u001b[0m\u001b[32;1m\u001b[1;3m[sec_filing_documents] Q: By first identifying and quoting the most relevant sources, what was the cost due to sales and marketing for Lyft in 2019 in millions of USD?\n",
-      "\u001b[0m\u001b[38;5;200m\u001b[1;3m[sec_filing_documents] A: \n",
-      "\n",
-      "According to the excerpt from the document, Lyft spent $1,505 million on research and development in 2019. This was 34% of total costs and expenses for the year.\n",
-      "\u001b[0m\u001b[33;1m\u001b[1;3m[sec_filing_documents] A: \n",
-      "\n",
-      "According to the excerpt from page 69 of the Uber Technologies, Inc. 2019 Annual Report, the cost due to sales and marketing for Uber in 2019 was $4,626 million in USD. This cost was driven by investments in non-Rides offerings, corporate overhead, and Driver incentives.\n",
-      "\u001b[0m\u001b[36;1m\u001b[1;3m[sec_filing_documents] A: \n",
-      "\n",
-      "According to the excerpt from page 69 of the document, Uber Technologies, Inc. spent $4.836 billion on research and development in 2019, which was driven by a 22% increase in MAPCs due to global expansion of their Eats product offerings combined with wider market adoption of their Rides product, and overall growth in their other offerings.\n",
-      "\u001b[0m\u001b[32;1m\u001b[1;3m[sec_filing_documents] A: \n",
-      "\n",
-      "According to the excerpt from page 69 of the document titled \"Lyft, Inc. 2021 Annual Meeting of Stockholders: Filing and Attestation of Management's Assessment Report, Filer Status, Internal Control Assessment, Shell Company Status, Market Value of Common Stock, and Analysis of Historical Financial Performance,\" the cost due to sales and marketing for Lyft in 2019 was $814.122 million in USD. This can be found in the table under the heading \"2020 2019 2018 (in thousands)\" which states that \"Sales and marketing $416,331 $814,122 $803,751.\"\n",
-      "\u001b[0mAnswer: \n",
-      "{\n",
-      "    \"Uber\": {\n",
-      "        \"Research and Development\": 4.836,\n",
-      "        \"Sales and Marketing\": 4.626\n",
-      "    },\n",
-      "    \"Lyft\": {\n",
-      "        \"Research and Development\": 1.505,\n",
-      "        \"Sales and Marketing\": 0.814\n",
-      "    }\n",
+      "\u001b[36;1m\u001b[1;3m[sec_filing_documents] Q: What was the cost due to research and development for Uber in 2019\n",
+      "\u001b[0m\u001b[33;1m\u001b[1;3m[sec_filing_documents] Q: What was the cost due to sales and marketing for Uber in 2019\n",
+      "\u001b[0m\u001b[38;5;200m\u001b[1;3m[sec_filing_documents] Q: What was the cost due to research and development for Lyft in 2019\n",
+      "\u001b[0m\u001b[32;1m\u001b[1;3m[sec_filing_documents] Q: What was the cost due to sales and marketing for Lyft in 2019\n",
+      "\u001b[0m\u001b[33;1m\u001b[1;3m[sec_filing_documents] A: The cost due to sales and marketing for Uber in 2019 was $4,626 million.\n",
+      "\u001b[0m\u001b[36;1m\u001b[1;3m[sec_filing_documents] A: The cost due to research and development for Uber in 2019 was $4,836 million.\n",
+      "\u001b[0m\u001b[32;1m\u001b[1;3m[sec_filing_documents] A: The cost due to sales and marketing for Lyft in 2019 was $814,122 in thousands.\n",
+      "\u001b[0m\u001b[38;5;200m\u001b[1;3m[sec_filing_documents] A: The cost of research and development for Lyft in 2019 was $1,505,640 in thousands.\n",
+      "\u001b[0m{\n",
+      "  \"Uber\": {\n",
+      "    \"Research and Development\": 4836,\n",
+      "    \"Sales and Marketing\": 4626\n",
+      "  },\n",
+      "  \"Lyft\": {\n",
+      "    \"Research and Development\": 1505.64,\n",
+      "    \"Sales and Marketing\": 814.122\n",
+      "  }\n",
       "}\n"
      ]
     }
@@ -640,9 +626,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "llama_index_jon",
+   "display_name": "llama-index",
    "language": "python",
-   "name": "llama_index_jon"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -654,7 +640,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,

--- a/llama_index/node_parser/extractors/metadata_extractors.py
+++ b/llama_index/node_parser/extractors/metadata_extractors.py
@@ -25,6 +25,7 @@ import json
 from typing import List, Optional, Sequence, cast, Dict, Callable
 from functools import reduce
 
+from llama_index.llms.base import LLM
 from llama_index.llm_predictor.base import BaseLLMPredictor, LLMPredictor
 from llama_index.node_parser.interface import BaseExtractor
 from llama_index.prompts.base import Prompt
@@ -136,6 +137,8 @@ class TitleExtractor(MetadataFeatureExtractor):
 
     def __init__(
         self,
+        llm: Optional[LLM] = None,
+        # TODO: llm_predictor arg is deprecated
         llm_predictor: Optional[BaseLLMPredictor] = None,
         nodes: int = 5,
         node_template: str = DEFAULT_TITLE_NODE_TEMPLATE,
@@ -147,7 +150,7 @@ class TitleExtractor(MetadataFeatureExtractor):
         self._nodes = nodes
         self._node_template = node_template
         self._combine_template = combine_template
-        self._llm_predictor = llm_predictor or LLMPredictor()
+        self._llm_predictor = llm_predictor or LLMPredictor(llm=llm)
 
     def extract(self, nodes: Sequence[BaseNode]) -> List[Dict]:
         nodes_to_extract_title: List[BaseNode] = []
@@ -197,11 +200,13 @@ class KeywordExtractor(MetadataFeatureExtractor):
 
     def __init__(
         self,
+        llm: Optional[LLM] = None,
+        # TODO: llm_predictor arg is deprecated
         llm_predictor: Optional[BaseLLMPredictor] = None,
         keywords: int = 5,
     ) -> None:
         """Init params."""
-        self._llm_predictor = llm_predictor or LLMPredictor()
+        self._llm_predictor = llm_predictor or LLMPredictor(llm=llm)
         if keywords < 1:
             raise ValueError("num_keywords must be >= 1")
         self._keywords = keywords
@@ -240,6 +245,8 @@ class QuestionsAnsweredExtractor(MetadataFeatureExtractor):
 
     def __init__(
         self,
+        llm: Optional[LLM] = None,
+        # TODO: llm_predictor arg is deprecated
         llm_predictor: Optional[BaseLLMPredictor] = None,
         questions: int = 5,
         prompt_template: Optional[str] = None,
@@ -248,7 +255,7 @@ class QuestionsAnsweredExtractor(MetadataFeatureExtractor):
         """Init params."""
         if questions < 1:
             raise ValueError("questions must be >= 1")
-        self._llm_predictor = llm_predictor or LLMPredictor()
+        self._llm_predictor = llm_predictor or LLMPredictor(llm=llm)
         self._questions = questions
         self._prompt_template = prompt_template
         self._embedding_only = embedding_only
@@ -297,11 +304,13 @@ class SummaryExtractor(MetadataFeatureExtractor):
 
     def __init__(
         self,
+        llm: Optional[LLM] = None,
+        # TODO: llm_predictor arg is deprecated
         llm_predictor: Optional[BaseLLMPredictor] = None,
         summaries: List[str] = ["self"],
         prompt_template: str = DEFAULT_SUMMARY_EXTRACT_TEMPLATE,
     ):
-        self._llm_predictor = llm_predictor or LLMPredictor()
+        self._llm_predictor = llm_predictor or LLMPredictor(llm=llm)
         # validation
         if not all([s in ["self", "prev", "next"] for s in summaries]):
             raise ValueError("summaries must be one of ['self', 'prev', 'next']")

--- a/llama_index/prompts/chat_prompts.py
+++ b/llama_index/prompts/chat_prompts.py
@@ -72,18 +72,16 @@ CHAT_REFINE_PROMPT_TMPL_MSGS = [
         "You are an expert Q&A system that follows strict rules:\n"
         "1. **Rewrite** an original answer using new context information\n"
         "2. **Repeat** the original answer if the context isn't useful\n"
-        "3. Never mention or reference the orginal answer."
+        "3. **Never** mention or reference the orginal answer or context "
+        "information directly.\n"
     ),
     HumanMessagePromptTemplate.from_template(
-        "We have the opportunity to refine an original answer "
-        "(only if needed) with some more context below.\n"
-        "------------\n"
-        "{context_msg}\n"
-        "------------\n"
+        "New Context: {context_msg}\n"
         "Given the new context, refine the original answer to better "
         "answer the question: {query_str}. "
         "If the context isn't useful, output the original answer again.\n"
-        "Original Answer: {existing_answer}"
+        "Original Answer: {existing_answer}\n"
+        "Refined Answer: "
     ),
 ]
 

--- a/llama_index/prompts/default_prompts.py
+++ b/llama_index/prompts/default_prompts.py
@@ -88,7 +88,8 @@ DEFAULT_REFINE_PROMPT_TMPL = (
     "------------\n"
     "Given the new context, refine the original answer to better "
     "answer the question. "
-    "If the context isn't useful, return the original answer."
+    "If the context isn't useful, return the original answer.\n"
+    "Refined Answer: "
 )
 DEFAULT_REFINE_PROMPT = Prompt(
     DEFAULT_REFINE_PROMPT_TMPL, prompt_type=PromptType.REFINE


### PR DESCRIPTION
# Description

This PR tweaks some prompts, as well as updates the metadata extraction notebook. 

After a lot of iteration, gpt-3.5 is just kind of bad at reading tabular data. Hence, the demo switches to GPT-4 for answering the questions (but uses 3.5 for extracting metadata)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
