### PR TITLE
fix callback trace ids (make them a context var) 

### DIFF
--- a/llama_index/callbacks/base.py
+++ b/llama_index/callbacks/base.py
@@ -11,6 +11,8 @@ from llama_index.callbacks.schema import CBEventType, LEAF_EVENTS, BASE_TRACE_EV
 
 logger = logging.getLogger(__name__)
 global_stack_trace = ContextVar("trace", default=[BASE_TRACE_EVENT])
+empty_trace_ids: List[str] = []
+global_stack_trace_ids = ContextVar("trace_ids", default=empty_trace_ids)
 
 
 class CallbackManager(BaseCallbackHandler, ABC):
@@ -63,7 +65,6 @@ class CallbackManager(BaseCallbackHandler, ABC):
 
         self.handlers = handlers
         self._trace_map: Dict[str, List[str]] = defaultdict(list)
-        self._trace_id_stack: List[str] = []
 
     def on_event_start(
         self,
@@ -156,16 +157,19 @@ class CallbackManager(BaseCallbackHandler, ABC):
 
     def start_trace(self, trace_id: Optional[str] = None) -> None:
         """Run when an overall trace is launched."""
+        current_trace_stack_ids = global_stack_trace_ids.get().copy()
         if trace_id is not None:
-            if len(self._trace_id_stack) == 0:
+            if len(current_trace_stack_ids) == 0:
                 self._reset_trace_events()
 
                 for handler in self.handlers:
                     handler.start_trace(trace_id=trace_id)
 
-                self._trace_id_stack = [trace_id]
+                current_trace_stack_ids = [trace_id]
             else:
-                self._trace_id_stack.append(trace_id)
+                current_trace_stack_ids.append(trace_id)
+
+        global_stack_trace_ids.set(current_trace_stack_ids)
 
     def end_trace(
         self,
@@ -173,12 +177,15 @@ class CallbackManager(BaseCallbackHandler, ABC):
         trace_map: Optional[Dict[str, List[str]]] = None,
     ) -> None:
         """Run when an overall trace is exited."""
-        if trace_id is not None and len(self._trace_id_stack) > 0:
-            self._trace_id_stack.pop()
-            if len(self._trace_id_stack) == 0:
+        current_trace_stack_ids = global_stack_trace_ids.get().copy()
+        if trace_id is not None and len(current_trace_stack_ids) > 0:
+            current_trace_stack_ids.pop()
+            if len(current_trace_stack_ids) == 0:
                 for handler in self.handlers:
                     handler.end_trace(trace_id=trace_id, trace_map=self._trace_map)
-                self._trace_id_stack = []
+                current_trace_stack_ids = []
+
+        global_stack_trace_ids.set(current_trace_stack_ids)
 
     def _reset_trace_events(self) -> None:
         """Helper function to reset the current trace."""


### PR DESCRIPTION
(reposting from an internal thread)

**Motivation**: there was a bug where nesting an agent/query engine under another query engine led to callbacks issues.

Reason:
at a high-level it's because we had a global_stack_trace for events, but the _trace_id_stack is still specific to each callback manager.
we had logic that checks if _trace_id_stack is empty then we reset global_stack_trace . but the issue arises when that callback manager starts a trace in a nested query call - when that trace ends, then the local _trace_id_stack for that callback manager will be empty, but that will reset the entire global_stack_trace  - affecting the outer callback manager

Solution: make trace_id_stack a global contextvar. still thread-safe but now isn't specific to a given callback manager

Testing: I tested this in a variant of the notebook in https://github.com/jerryjliu/llama_index/pull/7330 without defining the callback manager everywhere 