### PR TITLE
pin langchain version to avoid pydantic v2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 install_requires = [
     "tiktoken",
     "dataclasses_json",
-    "langchain>=0.0.262",
+    "langchain>=0.0.262,<=0.0.266",
     "sqlalchemy>=2.0.15",
     "numpy",
     "tenacity>=8.2.0,<9.0.0",


### PR DESCRIPTION
# Description

Langchain is moving to pydantic v2 in a staged process. We likely don't need to follow the same migration plan, but we can at least pin the langchain version for now and be ready for when they fully migrate.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
