### PR TITLE
accept api_key kwarg in OpenAI LLM class constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## Unreleased
+
+### Bug Fixes / Nits
+- accept `api_key` kwarg in OpenAI LLM class constructor (#7263)
+
 ## [0.8.2.post1] - 2023-08-14
 
 ### New Features

--- a/docs/examples/llm/openai.ipynb
+++ b/docs/examples/llm/openai.ipynb
@@ -438,6 +438,43 @@
     "async for delta in resp:\n",
     "    print(delta.delta, end=\"\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2782f06",
+   "metadata": {},
+   "source": [
+    "## Set API Key at a per-instance level\n",
+    "If desired, you can have separate LLM instances use separate API keys."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "015c2d39",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ValueError",
+     "evalue": "Invalid OpenAI API key.\nAPI key should be of the format: \"sk-\" followed by 48 alphanumeric characters.\n",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[2], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[39mfrom\u001b[39;00m \u001b[39mllama_index\u001b[39;00m\u001b[39m.\u001b[39;00m\u001b[39mllms\u001b[39;00m \u001b[39mimport\u001b[39;00m OpenAI\n\u001b[0;32m----> 3\u001b[0m llm \u001b[39m=\u001b[39m OpenAI(model\u001b[39m=\u001b[39;49m\u001b[39m\"\u001b[39;49m\u001b[39mtext-davinci-003\u001b[39;49m\u001b[39m\"\u001b[39;49m, api_key\u001b[39m=\u001b[39;49m\u001b[39m\"\u001b[39;49m\u001b[39mBAD_KEY\u001b[39;49m\u001b[39m\"\u001b[39;49m)\n\u001b[1;32m      4\u001b[0m resp \u001b[39m=\u001b[39m OpenAI()\u001b[39m.\u001b[39mcomplete(\u001b[39m\"\u001b[39m\u001b[39mPaul Graham is \u001b[39m\u001b[39m\"\u001b[39m)\n\u001b[1;32m      5\u001b[0m \u001b[39mprint\u001b[39m(resp)\n",
+      "File \u001b[0;32m/workspaces/llama_index/llama_index/llms/openai.py:51\u001b[0m, in \u001b[0;36mOpenAI.__init__\u001b[0;34m(self, model, temperature, max_tokens, additional_kwargs, max_retries, api_key, callback_manager, **kwargs)\u001b[0m\n\u001b[1;32m     40\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m__init__\u001b[39m(\n\u001b[1;32m     41\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m     42\u001b[0m     model: \u001b[39mstr\u001b[39m \u001b[39m=\u001b[39m \u001b[39m\"\u001b[39m\u001b[39mgpt-3.5-turbo\u001b[39m\u001b[39m\"\u001b[39m,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     49\u001b[0m     \u001b[39m*\u001b[39m\u001b[39m*\u001b[39mkwargs: Any,\n\u001b[1;32m     50\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[0;32m---> 51\u001b[0m     validate_openai_api_key(\n\u001b[1;32m     52\u001b[0m         api_key, kwargs\u001b[39m.\u001b[39;49mget(\u001b[39m\"\u001b[39;49m\u001b[39mapi_type\u001b[39;49m\u001b[39m\"\u001b[39;49m, \u001b[39mNone\u001b[39;49;00m)\n\u001b[1;32m     53\u001b[0m     )\n\u001b[1;32m     55\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mmodel \u001b[39m=\u001b[39m model\n\u001b[1;32m     56\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mtemperature \u001b[39m=\u001b[39m temperature\n",
+      "File \u001b[0;32m/workspaces/llama_index/llama_index/llms/openai_utils.py:272\u001b[0m, in \u001b[0;36mvalidate_openai_api_key\u001b[0;34m(api_key, api_type)\u001b[0m\n\u001b[1;32m    268\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mValueError\u001b[39;00m(MISSING_API_KEY_ERROR_MESSAGE)\n\u001b[1;32m    269\u001b[0m \u001b[39melif\u001b[39;00m openai_api_type \u001b[39m==\u001b[39m \u001b[39m\"\u001b[39m\u001b[39mopen_ai\u001b[39m\u001b[39m\"\u001b[39m \u001b[39mand\u001b[39;00m \u001b[39mnot\u001b[39;00m OPENAI_API_KEY_FORMAT\u001b[39m.\u001b[39msearch(\n\u001b[1;32m    270\u001b[0m     openai_api_key\n\u001b[1;32m    271\u001b[0m ):\n\u001b[0;32m--> 272\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mValueError\u001b[39;00m(INVALID_API_KEY_ERROR_MESSAGE)\n",
+      "\u001b[0;31mValueError\u001b[0m: Invalid OpenAI API key.\nAPI key should be of the format: \"sk-\" followed by 48 alphanumeric characters.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from llama_index.llms import OpenAI\n",
+    "\n",
+    "llm = OpenAI(model=\"text-davinci-003\", api_key=\"BAD_KEY\")\n",
+    "resp = OpenAI().complete(\"Paul Graham is \")\n",
+    "print(resp)"
+   ]
   }
  ],
  "metadata": {
@@ -456,7 +493,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/llama_index/llms/openai.py
+++ b/llama_index/llms/openai.py
@@ -48,9 +48,7 @@ class OpenAI(LLM):
         callback_manager: Optional[CallbackManager] = None,
         **kwargs: Any,
     ) -> None:
-        validate_openai_api_key(
-            api_key, kwargs.get("api_type", None)
-        )
+        validate_openai_api_key(api_key, kwargs.get("api_type", None))
 
         self.model = model
         self.temperature = temperature

--- a/llama_index/llms/openai.py
+++ b/llama_index/llms/openai.py
@@ -44,17 +44,20 @@ class OpenAI(LLM):
         max_tokens: Optional[int] = None,
         additional_kwargs: Optional[Dict[str, Any]] = None,
         max_retries: int = 10,
+        api_key: Optional[str] = None,
         callback_manager: Optional[CallbackManager] = None,
         **kwargs: Any,
     ) -> None:
         validate_openai_api_key(
-            kwargs.get("api_key", None), kwargs.get("api_type", None)
+            api_key, kwargs.get("api_type", None)
         )
 
         self.model = model
         self.temperature = temperature
         self.max_tokens = max_tokens
         self.additional_kwargs = additional_kwargs or {}
+        if api_key is not None:
+            self.additional_kwargs["api_key"] = api_key
         self.max_retries = max_retries
         self.callback_manager = callback_manager or CallbackManager([])
 


### PR DESCRIPTION
# Description

Not sure when this regressed but seems like we're no longer able to set the API key for an individual `OpenAI` LLM instance with the `api_key` constructor kwarg.

Added a notebook cell that shows you can set the key at the per instance level. Shows this by throwing a validation error for that individual instance's instantiation with a bad `api_key` value.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
