### PR TITLE
move LLM and embeddings to pydantic

### DIFF
--- a/llama_index/callbacks/base.py
+++ b/llama_index/callbacks/base.py
@@ -42,9 +42,11 @@ class CallbackManager(BaseCallbackHandler, ABC):
 
     """
 
-    def __init__(self, handlers: List[BaseCallbackHandler]):
+    def __init__(self, handlers: Optional[List[BaseCallbackHandler]] = None):
         """Initialize the manager with a list of handlers."""
         from llama_index import global_handler
+
+        handlers = handlers or []
 
         # add eval handlers based on global defaults
         if global_handler is not None:

--- a/llama_index/embeddings/base.py
+++ b/llama_index/embeddings/base.py
@@ -3,13 +3,14 @@
 import asyncio
 from abc import abstractmethod
 from enum import Enum
+from pydantic import BaseModel, Field, validator, PrivateAttr
 from typing import Callable, Coroutine, List, Optional, Tuple
 
 import numpy as np
 
 from llama_index.callbacks.base import CallbackManager
 from llama_index.callbacks.schema import CBEventType, EventPayload
-from llama_index.utils import get_tqdm_iterable, globals_helper
+from llama_index.utils import get_tqdm_iterable
 
 # TODO: change to numpy array
 EMB_TYPE = List
@@ -48,25 +49,31 @@ def similarity(
         return product / norm
 
 
-class BaseEmbedding:
+class BaseEmbedding(BaseModel):
     """Base class for embeddings."""
 
-    def __init__(
-        self,
-        embed_batch_size: int = DEFAULT_EMBED_BATCH_SIZE,
-        tokenizer: Optional[Callable] = None,
-        callback_manager: Optional[CallbackManager] = None,
-    ) -> None:
-        """Init params."""
-        self._total_tokens_used = 0
-        self._last_token_usage: Optional[int] = None
-        self._tokenizer = tokenizer or globals_helper.tokenizer
-        self.callback_manager = callback_manager or CallbackManager([])
-        # list of tuples of id, text
-        self._text_queue: List[Tuple[str, str]] = []
-        if embed_batch_size <= 0:
-            raise ValueError("embed_batch_size must be > 0")
-        self._embed_batch_size = embed_batch_size
+    model_name: str = Field(
+        default="unknown", description="The name of the embedding model."
+    )
+    embed_batch_size: int = Field(
+        default=DEFAULT_EMBED_BATCH_SIZE,
+        description="The batch size for embedding calls.",
+    )
+    callback_manager: CallbackManager = Field(
+        default_factory=lambda: CallbackManager([]), exclude=True
+    )
+    _text_queue: List[Tuple[str, str]] = PrivateAttr(default_factory=list)
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    @validator("callback_manager", pre=True)
+    def _validate_callback_manager(
+        cls, v: Optional[CallbackManager]
+    ) -> CallbackManager:
+        if v is None:
+            return CallbackManager([])
+        return v
 
     @abstractmethod
     def _get_query_embedding(self, query: str) -> List[float]:
@@ -80,8 +87,6 @@ class BaseEmbedding:
         """Get query embedding."""
         with self.callback_manager.event(CBEventType.EMBEDDING) as event:
             query_embedding = self._get_query_embedding(query)
-            query_tokens_count = len(self._tokenizer(query))
-            self._total_tokens_used += query_tokens_count
 
             event.on_end(
                 payload={
@@ -95,8 +100,6 @@ class BaseEmbedding:
         """Get query embedding."""
         with self.callback_manager.event(CBEventType.EMBEDDING) as event:
             query_embedding = await self._aget_query_embedding(query)
-            query_tokens_count = len(self._tokenizer(query))
-            self._total_tokens_used += query_tokens_count
 
             event.on_end(
                 payload={
@@ -165,8 +168,6 @@ class BaseEmbedding:
         """Get text embedding."""
         with self.callback_manager.event(CBEventType.EMBEDDING) as event:
             text_embedding = self._get_text_embedding(text)
-            text_tokens_count = len(self._tokenizer(text))
-            self._total_tokens_used += text_tokens_count
 
             event.on_end(
                 payload={
@@ -204,9 +205,7 @@ class BaseEmbedding:
 
         for idx, (text_id, text) in queue_with_progress:
             cur_batch.append((text_id, text))
-            text_tokens_count = len(self._tokenizer(text))
-            self._total_tokens_used += text_tokens_count
-            if idx == len(text_queue) - 1 or len(cur_batch) == self._embed_batch_size:
+            if idx == len(text_queue) - 1 or len(cur_batch) == self.embed_batch_size:
                 # flush
                 with self.callback_manager.event(CBEventType.EMBEDDING) as event:
                     cur_batch_ids = [text_id for text_id, _ in cur_batch]
@@ -242,9 +241,7 @@ class BaseEmbedding:
         embeddings_coroutines: List[Coroutine] = []
         for idx, (text_id, text) in enumerate(text_queue):
             cur_batch.append((text_id, text))
-            text_tokens_count = len(self._tokenizer(text))
-            self._total_tokens_used += text_tokens_count
-            if idx == len(text_queue) - 1 or len(cur_batch) == self._embed_batch_size:
+            if idx == len(text_queue) - 1 or len(cur_batch) == self.embed_batch_size:
                 # flush
                 event_id = self.callback_manager.on_event_start(CBEventType.EMBEDDING)
                 cur_batch_ids = [text_id for text_id, _ in cur_batch]
@@ -301,20 +298,3 @@ class BaseEmbedding:
     ) -> float:
         """Get embedding similarity."""
         return similarity(embedding1=embedding1, embedding2=embedding2, mode=mode)
-
-    @property
-    def total_tokens_used(self) -> int:
-        """Get the total tokens used so far."""
-        return self._total_tokens_used
-
-    @property
-    def last_token_usage(self) -> int:
-        """Get the last token usage."""
-        if self._last_token_usage is None:
-            return 0
-        return self._last_token_usage
-
-    @last_token_usage.setter
-    def last_token_usage(self, value: int) -> None:
-        """Set the last token usage."""
-        self._last_token_usage = value

--- a/llama_index/embeddings/google.py
+++ b/llama_index/embeddings/google.py
@@ -1,27 +1,41 @@
 """Google Universal Sentence Encoder Embedding Wrapper Module."""
 
-from typing import List, Optional
+from pydantic import PrivateAttr
+from typing import Any, List, Optional
 
-from llama_index.embeddings.base import BaseEmbedding
+from llama_index.callbacks import CallbackManager
+from llama_index.embeddings.base import BaseEmbedding, DEFAULT_EMBED_BATCH_SIZE
 
 # Google Universal Sentence Encode v5
 DEFAULT_HANDLE = "https://tfhub.dev/google/universal-sentence-encoder-large/5"
 
 
 class GoogleUnivSentEncoderEmbedding(BaseEmbedding):
-    def __init__(self, handle: Optional[str] = None) -> None:
+    _model: Any = PrivateAttr()
+
+    def __init__(
+        self,
+        handle: Optional[str] = None,
+        embed_batch_size: int = DEFAULT_EMBED_BATCH_SIZE,
+        callback_manager: Optional[CallbackManager] = None,
+    ):
         """Init params."""
         handle = handle or DEFAULT_HANDLE
         try:
             import tensorflow_hub as hub
 
-            self._google_use = hub.load(handle)
+            model = hub.load(handle)
         except ImportError:
             raise ImportError(
                 "Please install tensorflow_hub: `pip install tensorflow_hub`"
             )
 
-        super().__init__()
+        self._model = model
+        super().__init__(
+            embed_batch_size=embed_batch_size,
+            callback_manager=callback_manager,
+            model_name=handle,
+        )
 
     def _get_query_embedding(self, query: str) -> List[float]:
         """Get query embedding."""
@@ -32,10 +46,15 @@ class GoogleUnivSentEncoderEmbedding(BaseEmbedding):
         """Get text embedding."""
         return self._get_embedding(query)
 
+    # TODO: user proper async methods
+    async def _aget_query_embedding(self, query: str) -> List[float]:
+        """Get query embedding."""
+        return self._get_embedding(query)
+
     def _get_text_embedding(self, text: str) -> List[float]:
         """Get text embedding."""
         return self._get_embedding(text)
 
     def _get_embedding(self, text: str) -> List[float]:
-        vectors = self._google_use([text]).numpy().tolist()
+        vectors = self._model([text]).numpy().tolist()
         return vectors[0]

--- a/llama_index/embeddings/langchain.py
+++ b/llama_index/embeddings/langchain.py
@@ -1,10 +1,11 @@
 """Langchain Embedding Wrapper Module."""
 
-
-from typing import Any, List
+from pydantic import PrivateAttr
+from typing import List, Optional
 
 from llama_index.bridge.langchain import Embeddings as LCEmbeddings
-from llama_index.embeddings.base import BaseEmbedding
+from llama_index.callbacks import CallbackManager
+from llama_index.embeddings.base import BaseEmbedding, DEFAULT_EMBED_BATCH_SIZE
 
 
 class LangchainEmbedding(BaseEmbedding):
@@ -15,10 +16,31 @@ class LangchainEmbedding(BaseEmbedding):
             embeddings class.
     """
 
