### PR TITLE
make llm and embeddings more optional and robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+- Enable the LLM or embedding model to be disabled by setting to `None` in the service context (#7255)
+- Resolve nearly any huggingface embedding model using the `embed_model="local:<model_name>"` syntax (#7255)
+
 ### Bug Fixes / Nits
 - Updated supabase kwargs for add and query (#7103)
 

--- a/llama_index/embeddings/utils.py
+++ b/llama_index/embeddings/utils.py
@@ -1,14 +1,33 @@
 """Embedding utils for LlamaIndex."""
 import os
-from typing import List, Union
+from typing import List, Optional, Union
 
 from llama_index.utils import get_cache_dir
 from llama_index.bridge.langchain import Embeddings as LCEmbeddings
 from llama_index.embeddings.base import BaseEmbedding
 from llama_index.embeddings.langchain import LangchainEmbedding
 from llama_index.embeddings.openai import OpenAIEmbedding
+from llama_index.token_counter.mock_embed_model import MockEmbedding
 
 DEFAULT_HUGGINGFACE_EMBEDDING_MODEL = "BAAI/bge-small-en"
+BGE_MODELS = (
+    "BAAI/bge-small-en",
+    "BAAI/bge-base-en",
+    "BAAI/bge-large-en",
+    "BAAI/bge-small-zh",
+    "BAAI/bge-base-zh",
+    "BAAI/bge-large-zh",
+)
+INSTRUCTOR_MODELS = (
+    "hku-nlp/instructor-base",
+    "hku-nlp/instructor-large",
+    "hku-nlp/instructor-xl",
+    "hkunlp/instructor-base",
+    "hkunlp/instructor-large",
+    "hkunlp/instructor-xl",
+)
+
+EmbedType = Union[BaseEmbedding, LCEmbeddings, str]
 
 
 def save_embedding(embedding: List[float], file_path: str) -> None:
@@ -26,13 +45,11 @@ def load_embedding(file_path: str) -> List[float]:
         return embedding
 
 
-def resolve_embed_model(
-    embed_model: Union[None, str, BaseEmbedding, LCEmbeddings]
-) -> BaseEmbedding:
+def resolve_embed_model(embed_model: Optional[EmbedType] = None) -> BaseEmbedding:
     """Resolve embed model."""
-    if embed_model is None:
+    if embed_model == "default":
         try:
-            return OpenAIEmbedding()
+            embed_model = OpenAIEmbedding()
         except ValueError:
             embed_model = "local"
             print(
@@ -52,7 +69,11 @@ def resolve_embed_model(
                 "embed_model must start with str 'local' or of type BaseEmbedding"
             )
         try:
-            from langchain.embeddings import HuggingFaceBgeEmbeddings
+            from langchain.embeddings import (
+                HuggingFaceBgeEmbeddings,
+                HuggingFaceEmbeddings,
+                HuggingFaceInstructEmbeddings,
+            )
         except ImportError as exc:
             raise ImportError(
                 "Could not import sentence_transformers or langchain package. "
@@ -62,14 +83,29 @@ def resolve_embed_model(
         cache_folder = os.path.join(get_cache_dir(), "models")
         os.makedirs(cache_folder, exist_ok=True)
 
-        embed_model = LangchainEmbedding(
-            HuggingFaceBgeEmbeddings(
-                model_name=model_name or DEFAULT_HUGGINGFACE_EMBEDDING_MODEL,
-                cache_folder=cache_folder,
+        if model_name is None or model_name in BGE_MODELS:
+            embed_model = LangchainEmbedding(
+                HuggingFaceBgeEmbeddings(
+                    model_name=model_name or DEFAULT_HUGGINGFACE_EMBEDDING_MODEL,
+                    cache_folder=cache_folder,
+                )
             )
-        )
+        elif model_name in INSTRUCTOR_MODELS:
+            embed_model = LangchainEmbedding(
+                HuggingFaceInstructEmbeddings(
+                    model_name=model_name, cache_folder=cache_folder
+                )
+            )
+        else:
+            embed_model = LangchainEmbedding(
+                HuggingFaceEmbeddings(model_name=model_name, cache_folder=cache_folder)
+            )
 
     if isinstance(embed_model, LCEmbeddings):
         embed_model = LangchainEmbedding(embed_model)
+
+    if embed_model is None:
+        print("Embeddings have been explicitly disabled. Using MockEmbedding.")
+        embed_model = MockEmbedding(embed_dim=1)
 
     return embed_model

--- a/llama_index/embeddings/utils.py
+++ b/llama_index/embeddings/utils.py
@@ -50,13 +50,15 @@ def resolve_embed_model(embed_model: Optional[EmbedType] = None) -> BaseEmbeddin
     if embed_model == "default":
         try:
             embed_model = OpenAIEmbedding()
-        except ValueError:
+        except ValueError as e:
             embed_model = "local"
             print(
                 "******\n"
                 "Could not load OpenAIEmbedding. Using HuggingFaceBgeEmbeddings "
                 f"with model_name={DEFAULT_HUGGINGFACE_EMBEDDING_MODEL}. "
-                "Please check your API key if you intended to use OpenAI embeddings."
+                "If you intended to use OpenAI, please check your OPENAI_API_KEY.\n"
+                "Original error:\n"
+                f"{str(e)}"
                 "\n******"
             )
 

--- a/llama_index/indices/service_context.py
+++ b/llama_index/indices/service_context.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Optional
 
 import llama_index
 from llama_index.callbacks.base import CallbackManager
@@ -13,7 +13,7 @@ from llama_index.llms.utils import LLMType
 from llama_index.logger import LlamaLogger
 from llama_index.node_parser.interface import NodeParser
 from llama_index.node_parser.simple import SimpleNodeParser
-from llama_index.embeddings import resolve_embed_model
+from llama_index.embeddings.utils import resolve_embed_model, EmbedType
 
 logger = logging.getLogger(__name__)
 
@@ -70,9 +70,9 @@ class ServiceContext:
     def from_defaults(
         cls,
         llm_predictor: Optional[BaseLLMPredictor] = None,
-        llm: Optional[LLMType] = None,
+        llm: Optional[LLMType] = "default",
         prompt_helper: Optional[PromptHelper] = None,
-        embed_model: Optional[Union[BaseEmbedding, str]] = None,
+        embed_model: Optional[EmbedType] = "default",
         node_parser: Optional[NodeParser] = None,
         llama_logger: Optional[LlamaLogger] = None,
         callback_manager: Optional[CallbackManager] = None,
@@ -166,9 +166,9 @@ class ServiceContext:
         cls,
         service_context: "ServiceContext",
         llm_predictor: Optional[BaseLLMPredictor] = None,
-        llm: Optional[LLM] = None,
+        llm: Optional[LLMType] = "default",
         prompt_helper: Optional[PromptHelper] = None,
-        embed_model: Optional[Union[BaseEmbedding, str]] = None,
+        embed_model: Optional[EmbedType] = "default",
         node_parser: Optional[NodeParser] = None,
         llama_logger: Optional[LlamaLogger] = None,
         callback_manager: Optional[CallbackManager] = None,

--- a/llama_index/indices/service_context.py
+++ b/llama_index/indices/service_context.py
@@ -126,7 +126,7 @@ class ServiceContext:
             )
 
         callback_manager = callback_manager or CallbackManager([])
-        if llm is not None:
+        if llm is not None and llm != "default":
             if llm_predictor is not None:
                 raise ValueError("Cannot specify both llm and llm_predictor")
             llm_predictor = LLMPredictor(llm=llm)
@@ -190,7 +190,7 @@ class ServiceContext:
             chunk_size = chunk_size_limit
 
         callback_manager = callback_manager or service_context.callback_manager
-        if llm is not None:
+        if llm is not None and llm != "default":
             if llm_predictor is not None:
                 raise ValueError("Cannot specify both llm and llm_predictor")
             llm_predictor = LLMPredictor(llm=llm)

--- a/llama_index/llms/utils.py
+++ b/llama_index/llms/utils.py
@@ -18,12 +18,14 @@ def resolve_llm(llm: Optional[LLMType] = None) -> LLM:
         # return default OpenAI model. If it fails, return LlamaCPP
         try:
             llm = OpenAI()
-        except ValueError:
+        except ValueError as e:
             llm = "local"
             print(
                 "******\n"
                 "Could not load OpenAI model. Using default LlamaCPP=llama2-13b-chat. "
-                "If you intended to use OpenAI, please check your API key."
+                "If you intended to use OpenAI, please check your OPENAI_API_KEY.\n"
+                "Original error:\n"
+                f"{str(e)}"
                 "\n******"
             )
 

--- a/llama_index/llms/utils.py
+++ b/llama_index/llms/utils.py
@@ -6,6 +6,7 @@ from llama_index.llms.base import LLM
 from llama_index.llms.langchain import LangChainLLM
 from llama_index.llms.llama_cpp import LlamaCPP
 from llama_index.llms.llama_utils import messages_to_prompt, completion_to_prompt
+from llama_index.llms.mock import MockLLM
 from llama_index.llms.openai import OpenAI
 
 LLMType = Union[str, LLM, BaseLanguageModel]
@@ -13,6 +14,19 @@ LLMType = Union[str, LLM, BaseLanguageModel]
 
 def resolve_llm(llm: Optional[LLMType] = None) -> LLM:
     """Resolve LLM from string or LLM instance."""
+    if llm == "default":
+        # return default OpenAI model. If it fails, return LlamaCPP
+        try:
+            llm = OpenAI()
+        except ValueError:
+            llm = "local"
+            print(
+                "******\n"
+                "Could not load OpenAI model. Using default LlamaCPP=llama2-13b-chat. "
+                "If you intended to use OpenAI, please check your API key."
+                "\n******"
+            )
+
     if isinstance(llm, str):
         splits = llm.split(":", 1)
         is_local = splits[0]
@@ -21,7 +35,7 @@ def resolve_llm(llm: Optional[LLMType] = None) -> LLM:
             raise ValueError(
                 "llm must start with str 'local' or of type LLM or BaseLanguageModel"
             )
-        return LlamaCPP(
+        llm = LlamaCPP(
             model_path=model_path,
             messages_to_prompt=messages_to_prompt,
             completion_to_prompt=completion_to_prompt,
@@ -29,22 +43,9 @@ def resolve_llm(llm: Optional[LLMType] = None) -> LLM:
         )
     elif isinstance(llm, BaseLanguageModel):
         # NOTE: if it's a langchain model, wrap it in a LangChainLLM
-        return LangChainLLM(llm=llm)
+        llm = LangChainLLM(llm=llm)
+    elif llm is None:
+        print("LLM is explicitly disabled. Using MockLLM.")
+        llm = MockLLM()
 
-    # return default OpenAI model. If it fails, return LlamaCPP
-    try:
-        return llm or OpenAI()
-    except ValueError:
-        print(
-            "******\n"
-            "Could not load OpenAI model. Using default LlamaCPP=llama2-13b-chat. "
-            "If you intended to use OpenAI, please check your API key."
-            "\n******"
-        )
-
-        # instansiate LlamaCPP with proper llama2-chat prompts
-        return LlamaCPP(
-            messages_to_prompt=messages_to_prompt,
-            completion_to_prompt=completion_to_prompt,
-            model_kwargs={"n_gpu_layers": 1},
-        )
+    return llm

--- a/tests/embeddings/test_utils.py
+++ b/tests/embeddings/test_utils.py
@@ -4,6 +4,7 @@ from pytest import MonkeyPatch
 from llama_index.bridge.langchain import HuggingFaceBgeEmbeddings
 from llama_index.embeddings import OpenAIEmbedding, LangchainEmbedding
 from llama_index.embeddings.utils import resolve_embed_model
+from llama_index.token_counter.mock_embed_model import MockEmbedding
 
 
 def mock_hf_embeddings(*args: Any, **kwargs: Dict[str, Any]) -> Any:
@@ -27,7 +28,7 @@ def test_resolve_embed_model(monkeypatch: MonkeyPatch) -> None:
 
     # Test None
     embed_model = resolve_embed_model(None)
-    assert isinstance(embed_model, OpenAIEmbedding)
+    assert isinstance(embed_model, MockEmbedding)
 
     # Test str
     embed_model = resolve_embed_model("local")


### PR DESCRIPTION
# Description

If a user REALLY doesn't want to use embeddings or an LLM, you can now set them to `None` explicitly. 

Furthermore, resolving the `embed_model` has been improved to use appropriate classes for most huggingface models.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense
