### PR TITLE
Fixed OpenAiAgent force function call loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## Unreleased
+
+### Bug Fixes / Nits
+- Fix inifinite looping with forced function call in `OpenAIAgent` (#7363)
+
 ## [0.8.6] - 2023-08-22
 
 ### New Features

--- a/llama_index/agent/openai_agent.py
+++ b/llama_index/agent/openai_agent.py
@@ -270,7 +270,7 @@ class BaseOpenAIAgent(BaseAgent):
             self._call_function(tools, self.latest_function_call)
             # change function call to the default value, if a custom function was given
             # as an argument (none and auto are predefined by OpenAI)
-            if type(current_func) is not str or current_func.lower() not in ["auto", "none"]:
+            if current_func not in ("auto", "none"):
                 current_func = "auto"
             n_function_calls += 1
 
@@ -299,7 +299,7 @@ class BaseOpenAIAgent(BaseAgent):
             await self._acall_function(tools, self.latest_function_call)
             # change function call to the default value, if a custom function was given
             # as an argument (none and auto are predefined by OpenAI)
-            if type(current_func) is not str or current_func.lower() not in ["auto", "none"]:
+            if current_func not in ("auto", "none"):
                 current_func = "auto"
             n_function_calls += 1
 

--- a/llama_index/agent/openai_agent.py
+++ b/llama_index/agent/openai_agent.py
@@ -259,14 +259,19 @@ class BaseOpenAIAgent(BaseAgent):
         n_function_calls = 0
 
         # Loop until no more function calls or max_function_calls is reached
+        current_func = function_call
         while True:
-            llm_chat_kwargs = self._get_llm_chat_kwargs(functions, function_call)
+            llm_chat_kwargs = self._get_llm_chat_kwargs(functions, current_func)
             agent_chat_response = self._get_agent_response(mode=mode, **llm_chat_kwargs)
             if not self._should_continue(self.latest_function_call, n_function_calls):
                 logger.debug("Break: should continue False")
                 break
             assert isinstance(self.latest_function_call, dict)
             self._call_function(tools, self.latest_function_call)
+            # change function call to the default value, if a custom function was given
+            # as an argument (none and auto are predefined by OpenAI)
+            if type(current_func) is not str or current_func.lower() not in ["auto", "none"]:
+                current_func = "auto"
             n_function_calls += 1
 
         return agent_chat_response
@@ -282,8 +287,9 @@ class BaseOpenAIAgent(BaseAgent):
         n_function_calls = 0
 
         # Loop until no more function calls or max_function_calls is reached
+        current_func = function_call
         while True:
-            llm_chat_kwargs = self._get_llm_chat_kwargs(functions, function_call)
+            llm_chat_kwargs = self._get_llm_chat_kwargs(functions, current_func)
             agent_chat_response = await self._get_async_agent_response(
                 mode=mode, **llm_chat_kwargs
             )
@@ -291,6 +297,10 @@ class BaseOpenAIAgent(BaseAgent):
                 break
             assert isinstance(self.latest_function_call, dict)
             await self._acall_function(tools, self.latest_function_call)
+            # change function call to the default value, if a custom function was given
+            # as an argument (none and auto are predefined by OpenAI)
+            if type(current_func) is not str or current_func.lower() not in ["auto", "none"]:
+                current_func = "auto"
             n_function_calls += 1
 
         return agent_chat_response


### PR DESCRIPTION
# Description

When a function call was forced on the OpenAiAgent, a loop occurred where each response of the LLM called the function again and therefore never send a final response. To fix this, the custom value gets only applied at the first request. After that the function parameter in the OpenAi Api changes back to `auto`. For more information about this parameter, look at the [OpenAi API documentation](https://platform.openai.com/docs/api-reference/chat/create#chat/create-functions).

Fixes #7359 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] ~~New feature (non-breaking change which adds functionality)~~
- [ ] ~~Breaking change (fix or feature that would cause existing functionality to not work as expected)~~
- [ ] ~~This change requires a documentation update~~

# How Has This Been Tested?

The bugfix is quite small and the bug has been severely narrowed down and confirmed by @logan-markewich.
i tested the code afterwards and checked with the debugger if the function call is not passed the second time.

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~ (not relevant)
- [x] My changes generate no new warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~ (not relevant)
- [x] New and existing unit tests pass locally with my changes
