### PR TITLE
feat: add node_postprocessors to ContextChatEngine

### DIFF
--- a/llama_index/chat_engine/context.py
+++ b/llama_index/chat_engine/context.py
@@ -10,8 +10,8 @@ from llama_index.chat_engine.types import (
 )
 from llama_index.indices.base_retriever import BaseRetriever
 from llama_index.indices.postprocessor.types import BaseNodePostprocessor
-from llama_index.indices.service_context import ServiceContext
 from llama_index.indices.query.schema import QueryBundle
+from llama_index.indices.service_context import ServiceContext
 from llama_index.llm_predictor.base import LLMPredictor
 from llama_index.llms.base import LLM, ChatMessage, MessageRole
 from llama_index.memory import BaseMemory, ChatMemoryBuffer

--- a/llama_index/chat_engine/context.py
+++ b/llama_index/chat_engine/context.py
@@ -93,7 +93,9 @@ class ContextChatEngine(BaseChatEngine):
         """Generate context information from a message."""
         nodes = self._retriever.retrieve(message)
         for postprocessor in self._node_postprocessors:
-            nodes = postprocessor.postprocess_nodes(nodes)
+    nodes = postprocessor.postprocess_nodes(
+        nodes, query_bundle=QueryBundle(message)
+    )
 
         context_str = "\n\n".join(
             [n.node.get_content(metadata_mode=MetadataMode.LLM).strip() for n in nodes]

--- a/llama_index/chat_engine/context.py
+++ b/llama_index/chat_engine/context.py
@@ -37,7 +37,7 @@ class ContextChatEngine(BaseChatEngine):
         llm: LLM,
         memory: BaseMemory,
         prefix_messages: List[ChatMessage],
-        node_postprocessors: Optional[List[BaseNodePostprocessor]],
+        node_postprocessors: Optional[List[BaseNodePostprocessor]] = None,
         context_template: Optional[str] = None,
     ) -> None:
         self._retriever = retriever

--- a/llama_index/chat_engine/context.py
+++ b/llama_index/chat_engine/context.py
@@ -37,15 +37,15 @@ class ContextChatEngine(BaseChatEngine):
         llm: LLM,
         memory: BaseMemory,
         prefix_messages: List[ChatMessage],
+        node_postprocessors: Optional[List[BaseNodePostprocessor]],
         context_template: Optional[str] = None,
-        node_postprocessors: Optional[List[BaseNodePostprocessor]] = None,
     ) -> None:
         self._retriever = retriever
         self._llm = llm
         self._memory = memory
         self._prefix_messages = prefix_messages
+        self._node_postprocessors = node_postprocessors or []
         self._context_template = context_template or DEFAULT_CONTEXT_TEMPALTE
-        self._node_postprocessors = node_postprocessors
 
     @classmethod
     def from_defaults(

--- a/llama_index/chat_engine/context.py
+++ b/llama_index/chat_engine/context.py
@@ -93,9 +93,9 @@ class ContextChatEngine(BaseChatEngine):
         """Generate context information from a message."""
         nodes = self._retriever.retrieve(message)
         for postprocessor in self._node_postprocessors:
-    nodes = postprocessor.postprocess_nodes(
-        nodes, query_bundle=QueryBundle(message)
-    )
+            nodes = postprocessor.postprocess_nodes(
+                nodes, query_bundle=QueryBundle(message)
+            )
 
         context_str = "\n\n".join(
             [n.node.get_content(metadata_mode=MetadataMode.LLM).strip() for n in nodes]

--- a/llama_index/chat_engine/context.py
+++ b/llama_index/chat_engine/context.py
@@ -45,7 +45,7 @@ class ContextChatEngine(BaseChatEngine):
         self._memory = memory
         self._prefix_messages = prefix_messages
         self._context_template = context_template or DEFAULT_CONTEXT_TEMPALTE
-        self._node_postprocessors = node_postprocessors or []
+        self._node_postprocessors = node_postprocessors
 
     @classmethod
     def from_defaults(
@@ -57,6 +57,7 @@ class ContextChatEngine(BaseChatEngine):
         memory_cls: Type[BaseMemory] = ChatMemoryBuffer,
         system_prompt: Optional[str] = None,
         prefix_messages: Optional[List[ChatMessage]] = None,
+        node_postprocessors: Optional[List[BaseNodePostprocessor]] = None,
         **kwargs: Any,
     ) -> "ContextChatEngine":
         """Initialize a ContextChatEngine from default parameters."""
@@ -78,8 +79,15 @@ class ContextChatEngine(BaseChatEngine):
             ]
 
         prefix_messages = prefix_messages or []
+        node_postprocessors = node_postprocessors or []
 
-        return cls(retriever, llm=llm, memory=memory, prefix_messages=prefix_messages)
+        return cls(
+            retriever,
+            llm=llm,
+            memory=memory,
+            prefix_messages=prefix_messages,
+            node_postprocessors=node_postprocessors,
+        )
 
     def _generate_context(self, message: str) -> Tuple[str, List[NodeWithScore]]:
         """Generate context information from a message."""

--- a/llama_index/chat_engine/context.py
+++ b/llama_index/chat_engine/context.py
@@ -11,6 +11,7 @@ from llama_index.chat_engine.types import (
 from llama_index.indices.base_retriever import BaseRetriever
 from llama_index.indices.postprocessor.types import BaseNodePostprocessor
 from llama_index.indices.service_context import ServiceContext
+from llama_index.indices.query.schema import QueryBundle
 from llama_index.llm_predictor.base import LLMPredictor
 from llama_index.llms.base import LLM, ChatMessage, MessageRole
 from llama_index.memory import BaseMemory, ChatMemoryBuffer


### PR DESCRIPTION
# Description

Since the ContextChatEngine uses the Retriever to pulls the related context instead of using the QueryEngine, it lost the ability to do node postprocessing. This PR AIM to solve that gap

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- X ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
