### PR TITLE
update simple node parser usage

### DIFF
--- a/docs/core_modules/data_modules/documents_and_nodes/root.md
+++ b/docs/core_modules/data_modules/documents_and_nodes/root.md
@@ -41,7 +41,7 @@ from llama_index.node_parser import SimpleNodeParser
 ...
 
 # parse nodes
-parser = SimpleNodeParser()
+parser = SimpleNodeParser.from_defaults()
 nodes = parser.get_nodes_from_documents(documents)
 
 # build index

--- a/docs/core_modules/data_modules/documents_and_nodes/usage_metadata_extractor.md
+++ b/docs/core_modules/data_modules/documents_and_nodes/usage_metadata_extractor.md
@@ -26,7 +26,7 @@ metadata_extractor = MetadataExtractor(
     ],
 )
 
-node_parser = SimpleNodeParser(
+node_parser = SimpleNodeParser.from_defaults(
     text_splitter=text_splitter,
     metadata_extractor=metadata_extractor,
 )

--- a/docs/core_modules/data_modules/documents_and_nodes/usage_nodes.md
+++ b/docs/core_modules/data_modules/documents_and_nodes/usage_nodes.md
@@ -10,7 +10,7 @@ For instance, you can do
 ```python
 from llama_index.node_parser import SimpleNodeParser
 
-parser = SimpleNodeParser()
+parser = SimpleNodeParser.from_defaults()
 
 nodes = parser.get_nodes_from_documents(documents)
 ```

--- a/docs/core_modules/data_modules/index/metadata_extraction.md
+++ b/docs/core_modules/data_modules/index/metadata_extraction.md
@@ -34,7 +34,7 @@ metadata_extractor = MetadataExtractor(
     ],
 )
 
