### PR TITLE
fix metadata formatting and extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Bug Fixes / Nits
+- Fixed metadata formatting with custom tempalates and inheritance (#7216)
+
+## [0.7.23] - 2023-08-10
+
 ### New Features
 - Added Xorbits inference for local deployments (#7151)
 - Added Zep vector store integration (#7203)

--- a/llama_index/node_parser/extractors/metadata_extractors.py
+++ b/llama_index/node_parser/extractors/metadata_extractors.py
@@ -223,7 +223,7 @@ document. Format as comma separated. Keywords: """
                 context_str=cast(TextNode, node).text,
             )
             # node.metadata["excerpt_keywords"] = keywords
-            metadata_list.append({"excerpt_keywords": keywords})
+            metadata_list.append({"excerpt_keywords": keywords.strip()})
         return metadata_list
 
 
@@ -276,7 +276,9 @@ content: {cast(TextNode, node).text}""",
             )
             if self._embedding_only:
                 node.excluded_llm_metadata_keys = ["questions_this_excerpt_can_answer"]
-            metadata_list.append({"questions_this_excerpt_can_answer": questions})
+            metadata_list.append(
+                {"questions_this_excerpt_can_answer": questions.strip()}
+            )
         return metadata_list
 
 
@@ -317,7 +319,7 @@ class SummaryExtractor(MetadataFeatureExtractor):
             self._llm_predictor.predict(
                 Prompt(template=self._prompt_template),
                 context_str=cast(TextNode, node).text,
-            )
+            ).strip()
             for node in nodes
         ]
 

--- a/llama_index/node_parser/node_utils.py
+++ b/llama_index/node_parser/node_utils.py
@@ -95,6 +95,7 @@ def get_nodes_from_document(
                 excluded_embed_metadata_keys=document.excluded_embed_metadata_keys,
                 excluded_llm_metadata_keys=document.excluded_llm_metadata_keys,
                 metadata_seperator=document.metadata_seperator,
+                metadata_template=document.metadata_template,
                 text_template=document.text_template,
                 relationships={
                     NodeRelationship.SOURCE: document.as_related_node_info()

--- a/llama_index/schema.py
+++ b/llama_index/schema.py
@@ -258,6 +258,9 @@ class TextNode(BaseNode):
     def get_content(self, metadata_mode: MetadataMode = MetadataMode.NONE) -> str:
         """Get object content."""
         metadata_str = self.get_metadata_str(mode=metadata_mode).strip()
+        if not metadata_str:
+            return self.text
+
         return self.text_template.format(
             content=self.text, metadata_str=metadata_str
         ).strip()


### PR DESCRIPTION
# Description

Node parsing had a few issues
- metadata template not behing inherited
- formatting the node content for MetadataMode.NONE can be wonky with custom templates
- extractors have too much whitespace 

The PR fixes all 3 of these things.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Ran test-case in terminal
- [x] I stared at the code and made sure it makes sense
