### PR TITLE
always eval df as the last step of default output processor of pandas…

### DIFF
--- a/llama_index/query_engine/pandas_query_engine.py
+++ b/llama_index/query_engine/pandas_query_engine.py
@@ -58,11 +58,8 @@ def default_output_processor(
         tree = ast.parse(output)
         module = ast.Module(tree.body[:-1], type_ignores=[])
         exec(ast.unparse(module), {}, local_vars)  # type: ignore
-        module_end = ast.Module(tree.body[-1:], type_ignores=[])
-        module_end_str = ast.unparse(module_end)  # type: ignore
-        print(module_end_str)
         try:
-            return str(eval(module_end_str, {"np": np}, local_vars))
+            return str(eval("df", {"np": np}, local_vars))
         except Exception as e:
             raise e
     except Exception as e:


### PR DESCRIPTION
…_query_engine

# Description

Always eval df as the last step of default output processor of pandas_query_engine

Fixes # (issue)

To avoid situation like 
df['column'] = df.column.some_operation()
at the last step

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
