### PR TITLE
tune prompts to be more general

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes / Nits
 - Updated supabase kwargs for add and query (#7103)
+- Small tweak to default prompts to allow for more general purpose queries (#7254)
 
 ## [0.8.1] - 2023-08-13
 

--- a/llama_index/prompts/chat_prompts.py
+++ b/llama_index/prompts/chat_prompts.py
@@ -17,7 +17,7 @@ from llama_index.prompts.prompts import (
 # text qa prompt
 TEXT_QA_SYSTEM_PROMPT = SystemMessagePromptTemplate.from_template(
     "You are an expert Q&A system that is trusted around the world.\n"
-    "Always answer the question using the provided context information, "
+    "Always answer the query using the provided context information, "
     "and not prior knowledge.\n"
     "Some rules to follow:\n"
     "1. Never directly reference the given context in your answer.\n"
@@ -34,9 +34,8 @@ TEXT_QA_PROMPT_TMPL_MSGS = [
         "{context_str}\n"
         "---------------------\n"
         "Given the context information and not prior knowledge, "
-        "answer the question. If the answer is not in the context, inform "
-        "the user that you can't answer the question.\n"
-        "Question: {query_str}\n"
+        "answer the query.\n"
+        "Query: {query_str}\n"
         "Answer: "
     ),
 ]
@@ -54,9 +53,8 @@ TREE_SUMMARIZE_PROMPT_TMPL_MSGS = [
         "{context_str}\n"
         "---------------------\n"
         "Given the information from multiple sources and not prior knowledge, "
-        "answer the question. If the answer is not in the context, inform "
-        "the user that you can't answer the question.\n"
-        "Question: {query_str}\n"
+        "answer the query.\n"
+        "Query: {query_str}\n"
         "Answer: "
     ),
 ]

--- a/llama_index/prompts/default_prompts.py
+++ b/llama_index/prompts/default_prompts.py
@@ -79,7 +79,7 @@ DEFAULT_QUERY_PROMPT_MULTIPLE = Prompt(
 
 
 DEFAULT_REFINE_PROMPT_TMPL = (
-    "The original question is as follows: {query_str}\n"
+    "The original query is as follows: {query_str}\n"
     "We have provided an existing answer: {existing_answer}\n"
     "We have the opportunity to refine the existing answer "
     "(only if needed) with some more context below.\n"
@@ -87,7 +87,7 @@ DEFAULT_REFINE_PROMPT_TMPL = (
     "{context_msg}\n"
     "------------\n"
     "Given the new context, refine the original answer to better "
-    "answer the question. "
+    "answer the query. "
     "If the context isn't useful, return the original answer.\n"
     "Refined Answer: "
 )
@@ -102,9 +102,8 @@ DEFAULT_TEXT_QA_PROMPT_TMPL = (
     "{context_str}\n"
     "---------------------\n"
     "Given the context information and not prior knowledge, "
-    "answer the question. If the answer is not in the context, inform "
-    "the user that you can't answer the question.\n"
-    "Question: {query_str}\n"
+    "answer the query.\n"
+    "Query: {query_str}\n"
     "Answer: "
 )
 DEFAULT_TEXT_QA_PROMPT = Prompt(
@@ -117,9 +116,8 @@ DEFAULT_TREE_SUMMARIZE_TMPL = (
     "{context_str}\n"
     "---------------------\n"
     "Given the information from multiple sources and not prior knowledge, "
-    "answer the question. If the answer is not in the context, inform "
-    "the user that you can't answer the question.\n"
-    "Question: {query_str}\n"
+    "answer the query.\n"
+    "Query: {query_str}\n"
     "Answer: "
 )
 DEFAULT_TREE_SUMMARIZE_PROMPT = Prompt(


### PR DESCRIPTION
# Description

The current default prompts are maybe a little too restrictive and focused on question-answering. Since there are many applications beyond question-answering, the default prompts are updated to be a little more general.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested several types of queries locally
- [x] I stared at the code and made sure it makes sense
