### PR TITLE
feat: direction-wise SubGraph RAG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 ### New Features
 - Added support for FalkorDB/RedisGraph graph store (#7346)
+- Added directed sub-graph RAG (#7378)
 
 ### Bug Fixes / Nits
 - Added `max_tokens` to `Xinference` LLM (#7372)
 - Support cache dir creation in multithreaded apps (#7365)
 - Ensure temperature is a float for openai (#7382)
+- Remove duplicate subjects in knowledge graph retriever (#7378)
 
 ## [0.8.8] - 2023-08-23
 

--- a/llama_index/graph_stores/kuzu.py
+++ b/llama_index/graph_stores/kuzu.py
@@ -1,7 +1,6 @@
 """Kùzu graph store index."""
 from typing import Any, Dict, List, Optional
 
-
 from llama_index.graph_stores.types import GraphStore
 
 
@@ -106,8 +105,6 @@ class KuzuGraphStore(GraphStore):
                 curr_path.append(predicate)
             # Add the last node
             curr_path.append(obj["ID"])
-            # Remove subject as it is the key of the map
-            curr_path = curr_path[1:]
             if subj["ID"] not in retval:
                 retval[subj["ID"]] = []
             retval[subj["ID"]].append(curr_path)

--- a/llama_index/graph_stores/nebulagraph.py
+++ b/llama_index/graph_stores/nebulagraph.py
@@ -303,7 +303,7 @@ class NebulaGraphStore(GraphStore):
     ) -> Dict[str, List[List[str]]]:
         """Get flat rel map."""
         # The flat means for multi-hop relation path, we could get
-        # knowledge like: subj -> rel -> obj -> rel -> obj -> rel -> obj.
+        # knowledge like: subj -rel-> obj -rel-> obj <-rel- obj.
         # This type of knowledge is useful for some tasks.
         # +-------------+------------------------------------+
         # | subj        | flattened_rels                     |
@@ -318,8 +318,19 @@ class NebulaGraphStore(GraphStore):
             return rel_map
 
         if len(self._edge_types) == 1:
+            # WITH map{`true`: "-[", `false`: "<-["} AS arrow_l,
+            #      map{`true`: "]->", `false`: "]-"} AS arrow_r
             # MATCH (s)-[e:follow*..2]-() WHERE id(s) IN ["player100", "player101"]
-            #   WITH id(s) AS subj, [rel in e | [rel.degree, dst(rel)] ] AS rels
+            #   WITH id(s) AS subj, [rel in e | [
+            #      arrow_l[tostring(typeid(rel) > 0)] +
+            #         tostring(rel.degree)+
+            #      arrow_r[tostring(typeid(rel) > 0)],
+            #      CASE typeid(rel) > 0
+            #         WHEN true THEN dst(rel)
+            #         WHEN false THEN src(rel)
+            #      END
+            #      ]
+            #   ] AS rels
             #   WITH
             #       subj,
             #       REDUCE(acc = collect(NULL), l in rels | acc + l) AS flattened_rels
@@ -327,12 +338,22 @@ class NebulaGraphStore(GraphStore):
             #   subj,
             #   REDUCE(acc = subj,l in flattened_rels|acc + ', ' + l) AS flattened_rels
             query = (
+                f"WITH map{{`true`: '-[', `false`: '<-['}} AS arrow_l,"
+                f"     map{{`true`: ']->', `false`: ']-'}} AS arrow_r "
                 f"MATCH (s)-[e:`{self._edge_types[0]}`*..{depth}]-() "
                 f"  WHERE id(s) IN $subjs "
                 f"WITH "
                 f"id(s) AS subj,"
                 f"[rel IN e | "
-                f"  [rel.`{self._rel_prop_names[0]}`, dst(rel)] "
+                f"  ["
+                f"  arrow_l[tostring(typeid(rel) > 0)] +"
+                f"      rel.`{self._rel_prop_names[0]}`+"
+                f"  arrow_r[tostring(typeid(rel) > 0)],"
+                f"  CASE typeid(rel) > 0"
+                f"    WHEN true THEN dst(rel)"
+                f"    WHEN false THEN src(rel)"
+                f"  END"
+                f"  ]"
                 f"] AS rels "
                 f"WITH "
                 f"  subj,"
@@ -346,14 +367,27 @@ class NebulaGraphStore(GraphStore):
         else:
             # edge_types = ["follow", "serve"]
             # rel_prop_names = ["degree", "start_year"]
+            # WITH map{`true`: "-[", `false`: "<-["} AS arrow_l,
+            #      map{`true`: "]->", `false`: "]-"} AS arrow_r
             # MATCH (s)-[e:follow|serve*..2]-()
             # WHERE id(s) IN ["player100", "player101"]
             #   WITH id(s) AS subj,
             #        [rel in e | [CASE type(rel)
-            #     WHEN "follow" THEN rel.degree
-            #     WHEN "serve" THEN rel.start_year
-            #     END, dst(rel)] ]
-            #     AS rels
+            #     WHEN "follow" THEN
+            #      arrow_l[tostring(typeid(rel) > 0)] +
+            #         tostring(rel.degree)+
+            #      arrow_r[tostring(typeid(rel) > 0)]
+            #     WHEN "serve" THEN
+            #      arrow_l[tostring(typeid(rel) > 0)] +
+            #         tostring(rel.start_year)+
+            #      arrow_r[tostring(typeid(rel) > 0)]
+            #     END,
+            #     CASE typeid(rel) > 0
+            #       WHEN true THEN dst(rel)
+            #       WHEN false THEN src(rel)
+            #     END
+            #     ]
+            # ] AS rels
             #   WITH
             #     subj,
             #     REDUCE(acc = collect(NULL), l in rels | acc + l) AS
@@ -364,13 +398,18 @@ class NebulaGraphStore(GraphStore):
             #       flattened_rels
             _case_when_string = "".join(
                 [
-                    f"WHEN {QUOTE}{edge_type}{QUOTE} THEN rel.`{rel_prop_name}` "
+                    f"WHEN {QUOTE}{edge_type}{QUOTE} THEN "
+                    f"  arrow_l[tostring(typeid(rel) > 0)] +"
+                    f"  rel.`{rel_prop_name}` +"
+                    f"  arrow_r[tostring(typeid(rel) > 0)] "
                     for edge_type, rel_prop_name in zip(
                         self._edge_types, self._rel_prop_names
                     )
                 ]
             )
             query = (
+                f"WITH map{{`true`: '-[', `false`: '<-['}} AS arrow_l,"
+                f"     map{{`true`: ']->', `false`: ']-'}} AS arrow_r "
                 f"MATCH (s)-[e:`{'`|`'.join(self._edge_types)}`*..{depth}]-() "
                 f"  WHERE id(s) IN $subjs "
                 f"  WITH "
@@ -378,7 +417,12 @@ class NebulaGraphStore(GraphStore):
                 f" [rel IN e | "
                 f"  [CASE type(rel) "
                 f"  {_case_when_string}"
-                f"  END, dst(rel)] "
+                f"  END, "
+                f"  CASE typeid(rel) > 0"
+                f"    WHEN true THEN dst(rel)"
+                f"    WHEN false THEN src(rel)"
+                f"  END"
+                f"  ] "
                 f"] AS rels "
                 f"  WITH"
                 f"    subj,"

--- a/llama_index/graph_stores/simple.py
+++ b/llama_index/graph_stores/simple.py
@@ -46,7 +46,7 @@ class SimpleGraphStoreData(DataClassJsonMixin):
         rel_map = []
         if subj in self.graph_dict:
             for rel, obj in self.graph_dict[subj]:
-                rel_map.append([rel, obj])
+                rel_map.append([subj, rel, obj])
                 rel_map += self._get_rel_map(obj, depth=depth - 1)
         return rel_map
 

--- a/llama_index/indices/knowledge_graph/retrievers.py
+++ b/llama_index/indices/knowledge_graph/retrievers.py
@@ -277,7 +277,8 @@ class KGTableRetriever(BaseRetriever):
             f"The following are knowledge sequence in max depth"
             f" {self.graph_store_query_depth} "
             f"in the form of directed graph like:\n"
-            f"`subject -[predicate]->, object, <-[predicate_next_hop]-, object_next_hop ...`"
+            f"`subject -[predicate]->, object, <-[predicate_next_hop]-,"
+            f" object_next_hop ...`"
         )
         rel_info = [rel_initial_text] + rel_texts
         rel_node_info = {
@@ -657,7 +658,8 @@ class KnowledgeGraphRAGRetriever(BaseRetriever):
             f"The following are knowledge sequence in max depth"
             f" {self._graph_traversal_depth} "
             f"in the form of directed graph like:\n"
-            f"`subject -[predicate]->, object, <-[predicate_next_hop]-, object_next_hop ...`"
+            f"`subject -[predicate]->, object, <-[predicate_next_hop]-,"
+            f" object_next_hop ...`"
             f" extracted based on key entities as subject:\n"
             f"{_new_line_char.join(knowledge_sequence)}"
         )

--- a/llama_index/indices/knowledge_graph/retrievers.py
+++ b/llama_index/indices/knowledge_graph/retrievers.py
@@ -18,7 +18,6 @@ from llama_index.schema import BaseNode, MetadataMode, NodeWithScore, TextNode
 from llama_index.storage.storage_context import StorageContext
 from llama_index.utils import truncate_text
 
-
 DQKET = DEFAULT_QUERY_KEYWORD_EXTRACT_TEMPLATE
 DEFAULT_NODE_SCORE = 1000.0
 GLOBAL_EXPLORE_NODE_LIMIT = 3
@@ -108,6 +107,7 @@ class KGTableRetriever(BaseRetriever):
         self.graph_store_query_depth = graph_store_query_depth
         self.use_global_node_triplets = use_global_node_triplets
         self.max_knowledge_sequence = max_knowledge_sequence
+        self._verbose = kwargs.get("verbose", False)
 
     def _get_keywords(self, query_str: str) -> List[str]:
         """Extract keywords."""
@@ -135,10 +135,10 @@ class KGTableRetriever(BaseRetriever):
         query_bundle: QueryBundle,
     ) -> List[NodeWithScore]:
         """Get nodes for response."""
-        logger.info(f"> Starting query: {query_bundle.query_str}")
         node_visited = set()
         keywords = self._get_keywords(query_bundle.query_str)
-        logger.info(f"> Query keywords: {keywords}")
+        if self._verbose:
+            print_text(f"Extraced keywords: {keywords}\n", color="green")
         rel_texts = []
         cur_rel_map = {}
         chunk_indices_count: Dict[str, int] = defaultdict(int)
@@ -179,8 +179,8 @@ class KGTableRetriever(BaseRetriever):
                     continue
                 rel_texts.extend(
                     [
-                        f"{sub} {rel_obj}"
-                        for sub, rel_objs in rel_map.items()
+                        str(rel_obj)
+                        for rel_objs in rel_map.values()
                         for rel_obj in rel_objs
                     ]
                 )
@@ -219,7 +219,7 @@ class KGTableRetriever(BaseRetriever):
                 for node_id in node_ids:
                     chunk_indices_count[node_id] += 1
         elif len(self._index_struct.embedding_dict) == 0:
-            logger.error(
+            logger.warn(
                 "Index was not constructed with embeddings, skipping embedding usage..."
             )
 
@@ -276,16 +276,25 @@ class KGTableRetriever(BaseRetriever):
         rel_initial_text = (
             f"The following are knowledge sequence in max depth"
             f" {self.graph_store_query_depth} "
-            f"in the form of "
-            f"`subject [predicate, object, predicate_next_hop, object_next_hop ...]`"
+            f"in the form of directed graph like:\n"
+            f"`subject -[predicate]->, object, <-[predicate_next_hop]-, object_next_hop ...`"
         )
         rel_info = [rel_initial_text] + rel_texts
         rel_node_info = {
             "kg_rel_texts": rel_texts,
             "kg_rel_map": cur_rel_map,
         }
+        rel_info_text = "\n".join(
+            [
+                str(item)
+                for sublist in rel_info
+                for item in (sublist if isinstance(sublist, list) else [sublist])
+            ]
+        )
+        if self._verbose:
+            print_text(f"KG context:\n{rel_info_text}\n", color="blue")
         rel_text_node = TextNode(
-            text="\n".join(rel_info),
+            text=rel_info_text,
             metadata=rel_node_info,
             excluded_embed_metadata_keys=["kg_rel_map", "kg_rel_texts"],
             excluded_llm_metadata_keys=["kg_rel_map", "kg_rel_texts"],
@@ -294,8 +303,6 @@ class KGTableRetriever(BaseRetriever):
         sorted_nodes_with_scores.append(
             NodeWithScore(node=rel_text_node, score=DEFAULT_NODE_SCORE)
         )
-        rel_info_text = "\n".join(rel_info)
-        logger.info(f"> Extracted relationships: {rel_info_text}")
 
         return sorted_nodes_with_scores
 
@@ -649,8 +656,8 @@ class KnowledgeGraphRAGRetriever(BaseRetriever):
         context_string = (
             f"The following are knowledge sequence in max depth"
             f" {self._graph_traversal_depth} "
-            f"in the form of "
-            f"`subject predicate, object, predicate_next_hop, object_next_hop ...`"
+            f"in the form of directed graph like:\n"
+            f"`subject -[predicate]->, object, <-[predicate_next_hop]-, object_next_hop ...`"
             f" extracted based on key entities as subject:\n"
             f"{_new_line_char.join(knowledge_sequence)}"
         )

--- a/tests/indices/knowledge_graph/test_retrievers.py
+++ b/tests/indices/knowledge_graph/test_retrievers.py
@@ -34,7 +34,8 @@ def test_as_retriever(
         f"The following are knowledge sequence in max depth"
         f" {retriever.graph_store_query_depth} "
         f"in the form of directed graph like:\n"
-        f"`subject -[predicate]->, object, <-[predicate_next_hop]-, object_next_hop ...`"
+        f"`subject -[predicate]->, object, <-[predicate_next_hop]-,"
+        f" object_next_hop ...`"
     )
 
     raw_text = "['foo', 'is', 'bar']"
@@ -69,7 +70,8 @@ def test_retrievers(
         nodes[1].node.get_content()
         == "The following are knowledge sequence in max depth 2"
         " in the form of directed graph like:\n"
-        "`subject -[predicate]->, object, <-[predicate_next_hop]-, object_next_hop ...`"
+        "`subject -[predicate]->, object, <-[predicate_next_hop]-,"
+        " object_next_hop ...`"
         "\n['foo', 'is', 'bar']"
     )
 
@@ -101,7 +103,8 @@ def test_retriever_no_text(
         nodes[0].node.get_content()
         == "The following are knowledge sequence in max depth 2"
         " in the form of directed graph like:\n"
-        "`subject -[predicate]->, object, <-[predicate_next_hop]-, object_next_hop ...`"
+        "`subject -[predicate]->, object, <-[predicate_next_hop]-,"
+        " object_next_hop ...`"
         "\n['foo', 'is', 'bar']"
     )
 
@@ -134,6 +137,7 @@ def test_retrieve_similarity(
         nodes[1].node.get_content()
         == "The following are knowledge sequence in max depth 2"
         " in the form of directed graph like:\n"
-        "`subject -[predicate]->, object, <-[predicate_next_hop]-, object_next_hop ...`"
+        "`subject -[predicate]->, object, <-[predicate_next_hop]-,"
+        " object_next_hop ...`"
         "\n['foo', 'is', 'bar']"
     )

--- a/tests/indices/knowledge_graph/test_retrievers.py
+++ b/tests/indices/knowledge_graph/test_retrievers.py
@@ -33,10 +33,11 @@ def test_as_retriever(
     rel_initial_text = (
         f"The following are knowledge sequence in max depth"
         f" {retriever.graph_store_query_depth} "
-        f"in the form of "
-        f"`subject [predicate, object, predicate_next_hop, object_next_hop ...]`"
+        f"in the form of directed graph like:\n"
+        f"`subject -[predicate]->, object, <-[predicate_next_hop]-, object_next_hop ...`"
     )
-    raw_text = "foo ['is', 'bar']"
+
+    raw_text = "['foo', 'is', 'bar']"
     query = rel_initial_text + "\n" + raw_text
     assert len(nodes) == 2
     assert nodes[1].node.get_content() == query
@@ -67,9 +68,9 @@ def test_retrievers(
     assert (
         nodes[1].node.get_content()
         == "The following are knowledge sequence in max depth 2"
-        " in the form of "
-        "`subject [predicate, object, predicate_next_hop, object_next_hop ...]`"
-        "\nfoo ['is', 'bar']"
+        " in the form of directed graph like:\n"
+        "`subject -[predicate]->, object, <-[predicate_next_hop]-, object_next_hop ...`"
+        "\n['foo', 'is', 'bar']"
     )
 
 
@@ -99,9 +100,9 @@ def test_retriever_no_text(
     assert (
         nodes[0].node.get_content()
         == "The following are knowledge sequence in max depth 2"
-        " in the form of "
-        "`subject [predicate, object, predicate_next_hop, object_next_hop ...]`"
-        "\nfoo ['is', 'bar']"
+        " in the form of directed graph like:\n"
+        "`subject -[predicate]->, object, <-[predicate_next_hop]-, object_next_hop ...`"
+        "\n['foo', 'is', 'bar']"
     )
 
 
@@ -132,7 +133,7 @@ def test_retrieve_similarity(
     assert (
         nodes[1].node.get_content()
         == "The following are knowledge sequence in max depth 2"
-        " in the form of "
-        "`subject [predicate, object, predicate_next_hop, object_next_hop ...]`"
-        "\nfoo ['is', 'bar']"
+        " in the form of directed graph like:\n"
+        "`subject -[predicate]->, object, <-[predicate_next_hop]-, object_next_hop ...`"
+        "\n['foo', 'is', 'bar']"
     )


### PR DESCRIPTION
# Description

Optimization and fixes on KG index retriever and NebulaGraphStore

- Now SubGraph RAG could be **directed**, impl. in NebulaGraph as an example
- **Removed duplicated subject** in the KGIndex KGTableRetriver
- Fixed the object mismatch in NebulaGarph SubGraph retrieval(reported by @BleakStone )
- Optimized Log Printing of KGTableRetriver


## Type of Change

Please delete options that are not relevant.

- [x] Enhancement of existing feature(no break changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
