### PR TITLE
Make ChatMemoryBuffer Pickleable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 ## Unreleased
 
-### Bug Fixes / Nits
-- Update the default `EntityExtractor` model (#7209)
-
-## [0.7.22] - 2023-08-08
 ### New Features
 - Added Xorbits inference for local deployments (#7151)
+
+### Bug Fixes / Nits
+- Update the default `EntityExtractor` model (#7209)
+- Make `ChatMemoryBuffer` pickleable (#7205)
+
+## [0.7.22] - 2023-08-08
 
 ### New Features
 - add ensemble retriever notebook (#7190)

--- a/llama_index/indices/postprocessor/optimizer.py
+++ b/llama_index/indices/postprocessor/optimizer.py
@@ -7,7 +7,7 @@ from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.indices.postprocessor.types import BaseNodePostprocessor
 from llama_index.indices.query.embedding_utils import get_top_k_embeddings
 from llama_index.indices.query.schema import QueryBundle
-from llama_index.schema import NodeWithScore, MetadataMode
+from llama_index.schema import MetadataMode, NodeWithScore
 
 logger = logging.getLogger(__name__)
 

--- a/llama_index/memory/chat_memory_buffer.py
+++ b/llama_index/memory/chat_memory_buffer.py
@@ -16,9 +16,7 @@ class ChatMemoryBuffer(BaseMemory):
     token_limit: int
     tokenizer_fn: Callable[[str], List] = Field(
         # NOTE: mypy does not handle the typing here well, hence the cast
-        default_factory=cast(
-            Callable[[], Any], GlobalsHelper().tokenizer
-        ),  # do_nothing
+        default_factory=cast(Callable[[], Any], GlobalsHelper().tokenizer),
         exclude=True,
     )
     chat_history: List[ChatMessage] = Field(default_factory=list)
@@ -45,7 +43,7 @@ class ChatMemoryBuffer(BaseMemory):
         # Validate tokenizer -- this avoids errors when loading from json/dict
         tokenizer_fn = values.get("tokenizer_fn", None)
         if tokenizer_fn is None:
-            values["tokenizer_fn"] = GlobalsHelper().tokenizer  # do_nothing
+            values["tokenizer_fn"] = GlobalsHelper().tokenizer
 
         return values
 

--- a/llama_index/memory/chat_memory_buffer.py
+++ b/llama_index/memory/chat_memory_buffer.py
@@ -1,4 +1,3 @@
-from functools import partial
 from typing import Any, Callable, Dict, List, Optional, cast
 
 from pydantic import Field, root_validator

--- a/llama_index/memory/chat_memory_buffer.py
+++ b/llama_index/memory/chat_memory_buffer.py
@@ -1,7 +1,8 @@
-from pydantic import Field, root_validator
 from typing import Any, Callable, List, Optional, cast
 
-from llama_index.llms.base import ChatMessage, LLM
+from pydantic import Field, root_validator
+
+from llama_index.llms.base import LLM, ChatMessage
 from llama_index.memory.types import BaseMemory
 from llama_index.utils import GlobalsHelper
 

--- a/tests/memory/test_chat_memory_buffer.py
+++ b/tests/memory/test_chat_memory_buffer.py
@@ -1,3 +1,5 @@
+import pickle
+
 from llama_index.llms import ChatMessage, MessageRole
 from llama_index.memory.chat_memory_buffer import ChatMemoryBuffer
 
@@ -64,3 +66,10 @@ def test_dict_save_load() -> None:
 
     assert len(new_memory.get()) == 1
     assert new_memory.token_limit == 5
+
+
+def test_pickle() -> None:
+    """Unpickleable tiktoken tokenizer should be circumvented when pickling"""
+    memory = ChatMemoryBuffer.from_defaults()
+    bytes_ = pickle.dumps(memory)
+    assert isinstance(pickle.loads(bytes_), ChatMemoryBuffer)


### PR DESCRIPTION
# Description

`llama_index.memory.ChatMemoryBuffer` would try to pickle its tokenizer, leading to an error.

Implemented `__getstate__` and `__setstate__` to circumvent this and reconstruct the tokenizer according to the init logic.

Fixes # (issue)
#886 
#7169 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