-    def __init__(self, langchain_embedding: LCEmbeddings, **kwargs: Any) -> None:
-        """Init params."""
-        super().__init__(**kwargs)
-        self._langchain_embedding = langchain_embedding
+    _langchain_embedding: LCEmbeddings = PrivateAttr()
+
+    def __init__(
+        self,
+        langchain_embeddings: LCEmbeddings,
+        model_name: Optional[str] = None,
+        embed_batch_size: int = DEFAULT_EMBED_BATCH_SIZE,
+        callback_manager: Optional[CallbackManager] = None,
+    ):
+        # attempt to get a useful model name
+        if model_name is not None:
+            model_name = model_name
+        elif hasattr(langchain_embeddings, "model_name"):
+            model_name = langchain_embeddings.model_name
+        elif hasattr(langchain_embeddings, "model"):
+            model_name = langchain_embeddings.model
+        else:
+            model_name = type(langchain_embeddings).__name__
+
+        self._langchain_embedding = langchain_embeddings
+        super().__init__(
+            embed_batch_size=embed_batch_size,
+            callback_manager=callback_manager,
+            model_name=model_name,
+        )
 
     def _get_query_embedding(self, query: str) -> List[float]:
         """Get query embedding."""

--- a/llama_index/indices/postprocessor/optimizer.py
+++ b/llama_index/indices/postprocessor/optimizer.py
@@ -82,7 +82,6 @@ class SentenceEmbeddingOptimizer(BaseNodePostprocessor):
 
             split_text = self._tokenizer_fn(text)
 
