### PR TITLE
temp patch prompt helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes / Nits
 - Use service context for intermediate index in retry source query engine (#7341)
+- temp fix for prompt helper + chat models (#7350)
 
 ## [0.8.5.post2] - 2023-08-20
 

--- a/llama_index/indices/prompt_helper.py
+++ b/llama_index/indices/prompt_helper.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field, PrivateAttr
 from typing import Callable, List, Optional, Sequence
 
 from llama_index.constants import DEFAULT_CONTEXT_WINDOW, DEFAULT_NUM_OUTPUTS
+from llama_index.llms.openai_utils import is_chat_model
 from llama_index.llm_predictor.base import LLMMetadata
 from llama_index.prompts.base import Prompt
 from llama_index.prompts.utils import get_empty_prompt_txt
@@ -111,6 +112,11 @@ class PromptHelper(BaseModel):
             num_output = DEFAULT_NUM_OUTPUTS
         else:
             num_output = llm_metadata.num_output
+
+        # TODO: account for token counting in chat models
+        model_name = llm_metadata.model_name
+        if is_chat_model(model_name):
+            context_window -= 150
 
         return cls(
             context_window=context_window,


### PR DESCRIPTION
# Description

This is a temporary fix to unblock some users.

Token counting for chat models is a little more excessive than normal completion LLMs. And the prompt helper currently does not account for this.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested in the buggy notebook
- [x] I stared at the code and made sure it makes sense