-node_parser = SimpleNodeParser(
+node_parser = SimpleNodeParser.from_defaults(
     metadata_extractor=metadata_extractor,
 )
 ```

--- a/docs/core_modules/data_modules/node_parsers/usage_pattern.md
+++ b/docs/core_modules/data_modules/node_parsers/usage_pattern.md
@@ -63,7 +63,7 @@ text_splitter = SentenceSplitter(
   tokenizer=tiktoken.encoding_for_model("gpt-3.5-turbo").encode
 )
 
-node_parser = SimpleNodeParser(text_splitter=text_splitter)
+node_parser = SimpleNodeParser.from_defaults(text_splitter=text_splitter)
 ```
 
 `TokenTextSplitter` default configuration:
@@ -80,7 +80,7 @@ text_splitter = TokenTextSplitter(
   tokenizer=tiktoken.encoding_for_model("gpt-3.5-turbo").encode
 )
 
-node_parser = SimpleNodeParser(text_splitter=text_splitter)
+node_parser = SimpleNodeParser.from_defaults(text_splitter=text_splitter)
 ```
 
 `CodeSplitter` configuration:
@@ -95,7 +95,7 @@ text_splitter = CodeSplitter(
   max_chars=1500,
 )
 
-node_parser = SimpleNodeParser(text_splitter=text_splitter)
+node_parser = SimpleNodeParser.from_defaults(text_splitter=text_splitter)
 ```
 
 ## SentenceWindowNodeParser

--- a/docs/core_modules/data_modules/storage/customization.md
+++ b/docs/core_modules/data_modules/storage/customization.md
@@ -28,7 +28,7 @@ from llama_index.vector_stores import SimpleVectorStore
 from llama_index.node_parser import SimpleNodeParser
 
 # create parser and parse document into nodes 
-parser = SimpleNodeParser()
+parser = SimpleNodeParser.from_defaults()
 nodes = parser.get_nodes_from_documents(documents)
 
 # create storage context using default stores

--- a/docs/core_modules/data_modules/storage/docstores.md
+++ b/docs/core_modules/data_modules/storage/docstores.md
@@ -17,7 +17,7 @@ from llama_index.storage.docstore import MongoDocumentStore
 from llama_index.node_parser import SimpleNodeParser
 
 # create parser and parse document into nodes 
-parser = SimpleNodeParser()
+parser = SimpleNodeParser.from_defaults()
 nodes = parser.get_nodes_from_documents(documents)
 
 # create (or load) docstore and add nodes
@@ -50,7 +50,7 @@ from llama_index.storage.docstore import RedisDocumentStore
 from llama_index.node_parser import SimpleNodeParser
 
 # create parser and parse document into nodes 
-parser = SimpleNodeParser()
+parser = SimpleNodeParser.from_defaults()
 nodes = parser.get_nodes_from_documents(documents)
 
 # create (or load) docstore and add nodes
@@ -84,7 +84,7 @@ from llama_index.storage.docstore import FirestoreDocumentStore
 from llama_index.node_parser import SimpleNodeParser
 
 # create parser and parse document into nodes
-parser = SimpleNodeParser()
+parser = SimpleNodeParser.from_defaults()
 nodes = parser.get_nodes_from_documents(documents)
 
 # create (or load) docstore and add nodes

--- a/docs/core_modules/supporting_modules/service_context.md
+++ b/docs/core_modules/supporting_modules/service_context.md
@@ -71,7 +71,7 @@ from llama_index.node_parser import SimpleNodeParser
 
 llm = OpenAI(model='text-davinci-003', temperature=0, max_tokens=256)
 embed_model = OpenAIEmbedding()
-node_parser = SimpleNodeParser(
+node_parser = SimpleNodeParser.from_defaults(
   text_splitter=TokenTextSplitter(chunk_size=1024, chunk_overlap=20)
 )
 prompt_helper = PromptHelper(

--- a/docs/examples/agent/openai_agent_query_cookbook.ipynb
+++ b/docs/examples/agent/openai_agent_query_cookbook.ipynb
@@ -674,7 +674,7 @@
     "llm = OpenAI(temperature=0, model=\"gpt-4\")\n",
     "service_context = ServiceContext.from_defaults(chunk_size=chunk_size, llm=llm)\n",
     "text_splitter = TokenTextSplitter(chunk_size=chunk_size)\n",
-    "node_parser = SimpleNodeParser(text_splitter=text_splitter)\n",
+    "node_parser = SimpleNodeParser.from_defaults(text_splitter=text_splitter)\n",
     "\n",
     "# define pinecone vector index\n",
     "vector_store = PineconeVectorStore(\n",

--- a/docs/examples/callbacks/OpenInferenceCallback.ipynb
+++ b/docs/examples/callbacks/OpenInferenceCallback.ipynb
@@ -503,7 +503,7 @@
     }
    ],
    "source": [
-    "parser = SimpleNodeParser()\n",
+    "parser = SimpleNodeParser.from_defaults()\n",
     "nodes = parser.get_nodes_from_documents(documents)\n",
     "print(nodes[0].text)"
    ]

--- a/docs/examples/docstore/DocstoreDemo.ipynb
+++ b/docs/examples/docstore/DocstoreDemo.ipynb
@@ -87,7 +87,7 @@
    "source": [
     "from llama_index.node_parser import SimpleNodeParser\n",
     "\n",
-    "nodes = SimpleNodeParser().get_nodes_from_documents(documents)"
+    "nodes = SimpleNodeParser.from_defaults().get_nodes_from_documents(documents)"
    ]
   },
   {

--- a/docs/examples/docstore/FirestoreDemo.ipynb
+++ b/docs/examples/docstore/FirestoreDemo.ipynb
@@ -74,7 +74,7 @@
    "source": [
     "from llama_index.node_parser import SimpleNodeParser\n",
     "\n",
-    "nodes = SimpleNodeParser().get_nodes_from_documents(documents)"
+    "nodes = SimpleNodeParser.from_defaults().get_nodes_from_documents(documents)"
    ]
   },
   {

--- a/docs/examples/docstore/MongoDocstoreDemo.ipynb
+++ b/docs/examples/docstore/MongoDocstoreDemo.ipynb
@@ -99,7 +99,7 @@
    "source": [
     "from llama_index.node_parser import SimpleNodeParser\n",
     "\n",
-    "nodes = SimpleNodeParser().get_nodes_from_documents(documents)"
+    "nodes = SimpleNodeParser.from_defaults().get_nodes_from_documents(documents)"
    ]
   },
   {

--- a/docs/examples/docstore/RedisDocstoreIndexStoreDemo.ipynb
+++ b/docs/examples/docstore/RedisDocstoreIndexStoreDemo.ipynb
@@ -127,7 +127,7 @@
    "source": [
     "from llama_index.node_parser import SimpleNodeParser\n",
     "\n",
-    "nodes = SimpleNodeParser().get_nodes_from_documents(documents)"
+    "nodes = SimpleNodeParser.from_defaults().get_nodes_from_documents(documents)"
    ]
   },
   {

--- a/docs/examples/index_structs/knowledge_graph/KnowledgeGraphDemo.ipynb
+++ b/docs/examples/index_structs/knowledge_graph/KnowledgeGraphDemo.ipynb
@@ -437,7 +437,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "node_parser = SimpleNodeParser()"
+    "node_parser = SimpleNodeParser.from_defaults()"
    ]
   },
   {

--- a/docs/examples/index_structs/knowledge_graph/KuzuGraphDemo.ipynb
+++ b/docs/examples/index_structs/knowledge_graph/KuzuGraphDemo.ipynb
@@ -561,7 +561,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "node_parser = SimpleNodeParser()"
+    "node_parser = SimpleNodeParser.from_defaults()"
    ]
   },
   {

--- a/docs/examples/index_structs/knowledge_graph/NebulaGraphKGIndexDemo.ipynb
+++ b/docs/examples/index_structs/knowledge_graph/NebulaGraphKGIndexDemo.ipynb
@@ -1006,7 +1006,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "node_parser = SimpleNodeParser()"
+    "node_parser = SimpleNodeParser.from_defaults()"
    ]
   },
   {

--- a/docs/examples/index_structs/knowledge_graph/Neo4jKGIndexDemo.ipynb
+++ b/docs/examples/index_structs/knowledge_graph/Neo4jKGIndexDemo.ipynb
@@ -486,7 +486,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "node_parser = SimpleNodeParser()"
+    "node_parser = SimpleNodeParser.from_defaults()"
    ]
   },
   {

--- a/docs/examples/metadata_extraction/MetadataExtractionSEC.ipynb
+++ b/docs/examples/metadata_extraction/MetadataExtractionSEC.ipynb
@@ -121,7 +121,7 @@
     "    ],\n",
     ")\n",
     "\n",
-    "node_parser = SimpleNodeParser(\n",
+    "node_parser = SimpleNodeParser.from_defaults(\n",
     "    text_splitter=text_splitter,\n",
     "    metadata_extractor=metadata_extractor,\n",
     ")"

--- a/docs/examples/query_engine/SQLAutoVectorQueryEngine.ipynb
+++ b/docs/examples/query_engine/SQLAutoVectorQueryEngine.ipynb
@@ -169,7 +169,7 @@
     "llm = OpenAI(temperature=0, model=\"gpt-4\", streaming=True)\n",
     "service_context = ServiceContext.from_defaults(chunk_size=chunk_size, llm=llm)\n",
     "text_splitter = TokenTextSplitter(chunk_size=chunk_size)\n",
-    "node_parser = SimpleNodeParser(text_splitter=text_splitter)\n",
+    "node_parser = SimpleNodeParser.from_defaults(text_splitter=text_splitter)\n",
     "\n",
     "# define pinecone vector index\n",
     "vector_store = PineconeVectorStore(\n",

--- a/docs/examples/query_engine/SQLJoinQueryEngine.ipynb
+++ b/docs/examples/query_engine/SQLJoinQueryEngine.ipynb
@@ -136,7 +136,7 @@
     "llm = OpenAI(temperature=0, model=\"gpt-4\", streaming=True)\n",
     "service_context = ServiceContext.from_defaults(chunk_size=chunk_size, llm=llm)\n",
     "text_splitter = TokenTextSplitter(chunk_size=chunk_size)\n",
-    "node_parser = SimpleNodeParser(text_splitter=text_splitter)\n",
+    "node_parser = SimpleNodeParser.from_defaults(text_splitter=text_splitter)\n",
     "\n",
     "# # define pinecone vector index\n",
     "# vector_store = PineconeVectorStore(pinecone_index=pinecone_index, namespace='wiki_cities')\n",

--- a/examples/paul_graham_essay/SentenceSplittingDemo.ipynb
+++ b/examples/paul_graham_essay/SentenceSplittingDemo.ipynb
@@ -130,7 +130,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "node_parser = SimpleNodeParser(text_splitter=sentence_splitter)\n",
+    "node_parser = SimpleNodeParser.from_defaults(text_splitter=sentence_splitter)\n",
     "service_context = ServiceContext.from_defaults(node_parser=node_parser)\n",
     "documents = []\n",
     "documents.append(Document(text=page))\n",

--- a/tests/node_parser/metadata_extractor.py
+++ b/tests/node_parser/metadata_extractor.py
@@ -20,7 +20,7 @@ def test_metadata_extractor(mock_service_context: ServiceContext) -> None:
         ],
     )
 
-    node_parser = SimpleNodeParser(
+    node_parser = SimpleNodeParser.from_defaults(
         metadata_extractor=metadata_extractor,
     )
 


### PR DESCRIPTION
# Description

`SimpleNodeParser` docs were out of date -- should be using `from_defaults()`. Surprisingly more common than I thought, must have got missed in the pydantic changes.

Fixes https://github.com/jerryjliu/llama_index/issues/7352

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

