### PR TITLE
use 1-cosine distance for pgvector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Bug Fixes / Nits
+- Use `1 - cosine_distance` for pgvector/postgres vector db (#7217)
+
+## [0.7.23] - 2023-08-10
+
 ### New Features
 - Added Xorbits inference for local deployments (#7151)
 - Added Zep vector store integration (#7203)

--- a/llama_index/vector_stores/postgres.py
+++ b/llama_index/vector_stores/postgres.py
@@ -168,8 +168,8 @@ class PGVectorStore(VectorStore):
         from sqlalchemy import select
 
         stmt = select(  # type: ignore
-            self.table_class, self.table_class.embedding.l2_distance(embedding)
-        ).order_by(self.table_class.embedding.l2_distance(embedding))
+            self.table_class, self.table_class.embedding.cosine_distance(embedding)
+        ).order_by(self.table_class.embedding.cosine_distance(embedding))
         if metadata_filters:
             for filter_ in metadata_filters.filters:
                 bind_parameter = f"value_{filter_.key}"
@@ -196,7 +196,7 @@ class PGVectorStore(VectorStore):
                         node_id=item.node_id,
                         text=item.text,
                         metadata=item.metadata_,
-                        similarity=sim,
+                        similarity=(1 - sim),
                     )
                     for item, sim in res.all()
                 ]
@@ -216,7 +216,7 @@ class PGVectorStore(VectorStore):
                         node_id=item.node_id,
                         text=item.text,
                         metadata=item.metadata_,
-                        similarity=sim,
+                        similarity=(1 - sim),
                     )
                     for item, sim in res.all()
                 ]


### PR DESCRIPTION
# Description

PgVector scoring seemed to be a little wonky. Switching to `1 - cosine_distance` seems to make a lot more sense.

Fixes https://github.com/jerryjliu/llama_index/issues/7214

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Local notebook
- [x] I stared at the code and made sure it makes sense
