### PR TITLE
fix broken link syntax

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,7 +48,7 @@ Our documentation includes detailed `Installation Instructions <./getting_starte
 
 Once you're up and running, `High-Level Concepts <./getting_started/concepts.html>`_ has an overview of LlamaIndex's modular architecture. For more hands-on practical examples, look through our `End-to-End Tutorials <./end_to_end_tutorials/use_cases.html>`_ or learn how to `customize <./getting_started/customization.html>`_ components to fit your specific needs.
 
-**NOTE**: We have a Typescript package too! [[Repo]](https://github.com/run-llama/LlamaIndexTS) [[Docs]](https://ts.llamaindex.ai/)
+**NOTE**: We have a Typescript package too! `Repo <https://github.com/run-llama/LlamaIndexTS>`_, `Docs <https://ts.llamaindex.ai/>`_
 
 🗺️ Ecosystem
 ************


### PR DESCRIPTION
# Description

Fixes this docs syntax on https://gpt-index.readthedocs.io/en/latest/

![image](https://github.com/czue/llama_index/assets/66555/3161459a-6a89-4951-92ee-bf2d6c703d3e)


Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Viewed the [updated page on Github](https://github.com/czue/llama_index/blob/a0e8569341a6a926b5c73eafaac7704d51cc3f78/docs/index.rst) to confirm the links work and look good.

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