-            start_embed_token_ct = self.embed_model.total_tokens_used
             if query_bundle.embedding is None:
                 query_bundle.embedding = (
                     self.embed_model.get_agg_embedding_from_queries(
@@ -106,12 +105,6 @@ class SentenceEmbeddingOptimizer(BaseNodePostprocessor):
                 similarity_top_k=num_top_k,
                 embedding_ids=list(range(len(text_embeddings))),
                 similarity_cutoff=threshold,
-            )
-
-            net_embed_tokens = self.embed_model.total_tokens_used - start_embed_token_ct
-            logger.info(
-                f"> [optimize] Total embedding token usage: "
-                f"{net_embed_tokens} tokens"
             )
 
             if len(top_idxs) == 0:

--- a/llama_index/llms/anthropic.py
+++ b/llama_index/llms/anthropic.py
@@ -1,3 +1,4 @@
+from pydantic import Field, PrivateAttr
 from typing import Any, Dict, Optional, Sequence
 
 from llama_index.llms.anthropic_utils import (
@@ -28,6 +29,24 @@ from llama_index.llms.generic_utils import (
 
 
 class Anthropic(LLM):
+    model: str = Field(description="The anthropic model to use.")
+    temperature: float = Field(description="The temperature to use for sampling.")
+    max_tokens: int = Field(description="The maximum number of tokens to generate.")
+
+    base_url: Optional[str] = Field(default=None, description="The base URL to use.")
+    timeout: Optional[float] = Field(
+        default=None, description="The timeout to use in seconds."
+    )
+    max_retries: int = Field(
+        default=10, description="The maximum number of API retries."
+    )
+    additional_kwargs: Dict[str, Any] = Field(
+        default_factory=dict, description="Additonal kwargs for the anthropic API."
+    )
+
+    _client: Any = PrivateAttr()
+    _aclient: Any = PrivateAttr()
+
     def __init__(
         self,
         model: str = "claude-2",
@@ -37,7 +56,7 @@ class Anthropic(LLM):
         timeout: Optional[float] = None,
         max_retries: int = 10,
         api_key: Optional[str] = None,
-        additional_kwargs: Dict[str, Any] = {},
+        additional_kwargs: Optional[Dict[str, Any]] = None,
         callback_manager: Optional[CallbackManager] = None,
     ) -> None:
         try:
@@ -48,11 +67,8 @@ class Anthropic(LLM):
                 "Please `pip install anthropic`"
             ) from e
 
-        self._model = model
-        self._temperature = temperature
-        self._max_tokens = max_tokens
-        self._additional_kwargs = additional_kwargs
-        self.callback_manager = callback_manager or CallbackManager([])
+        additional_kwargs = additional_kwargs or {}
+        callback_manager = callback_manager or CallbackManager([])
 
         self._client = anthropic.Anthropic(
             api_key=api_key, base_url=base_url, timeout=timeout, max_retries=max_retries
@@ -61,25 +77,36 @@ class Anthropic(LLM):
             api_key=api_key, base_url=base_url, timeout=timeout, max_retries=max_retries
         )
 
+        super().__init__(
+            temperature=temperature,
+            max_tokens=max_tokens,
+            additional_kwargs=additional_kwargs,
+            base_url=base_url,
+            timeout=timeout,
+            max_retries=max_retries,
+            model=model,
+            callback_manager=callback_manager,
+        )
+
     @property
     def metadata(self) -> LLMMetadata:
         return LLMMetadata(
-            context_window=anthropic_modelname_to_contextsize(self._model),
-            num_output=self._max_tokens,
+            context_window=anthropic_modelname_to_contextsize(self.model),
+            num_output=self.max_tokens,
             is_chat_model=True,
-            model_name=self._model,
+            model_name=self.model,
         )
 
     @property
     def _model_kwargs(self) -> Dict[str, Any]:
         base_kwargs = {
-            "model": self._model,
-            "temperature": self._temperature,
-            "max_tokens_to_sample": self._max_tokens,
+            "model": self.model,
+            "temperature": self.temperature,
+            "max_tokens_to_sample": self.max_tokens,
         }
         model_kwargs = {
             **base_kwargs,
-            **self._additional_kwargs,
+            **self.additional_kwargs,
         }
         return model_kwargs
 

--- a/llama_index/llms/azure_openai.py
+++ b/llama_index/llms/azure_openai.py
@@ -1,3 +1,4 @@
+from pydantic import Field
 from typing import Any, Dict, Optional
 
 from llama_index.callbacks import CallbackManager
@@ -29,6 +30,8 @@ class AzureOpenAI(OpenAI):
         https://learn.microsoft.com/en-us/azure/cognitive-services/openai/quickstart?tabs=command-line&pivots=programming-language-python
     """
 
+    engine: str = Field(description="The name of the deployed azure engine.")
+
     def __init__(
         self,
         model: str = "gpt-35-turbo",
@@ -40,8 +43,13 @@ class AzureOpenAI(OpenAI):
         callback_manager: Optional[CallbackManager] = None,
         **kwargs: Any,
     ) -> None:
-        self.engine = engine
+        if engine is None:
+            raise ValueError("You must specify an `engine` parameter.")
+
+        self.validate_env()
+
         super().__init__(
+            engine=engine,
             model=model,
             temperature=temperature,
             max_tokens=max_tokens,
@@ -50,11 +58,6 @@ class AzureOpenAI(OpenAI):
             callback_manager=callback_manager,
             **kwargs,
         )
-
-        if self.engine is None:
-            raise ValueError("You must specify an `engine` parameter.")
-
-        self.validate_env()
 
     def validate_env(self) -> None:
         """Validate necessary environment variables are set."""

--- a/llama_index/llms/base.py
+++ b/llama_index/llms/base.py
@@ -1,10 +1,10 @@
 import asyncio
 from contextlib import contextmanager
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from enum import Enum
 from typing import Any, AsyncGenerator, Callable, Generator, Optional, Sequence, cast
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 
 from llama_index.callbacks import CallbackManager, CBEventType, EventPayload
 from llama_index.constants import DEFAULT_CONTEXT_WINDOW, DEFAULT_NUM_OUTPUTS
@@ -309,10 +309,23 @@ def llm_completion_callback() -> Callable:
     return wrap
 
 
-class LLM(ABC):
+class LLM(BaseModel):
     """LLM interface."""
 
-    callback_manager: Optional[CallbackManager] = None
+    callback_manager: Optional[CallbackManager] = Field(
+        default_factory=CallbackManager, exclude=True
+    )
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    @validator("callback_manager", pre=True)
+    def _validate_callback_manager(
+        cls, v: Optional[CallbackManager]
+    ) -> CallbackManager:
+        if v is None:
+            return CallbackManager([])
+        return v
 
     @property
     @abstractmethod

--- a/llama_index/llms/custom.py
+++ b/llama_index/llms/custom.py
@@ -1,6 +1,5 @@
-from typing import Any, Optional, Sequence
+from typing import Any, Sequence
 
-from llama_index.callbacks import CallbackManager
 from llama_index.llms.base import (
     LLM,
     ChatMessage,
@@ -24,9 +23,6 @@ class CustomLLM(LLM):
     Subclasses must implement the `__init__`, `complete`,
         `stream_complete`, and `metadata` methods.
     """
-
-    def __init__(self, callback_manager: Optional[CallbackManager] = None) -> None:
-        self.callback_manager = callback_manager or CallbackManager([])
 
     @llm_chat_callback()
     def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:

--- a/llama_index/llms/huggingface.py
+++ b/llama_index/llms/huggingface.py
@@ -1,4 +1,5 @@
 import logging
+from pydantic import Field, PrivateAttr
 from threading import Thread
 from typing import Any, List, Optional
 
@@ -10,8 +11,6 @@ from llama_index.llms.base import (
 )
 from llama_index.callbacks import CallbackManager
 from llama_index.llms.custom import CustomLLM
-from llama_index.prompts.default_prompts import DEFAULT_SIMPLE_INPUT_PROMPT
-from llama_index.prompts.prompts import SimpleInputPrompt
 
 logger = logging.getLogger(__name__)
 
@@ -19,12 +18,71 @@ logger = logging.getLogger(__name__)
 class HuggingFaceLLM(CustomLLM):
     """HuggingFace LLM."""
 
+    model_name: str = Field(
+        description=(
+            "The model name to use from HuggingFace. "
+            "Unused if `model` is passed in directly."
+        )
+    )
+    context_window: int = Field(
+        description="The maximum number of tokens available for input."
+    )
+    max_new_tokens: int = Field(description="The maximum number of tokens to generate.")
+    system_prompt: str = Field(
+        description=(
+            "The system prompt, containing any extra instructions or context. "
+            "The model card on HuggingFace should specify if this is needed."
+        ),
+    )
+    query_wrapper_prompt: str = Field(
+        description=(
+            "The query wrapper prompt, containing the query placeholder. "
+            "The model card on HuggingFace should specify if this is needed."
+        ),
+    )
+    tokenizer_name: str = Field(
+        description=(
+            "The name of the tokenizer to use from HuggingFace. "
+            "Unused if `tokenizer` is passed in directly."
+        )
+    )
+    device_map: str = Field(description="The device_map to use. Defaults to 'auto'.")
+    stopping_ids: List[int] = Field(
+        default_factory=list,
+        description=(
+            "The stopping ids to use. "
+            "Generation stops when these token IDs are predicted.",
+        ),
+    )
+    tokenizer_outputs_to_remove: list = Field(
+        default_factory=list,
+        description=(
+            "The outputs to remove from the tokenizer. "
+            "Sometimes huggingface tokenizers return extra inputs that cause errors."
+        ),
+    )
+    tokenizer_kwargs: dict = Field(
+        default_factory=dict, description="The kwargs to pass to the tokenizer."
+    )
+    model_kwargs: dict = Field(
+        default_factory=dict,
+        description="The kwargs to pass to the model during initialization.",
+    )
+    generate_kwargs: dict = Field(
+        default_factory=dict,
+        description="The kwargs to pass to the model during generation.",
+    )
+
+    _model: Any = PrivateAttr()
+    _tokenizer: Any = PrivateAttr()
+    _stopping_criteria: Any = PrivateAttr()
+
     def __init__(
         self,
         context_window: int = 4096,
         max_new_tokens: int = 256,
         system_prompt: str = "",
-        query_wrapper_prompt: SimpleInputPrompt = DEFAULT_SIMPLE_INPUT_PROMPT,
+        query_wrapper_prompt: str = "",
         tokenizer_name: str = "StabilityAI/stablelm-tuned-alpha-3b",
         model_name: str = "StabilityAI/stablelm-tuned-alpha-3b",
         model: Optional[Any] = None,
@@ -47,13 +105,12 @@ class HuggingFaceLLM(CustomLLM):
         )
 
         model_kwargs = model_kwargs or {}
-        self._model_name = model_name
-        self.model = model or AutoModelForCausalLM.from_pretrained(
+        self._model = model or AutoModelForCausalLM.from_pretrained(
             model_name, device_map=device_map, **model_kwargs
         )
 
         # check context_window
-        config_dict = self.model.config.to_dict()
+        config_dict = self._model.config.to_dict()
         model_context_window = int(
             config_dict.get("max_position_embeddings", context_window)
         )
@@ -69,21 +126,9 @@ class HuggingFaceLLM(CustomLLM):
         if "max_length" not in tokenizer_kwargs:
             tokenizer_kwargs["max_length"] = context_window
 
-        self.tokenizer = tokenizer or AutoTokenizer.from_pretrained(
+        self._tokenizer = tokenizer or AutoTokenizer.from_pretrained(
             tokenizer_name, **tokenizer_kwargs
         )
-
-        self._context_window = context_window
-        self._max_new_tokens = max_new_tokens
-
-        self._generate_kwargs = generate_kwargs or {}
-        self._device_map = device_map
-        self._tokenizer_outputs_to_remove = tokenizer_outputs_to_remove or []
-        self._system_prompt = system_prompt
-        self._query_wrapper_prompt = query_wrapper_prompt
-        self._total_tokens_used = 0
-        self._last_token_usage: Optional[int] = None
-        self.callback_manager = callback_manager or CallbackManager([])
 
         # setup stopping criteria
         stopping_ids_list = stopping_ids or []
@@ -102,40 +147,57 @@ class HuggingFaceLLM(CustomLLM):
 
         self._stopping_criteria = StoppingCriteriaList([StopOnTokens()])
 
+        super().__init__(
+            context_window=context_window,
+            max_new_tokens=max_new_tokens,
+            system_prompt=system_prompt,
+            query_wrapper_prompt=query_wrapper_prompt,
+            tokenizer_name=tokenizer_name,
+            model_name=model_name,
+            device_map=device_map,
+            stopping_ids=stopping_ids or [],
+            tokenizer_kwargs=tokenizer_kwargs or {},
+            tokenizer_outputs_to_remove=tokenizer_outputs_to_remove or [],
+            model_kwargs=model_kwargs or {},
+            generate_kwargs=generate_kwargs or {},
+            callback_manager=callback_manager,
+        )
+
     @property
     def metadata(self) -> LLMMetadata:
         """LLM metadata."""
         return LLMMetadata(
-            context_window=self._context_window,
-            num_output=self._max_new_tokens,
-            model_name=self._model_name,
+            context_window=self.context_window,
+            num_output=self.max_new_tokens,
+            model_name=self.model_name,
         )
 
     @llm_completion_callback()
     def complete(self, prompt: str, **kwargs: Any) -> CompletionResponse:
         """Completion endpoint."""
 
-        full_prompt = self._query_wrapper_prompt.format(query_str=prompt)
-        if self._system_prompt:
-            full_prompt = f"{self._system_prompt} {full_prompt}"
+        full_prompt = prompt
+        if self.query_wrapper_prompt:
+            full_prompt = self.query_wrapper_prompt.format(query_str=prompt)
+        if self.system_prompt:
+            full_prompt = f"{self.system_prompt} {full_prompt}"
 
-        inputs = self.tokenizer(full_prompt, return_tensors="pt")
-        inputs = inputs.to(self.model.device)
+        inputs = self._tokenizer(full_prompt, return_tensors="pt")
+        inputs = inputs.to(self._model.device)
 
         # remove keys from the tokenizer if needed, to avoid HF errors
-        for key in self._tokenizer_outputs_to_remove:
+        for key in self.tokenizer_outputs_to_remove:
             if key in inputs:
                 inputs.pop(key, None)
 
-        tokens = self.model.generate(
+        tokens = self._model.generate(
             **inputs,
-            max_new_tokens=self._max_new_tokens,
+            max_new_tokens=self.max_new_tokens,
             stopping_criteria=self._stopping_criteria,
-            **self._generate_kwargs,
+            **self.generate_kwargs,
         )
         completion_tokens = tokens[0][inputs["input_ids"].size(1) :]
-        self._total_tokens_used += len(completion_tokens) + inputs["input_ids"].size(1)
-        completion = self.tokenizer.decode(completion_tokens, skip_special_tokens=True)
+        completion = self._tokenizer.decode(completion_tokens, skip_special_tokens=True)
 
         return CompletionResponse(text=completion, raw={"model_output": tokens})
 
@@ -144,34 +206,36 @@ class HuggingFaceLLM(CustomLLM):
         """Streaming completion endpoint."""
         from transformers import TextIteratorStreamer
 
-        full_prompt = self._query_wrapper_prompt.format(query_str=prompt)
-        if self._system_prompt:
-            full_prompt = f"{self._system_prompt} {full_prompt}"
+        full_prompt = prompt
+        if self.query_wrapper_prompt:
+            full_prompt = self.query_wrapper_prompt.format(query_str=prompt)
+        if self.system_prompt:
+            full_prompt = f"{self.system_prompt} {full_prompt}"
 
-        inputs = self.tokenizer(full_prompt, return_tensors="pt")
-        inputs = inputs.to(self.model.device)
+        inputs = self._tokenizer(full_prompt, return_tensors="pt")
+        inputs = inputs.to(self._model.device)
 
         # remove keys from the tokenizer if needed, to avoid HF errors
-        for key in self._tokenizer_outputs_to_remove:
+        for key in self.tokenizer_outputs_to_remove:
             if key in inputs:
                 inputs.pop(key, None)
 
         streamer = TextIteratorStreamer(
-            self.tokenizer,
+            self._tokenizer,
             skip_prompt=True,
             decode_kwargs={"skip_special_tokens": True},
         )
         generation_kwargs = dict(
             inputs,
             streamer=streamer,
-            max_new_tokens=self._max_new_tokens,
+            max_new_tokens=self.max_new_tokens,
             stopping_criteria=self._stopping_criteria,
-            **self._generate_kwargs,
+            **self.generate_kwargs,
         )
 
         # generate in background thread
         # NOTE/TODO: token counting doesn't work with streaming
-        thread = Thread(target=self.model.generate, kwargs=generation_kwargs)
+        thread = Thread(target=self._model.generate, kwargs=generation_kwargs)
         thread.start()
 
         # create generator based off of streamer

--- a/llama_index/llms/langchain.py
+++ b/llama_index/llms/langchain.py
@@ -1,3 +1,4 @@
+from pydantic import PrivateAttr
 from threading import Thread
 from typing import Any, Generator, Optional, Sequence
 
@@ -28,11 +29,13 @@ from llama_index.llms.langchain_utils import (
 class LangChainLLM(LLM):
     """Adapter for a LangChain LLM."""
 
+    _llm: BaseLanguageModel = PrivateAttr()
+
     def __init__(
         self, llm: BaseLanguageModel, callback_manager: Optional[CallbackManager] = None
     ) -> None:
         self._llm = llm
-        self.callback_manager = callback_manager or CallbackManager([])
+        super().__init__(callback_manager=callback_manager)
 
     @property
     def llm(self) -> BaseLanguageModel:

--- a/llama_index/llms/llama_api.py
+++ b/llama_index/llms/llama_api.py
@@ -1,3 +1,4 @@
+from pydantic import Field, PrivateAttr
 from typing import Any, Dict, Optional, Sequence
 
 from llama_index.callbacks import CallbackManager
@@ -21,6 +22,15 @@ from llama_index.llms.openai_utils import (
 
 
 class LlamaAPI(CustomLLM):
+    model: str = Field(description="The llama-api model to use.")
+    temperature: float = Field(description="The temperature to use for sampling.")
+    max_tokens: int = Field(description="The maximum number of tokens to generate.")
+    additional_kwargs: Dict[str, Any] = Field(
+        default_factory=dict, description="Additonal kwargs for the llama-api API."
+    )
+
+    _client: Any = PrivateAttr()
+
     def __init__(
         self,
         model: str = "llama-13b-chat",
@@ -39,22 +49,25 @@ class LlamaAPI(CustomLLM):
             ) from e
 
         self._client = Client(api_key)
-        self._model = model
-        self._temperature = temperature
-        self._max_tokens = max_tokens
-        self._additional_kwargs = additional_kwargs or {}
-        self.callback_manager = callback_manager or CallbackManager([])
+
+        super().__init__(
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            additional_kwargs=additional_kwargs or {},
+            callback_manager=callback_manager,
+        )
 
     @property
     def _model_kwargs(self) -> Dict[str, Any]:
         base_kwargs = {
-            "model": self._model,
-            "temperature": self._temperature,
-            "max_length": self._max_tokens,
+            "model": self.model,
+            "temperature": self.temperature,
+            "max_length": self.max_tokens,
         }
         model_kwargs = {
             **base_kwargs,
-            **self._additional_kwargs,
+            **self.additional_kwargs,
         }
         return model_kwargs
 

--- a/llama_index/llms/openai.py
+++ b/llama_index/llms/openai.py
@@ -1,3 +1,4 @@
+from pydantic import Field
 from typing import Any, Awaitable, Callable, Dict, Optional, Sequence
 
 from llama_index.callbacks import CallbackManager
@@ -37,6 +38,14 @@ from llama_index.llms.openai_utils import (
 
 
 class OpenAI(LLM):
+    model: str = Field(description="The OpenAI model to use.")
+    temperature: str = Field(description="The tempature to use during generation.")
+    max_tokens: int = Field(description="The maximum number of tokens to generate.")
+    additional_kwargs: Dict[str, Any] = Field(
+        default_factory=dict, description="Additonal kwargs for the OpenAI API."
+    )
+    max_retries: int = Field(description="The maximum number of API retries.")
+
     def __init__(
         self,
         model: str = "gpt-3.5-turbo",
@@ -51,16 +60,20 @@ class OpenAI(LLM):
     ) -> None:
         validate_openai_api_key(api_key, api_type)
 
-        self.model = model
-        self.temperature = temperature
-        self.max_tokens = max_tokens
-        self.additional_kwargs = additional_kwargs or {}
+        additional_kwargs = additional_kwargs or {}
         if api_key is not None:
-            self.additional_kwargs["api_key"] = api_key
+            additional_kwargs["api_key"] = api_key
         if api_type is not None:
-            self.additional_kwargs["api_type"] = api_type
-        self.max_retries = max_retries
-        self.callback_manager = callback_manager or CallbackManager([])
+            additional_kwargs["api_type"] = api_type
+
+        super().__init__(
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            additional_kwargs=additional_kwargs,
+            max_retries=max_retries,
+            callback_manager=callback_manager,
+        )
 
     @property
     def metadata(self) -> LLMMetadata:

--- a/llama_index/llms/palm.py
+++ b/llama_index/llms/palm.py
@@ -1,19 +1,28 @@
 """Palm API."""
+import os
+from pydantic import Field, PrivateAttr
+from typing import Optional, Any
 
 from llama_index.callbacks import CallbackManager
 from llama_index.llms.custom import CustomLLM
-from typing import Optional, Any
 from llama_index.llms.base import (
     CompletionResponse,
     CompletionResponseGen,
     LLMMetadata,
     llm_completion_callback,
 )
-import os
 
 
 class PaLM(CustomLLM):
     """PaLM LLM."""
+
+    model_name: str = Field(description="The PaLM model to use.")
+    num_output: int = Field(description="The number of tokens to generate.")
+    generate_kwargs: dict = Field(
+        default_factory=dict, description="Kwargs for generation."
+    )
+
+    _model: Any = PrivateAttr()
 
     def __init__(
         self,
@@ -32,32 +41,38 @@ class PaLM(CustomLLM):
                 "Please install it with `pip install google-generativeai`."
             )
         api_key = api_key or os.environ.get("PALM_API_KEY")
-        self._api_key = api_key
         palm.configure(api_key=api_key)
+
         models = palm.list_models()
         models_dict = {m.name: m for m in models}
         if model_name not in models_dict:
             raise ValueError(
                 f"Model name {model_name} not found in {models_dict.keys()}"
             )
-        self._model_name = model_name
+
+        model_name = model_name
         self._model = models_dict[model_name]
 
         # get num_output
-        self._num_output = num_output or self._model.output_token_limit
+        num_output = num_output or self._model.output_token_limit
 
-        self._generate_kwargs = generate_kwargs
-        self.callback_manager = callback_manager or CallbackManager([])
+        generate_kwargs = generate_kwargs or {}
+        super().__init__(
+            model_name=model_name,
+            num_output=num_output,
+            generate_kwargs=generate_kwargs,
+            callback_manager=callback_manager,
+        )
 
     @property
     def metadata(self) -> LLMMetadata:
         """Get LLM metadata."""
         # TODO: google palm actually separates input and output token limits
-        total_tokens = self._model.input_token_limit + self._num_output
+        total_tokens = self._model.input_token_limit + self.num_output
         return LLMMetadata(
             context_window=total_tokens,
-            num_output=self._num_output,
-            model_name=self._model_name,
+            num_output=self.num_output,
+            model_name=self.model_name,
         )
 
     @llm_completion_callback()
@@ -75,7 +90,7 @@ class PaLM(CustomLLM):
         import google.generativeai as palm
 
         completion = palm.generate_text(
-            model=self._model_name,
+            model=self.model_name,
             prompt=prompt,
             **kwargs,
         )

--- a/llama_index/llms/replicate.py
+++ b/llama_index/llms/replicate.py
@@ -1,3 +1,4 @@
+from pydantic import Field, PrivateAttr
 from typing import Any, Callable, Dict, Optional, Sequence
 
 from llama_index.callbacks import CallbackManager
@@ -21,6 +22,19 @@ from llama_index.llms.generic_utils import stream_completion_response_to_chat_re
 
 
 class Replicate(CustomLLM):
+    model: str = Field(description="The Replicate model to use.")
+    temperature: float = Field(description="The temperature to use for sampling.")
+    context_window: int = Field(
+        description="The maximum number of context tokens for the model."
+    )
+    prompt_key: str = Field(description="The key to use for the prompt in API calls.")
+    additional_kwargs: Dict[str, Any] = Field(
+        default_factory=dict, description="Additonal kwargs for the Replicate API."
+    )
+
+    _messages_to_prompt: Callable = PrivateAttr()
+    _completion_to_prompt: Callable = PrivateAttr()
+
     def __init__(
         self,
         model: str,
@@ -32,40 +46,41 @@ class Replicate(CustomLLM):
         completion_to_prompt: Optional[Callable] = None,
         callback_manager: Optional[CallbackManager] = None,
     ) -> None:
-        self._model = model
-        self._context_window = context_window
-        self._prompt_key = prompt_key
         self._messages_to_prompt = messages_to_prompt or generic_messages_to_prompt
         self._completion_to_prompt = completion_to_prompt or (lambda x: x)
-        self.callback_manager = callback_manager or CallbackManager([])
 
-        # model kwargs
-        self._temperature = temperature
-        self._additional_kwargs = additional_kwargs or {}
+        super().__init__(
+            model=model,
+            temperature=temperature,
+            additional_kwargs=additional_kwargs or {},
+            context_window=context_window,
+            prompt_key=prompt_key,
+            callback_manager=callback_manager,
+        )
 
     @property
     def metadata(self) -> LLMMetadata:
         """LLM metadata."""
         return LLMMetadata(
-            context_window=self._context_window,
+            context_window=self.context_window,
             num_output=DEFAULT_NUM_OUTPUTS,
-            model_name=self._model,
+            model_name=self.model,
         )
 
     @property
     def _model_kwargs(self) -> Dict[str, Any]:
         base_kwargs = {
-            "temperature": self._temperature,
-            "max_length": self._context_window,
+            "temperature": self.temperature,
+            "max_length": self.context_window,
         }
         model_kwargs = {
             **base_kwargs,
-            **self._additional_kwargs,
+            **self.additional_kwargs,
         }
         return model_kwargs
 
     def _get_input_dict(self, prompt: str, **kwargs: Any) -> Dict[str, Any]:
-        return {self._prompt_key: prompt, **self._model_kwargs, **kwargs}
+        return {self.prompt_key: prompt, **self._model_kwargs, **kwargs}
 
     @llm_chat_callback()
     def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
@@ -101,7 +116,7 @@ class Replicate(CustomLLM):
 
         prompt = self._completion_to_prompt(prompt)
         input_dict = self._get_input_dict(prompt, **kwargs)
-        response_iter = replicate.run(self._model, input=input_dict)
+        response_iter = replicate.run(self.model, input=input_dict)
 
         def gen() -> CompletionResponseGen:
             text = ""


### PR DESCRIPTION
# Description

Our core components should be using pydantic. This makes type checking and serializing object configs extremely easy.

NOTE: while langchain (and by association, LlamaIndex) is moving to pydantic V2, the migration is pretty straightforward for us.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [x] I stared at the code and made sure it makes sense

# TODO

- [ ] Run as many embedding models/LLMs as I can to confirm they all work
