### PR TITLE
make callback manager properly optional for customLLM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@
 ### New Features
 - Enable the LLM or embedding model to be disabled by setting to `None` in the service context (#7255)
 - Resolve nearly any huggingface embedding model using the `embed_model="local:<model_name>"` syntax (#7255)
+- Async tool-calling support (#7239)
 
 ### Bug Fixes / Nits
 - Updated supabase kwargs for add and query (#7103)
 - Small tweak to default prompts to allow for more general purpose queries (#7254)
+- Make callback manager optional for `CustomLLM` + docs update (#7257)
 
 ## [0.8.1] - 2023-08-13
 

--- a/docs/core_modules/model_modules/llms/usage_custom.md
+++ b/docs/core_modules/model_modules/llms/usage_custom.md
@@ -190,7 +190,12 @@ from llama_index import (
     ListIndex
 )
 from llama_index.callbacks import CallbackManager
-from llama_index.llms import CustomLLM, CompletionResponse, LLMMetadata
+from llama_index.llms import (
+    CustomLLM, 
+    CompletionResponse, 
+    CompletionResponseGen,
+    LLMMetadata,
+)
 from llama_index.llms.base import llm_completion_callback
 
 
@@ -204,8 +209,6 @@ model_name = "facebook/opt-iml-max-30b"
 pipeline = pipeline("text-generation", model=model_name, device="cuda:0", model_kwargs={"torch_dtype":torch.bfloat16})
 
 class OurLLM(CustomLLM):
-
-    callback_manager = CallbackManager([])
 
     @property
     def metadata(self) -> LLMMetadata:

--- a/llama_index/llms/custom.py
+++ b/llama_index/llms/custom.py
@@ -25,7 +25,7 @@ class CustomLLM(LLM):
         `stream_complete`, and `metadata` methods.
     """
 
-    def __init__(self, callback_manager: Optional[CallbackManager]) -> None:
+    def __init__(self, callback_manager: Optional[CallbackManager] = None) -> None:
         self.callback_manager = callback_manager or CallbackManager([])
 
     @llm_chat_callback()


### PR DESCRIPTION
# Description

The callback manager was not properly optional for the `CustomLLM` class. Updated the code + example accordingly.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense
