### PR TITLE
Track LlamaIndex usage in Rockset

### DIFF
--- a/llama_index/vector_stores/rocksetdb.py
+++ b/llama_index/vector_stores/rocksetdb.py
@@ -112,6 +112,13 @@ class RocksetVectorStore(VectorStore):
             "ASC" if distance_func is distance_func.EUCLIDEAN_DIST else "DESC"
         )
 
+        try:
+            self.rs.set_application("llama_index")
+        except AttributeError:
+            # set_application method does not exist.
+            # rockset version < 2.1.0
+            pass
+
     @property
     def client(self) -> Any:
         return self.rs


### PR DESCRIPTION
# Description

Adds ability to track LlamaIndex usage in Rockset. 

Rockset's new python client has the `set_application` method. This method sets a header when requesting the Rockset API. It provides Rockset insight into how people use the Python client. 

To prevent old clients from failing, it ignores an `AttributeError` (where method `set_application` does not exist).

This change will not affect how users interact with the library, so no documentation changes are needed.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**None of the above.**

# How Has This Been Tested?

I ran the Rockset integration test and it passed.

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
