### PR TITLE
An example of sticky scrolling for codesplitting

### DIFF
--- a/llama_index/text_splitter/code_splitter.py
+++ b/llama_index/text_splitter/code_splitter.py
@@ -95,7 +95,118 @@ def _generate_comment_line(language: str, comment: str) -> str:
         return f"🦙{comment}🦙"  # For unknown languages, use emoji to enclose the comment
 
 
+DEFAULT_CHUNK_LINES = 40
+DEFAULT_LINES_OVERLAP = 15
+DEFAULT_MAX_CHARS = 1500
+
+
 class CodeSplitter(TextSplitter):
+    """Split code using a AST parser.
+
+    Thank you to Kevin Lu / SweepAI for suggesting this elegant code splitting solution.
+    https://docs.sweep.dev/blogs/chunking-2m-files
+    """
+
+    language: str = Field(
+        description="The programming languge of the code being split."
+    )
+    chunk_lines: int = Field(
+        default=DEFAULT_CHUNK_LINES,
+        description="The number of lines to include in each chunk.",
+    )
+    chunk_lines_overlap: int = Field(
+        default=DEFAULT_LINES_OVERLAP,
+        description="How many lines of code each chunk overlaps with.",
+    )
+    max_chars: int = Field(
+        default=DEFAULT_MAX_CHARS, description="Maximum number of characters per chunk."
+    )
+    callback_manager: CallbackManager = Field(
+        default_factory=CallbackManager, exclude=True
+    )
+
+    def __init__(
+        self,
+        language: str,
+        chunk_lines: int = 40,
+        chunk_lines_overlap: int = 15,
+        max_chars: int = 1500,
+        callback_manager: Optional[CallbackManager] = None,
+    ):
+        callback_manager = callback_manager or CallbackManager([])
+        super().__init__(
+            language=language,
+            chunk_lines=chunk_lines,
+            chunk_lines_overlap=chunk_lines_overlap,
+            max_chars=max_chars,
+            callback_manager=callback_manager,
+        )
+
+    def _chunk_node(self, node: Any, text: str, last_end: int = 0) -> List[str]:
+        new_chunks = []
+        current_chunk = ""
+        for child in node.children:
+            if child.end_byte - child.start_byte > self.max_chars:
+                # Child is too big, recursively chunk the child
+                if len(current_chunk) > 0:
+                    new_chunks.append(current_chunk)
+                current_chunk = ""
+                new_chunks.extend(self._chunk_node(child, text, last_end))
+            elif (
+                len(current_chunk) + child.end_byte - child.start_byte > self.max_chars
+            ):
+                # Child would make the current chunk too big, so start a new chunk
+                new_chunks.append(current_chunk)
+                current_chunk = text[last_end : child.end_byte]
+            else:
+                current_chunk += text[last_end : child.end_byte]
+            last_end = child.end_byte
+        if len(current_chunk) > 0:
+            new_chunks.append(current_chunk)
+        return new_chunks
+
+    def split_text(self, text: str) -> List[str]:
+        """Split incoming code and return chunks using the AST."""
+        with self.callback_manager.event(
+            CBEventType.CHUNKING, payload={EventPayload.CHUNKS: [text]}
+        ) as event:
+            try:
+                import tree_sitter_languages
+            except ImportError:
+                raise ImportError(
+                    "Please install tree_sitter_languages to use CodeSplitter."
+                )
+
+            try:
+                parser = tree_sitter_languages.get_parser(self.language)
+            except Exception as e:
+                print(
+                    f"Could not get parser for language {self.language}. Check "
+                    "https://github.com/grantjenks/py-tree-sitter-languages#license "
+                    "for a list of valid languages."
+                )
+                raise e
+
+            tree = parser.parse(bytes(text, "utf-8"))
+
+            if (
+                not tree.root_node.children
+                or tree.root_node.children[0].type != "ERROR"
+            ):
+                chunks = [
+                    chunk.strip() for chunk in self._chunk_node(tree.root_node, text)
+                ]
+                event.on_end(
+                    payload={EventPayload.CHUNKS: chunks},
+                )
+
+                return chunks
+            else:
+                raise ValueError(f"Could not parse code with language {self.language}.")
+
+        # TODO: set up auto-language detection using something like https://github.com/yoeo/guesslang.
+
+class CodeBlockSplitter(TextSplitter):
     """Split code using a AST parser.
 
     Thank you to Kevin Lu / SweepAI for suggesting this elegant code splitting solution.

--- a/llama_index/text_splitter/code_splitter.py
+++ b/llama_index/text_splitter/code_splitter.py
@@ -10,9 +10,89 @@ from llama_index.callbacks.base import CallbackManager
 from llama_index.callbacks.schema import CBEventType, EventPayload
 from llama_index.text_splitter.types import TextSplitter
 
-DEFAULT_CHUNK_LINES = 40
-DEFAULT_LINES_OVERLAP = 15
-DEFAULT_MAX_CHARS = 1500
+ELLIPSES_COMMENT = " ... May have additional code availible in other documents, cut for brevity ..."  # The comment to use when chunking code
+
+def _generate_comment_line(language: str, comment: str) -> str:
+    single_line = {
+        'Ada': '--',
+        'Agda': '--',
+        'Apex': '//',
+        'Bash': '#',
+        'C': '//',
+        'C++': '//',
+        'C#': '//',
+        'Clojure': ';;',
+        'CMake': '#',
+        'Common Lisp': ';;',
+        'CUDA': '//',
+        'Dart': '//',
+        'D': '//',
+        'Dockerfile': '#',
+        'Elixir': '#',
+        'Elm': '--',
+        'Emacs Lisp': ';;',
+        'Erlang': '%',
+        'Fish': '#',
+        'Formula': '#',  # Assuming Excel-like formula
+        'Fortran': '!',
+        'Go': '//',
+        'Graphql': '#',
+        'Hack': '//',
+        'Haskell': '--',
+        'HCL': '#',
+        'HTML': '<!-- {} -->',
+        'Java': '//',
+        'JavaScript': '//',
+        'jq': '#',
+        'JSON5': '//',
+        'Julia': '#',
+        'Kotlin': '//',
+        'Latex': '%',
+        'Lua': '--',
+        'Make': '#',
+        'Markdown': '<!-- {} -->',  # Technically HTML but often used in Markdown
+        'Meson': '#',
+        'Nix': '#',
+        'Objective-C': '//',
+        'OCaml': '(* {} *)',
+        'Pascal': '//',
+        'Perl': '#',
+        'PHP': '//',
+        'PowerShell': '#',
+        'Protocol Buffers': '//',
+        'Python': '#',
+        'QML': '//',
+        'R': '#',
+        'Ruby': '#',
+        'Rust': '//',
+        'Scala': '//',
+        'Scheme': ';',
+        'Scss': '//',
+        'Shell': '#',
+        'SQL': '--',
+        'Svelte': '<!-- {} -->',  # HTML-like
+        'Swift': '//',
+        'TOML': '#',
+        'Turtle': '#',
+        'TypeScript': '//',
+        'Verilog': '//',
+        'VHDL': '--',
+        'Vue': '//',
+        'WASM': ';;',
+        'YAML': '#',
+        'YANG': '//',
+        'Zig': '//',
+    }
+    single_line = {k.lower(): v for k, v in single_line.items()}
+
+    if language.lower() in single_line:
+        syntax = single_line[language.lower()]
+        if '{}' in syntax:
+            return syntax.format(comment)
+        else:
+            return f"{syntax} {comment}"
+    else:
+        return f"🦙{comment}🦙"  # For unknown languages, use emoji to enclose the comment
 
 
 class CodeSplitter(TextSplitter):
@@ -45,9 +125,17 @@ class CodeSplitter(TextSplitter):
             context_list = []
 
         new_chunks = []
-        context_str = ''.join(context_list)
-        current_chunk = context_str  # Initialize current_chunk with current context
 
+        # We will assemble the context string from the context list
+        # For anything other than the last context, we will add an ellipses comment
+        # to indicate that there is more context before the current chunk
+        context_str = "".join(context_list)
+
+        current_chunk = str(context_str)  # Initialize current_chunk with current context
+        if current_chunk == "class Foo:\n    a: int = 1":
+            pass
+
+        has_recursive_children = False
         for child in node.children:
 
             # Add the new signature or header to the context list before recursing
@@ -57,7 +145,10 @@ class CodeSplitter(TextSplitter):
                 # In python, last_end will represent the spaces before child
                 # In any language, since child.children[-1] is a block, child.children[-2] will be the end of the signature
                 new_context = text[last_end:child.children[-2].end_byte]
+                if len(new_context_list) > 0:
+                    new_context_list.append('\n'+_generate_comment_line(self.language, ELLIPSES_COMMENT))
                 new_context_list.append(new_context)
+                has_recursive_children = True
                 next_chunks = self._chunk_node(child.children[-1], text, child.children[-2].end_byte, new_context_list)
                 new_chunks.extend(next_chunks)
             else:
@@ -66,6 +157,8 @@ class CodeSplitter(TextSplitter):
             last_end = child.end_byte
 
         if len(current_chunk) > len(context_str):  # If current_chunk has more than just the context
+            if has_recursive_children:
+                current_chunk += '\n'+_generate_comment_line(self.language, ELLIPSES_COMMENT)
             new_chunks.append(current_chunk)
 
         return new_chunks

--- a/tests/text_splitter/test_code_splitter.py
+++ b/tests/text_splitter/test_code_splitter.py
@@ -1,7 +1,7 @@
 """Test text splitter."""
 import os
 
-from llama_index.text_splitter.code_splitter import ELLIPSES_COMMENT, CodeSplitter, _generate_comment_line
+from llama_index.text_splitter.code_splitter import ELLIPSES_COMMENT, CodeSplitter, CodeBlockSplitter, _generate_comment_line
 
 
 def test_generate_comment_line_python() -> None:
@@ -30,6 +30,28 @@ def test_python_code_splitter() -> None:
         return
 
     code_splitter = CodeSplitter(
+        language="python", chunk_lines=4, chunk_lines_overlap=1, max_chars=50
+    )
+
+    text = """\
+def foo():
+    print("bar")
+
+def baz():
+    print("bbq")"""
+
+    chunks = code_splitter.split_text(text)
+    assert chunks[0] == "def foo():\n    print(\"bar\")"
+    assert chunks[1] == "def baz():\n    print(\"bbq\")"
+
+
+def test_python_code_block_splitter() -> None:
+    """Test case for code splitting using python"""
+
+    if "CI" in os.environ:
+        return
+
+    code_splitter = CodeBlockSplitter(
         language="python"
     )
 
@@ -45,13 +67,13 @@ def baz():
     assert chunks[1] == "def baz():\n    print(\"bbq\")"
 
 
-def test_python_code_splitter_class() -> None:
+def test_python_code_block_splitter_class() -> None:
     """Test case for code splitting using python including classes"""
 
     if "CI" in os.environ:
         return
 
-    code_splitter = CodeSplitter(
+    code_splitter = CodeBlockSplitter(
         language="python"
     )
 
@@ -69,122 +91,122 @@ class Foo:
     assert chunks[1] == f"class Foo:\n{ellipsis_comment}\n    def bar(self):\n        print(\"bar\")"
     assert chunks[2] == f"class Foo:\n    a: int = 1\n{ellipsis_comment}"
 
-# def test_typescript_code_splitter() -> None:
-#     """Test case for code splitting using typescript"""
+def test_typescript_code_splitter() -> None:
+    """Test case for code splitting using typescript"""
 
-#     if "CI" in os.environ:
-#         return
+    if "CI" in os.environ:
+        return
 
-#     code_splitter = CodeSplitter(
-#         language="typescript", chunk_lines=4, chunk_lines_overlap=1, max_chars=50
-#     )
+    code_splitter = CodeSplitter(
+        language="typescript", chunk_lines=4, chunk_lines_overlap=1, max_chars=50
+    )
 
-#     text = """\
-# function foo() {
-#     console.log("bar");
-# }
+    text = """\
+function foo() {
+    console.log("bar");
+}
 
-# function baz() {
-#     console.log("bbq");
-# }"""
+function baz() {
+    console.log("bbq");
+}"""
 
-#     chunks = code_splitter.split_text(text)
-#     assert chunks[0].startswith("function foo()")
-#     assert chunks[1].startswith("function baz()")
-
-
-# def test_html_code_splitter() -> None:
-#     """Test case for code splitting using typescript"""
-
-#     if "CI" in os.environ:
-#         return
-
-#     code_splitter = CodeSplitter(
-#         language="html", chunk_lines=4, chunk_lines_overlap=1, max_chars=50
-#     )
-
-#     text = """\
-# <!DOCTYPE html>
-# <html>
-# <head>
-#     <title>My Example Page</title>
-# </head>
-# <body>
-#     <h1>Welcome to My Example Page</h1>
-#     <p>This is a basic HTML page example.</p>
-#     <ul>
-#         <li>Item 1</li>
-#         <li>Item 2</li>
-#         <li>Item 3</li>
-#     </ul>
-#     <img src="https://example.com/image.jpg" alt="Example Image">
-# </body>
-# </html>"""
-
-#     chunks = code_splitter.split_text(text)
-#     assert chunks[0].startswith("<!DOCTYPE html>")
-#     assert chunks[1].startswith("<html>")
-#     assert chunks[2].startswith("<head>")
+    chunks = code_splitter.split_text(text)
+    assert chunks[0].startswith("function foo()")
+    assert chunks[1].startswith("function baz()")
 
 
-# def test_tsx_code_splitter() -> None:
-#     """Test case for code splitting using typescript"""
+def test_html_code_splitter() -> None:
+    """Test case for code splitting using typescript"""
 
-#     if "CI" in os.environ:
-#         return
+    if "CI" in os.environ:
+        return
 
-#     code_splitter = CodeSplitter(
-#         language="typescript", chunk_lines=4, chunk_lines_overlap=1, max_chars=50
-#     )
+    code_splitter = CodeSplitter(
+        language="html", chunk_lines=4, chunk_lines_overlap=1, max_chars=50
+    )
 
-#     text = """\
-# import React from 'react';
+    text = """\
+<!DOCTYPE html>
+<html>
+<head>
+    <title>My Example Page</title>
+</head>
+<body>
+    <h1>Welcome to My Example Page</h1>
+    <p>This is a basic HTML page example.</p>
+    <ul>
+        <li>Item 1</li>
+        <li>Item 2</li>
+        <li>Item 3</li>
+    </ul>
+    <img src="https://example.com/image.jpg" alt="Example Image">
+</body>
+</html>"""
 
-# interface Person {
-#   name: string;
-#   age: number;
-# }
-
-# const ExampleComponent: React.FC = () => {
-#   const person: Person = {
-#     name: 'John Doe',
-#     age: 30,
-#   };
-
-#   return (
-#     <div>
-#       <h1>Hello, {person.name}!</h1>
-#       <p>You are {person.age} years old.</p>
-#     </div>
-#   );
-# };
-
-# export default ExampleComponent;"""
-
-#     chunks = code_splitter.split_text(text)
-#     assert chunks[0].startswith("import React from 'react';")
-#     assert chunks[1].startswith("interface Person")
+    chunks = code_splitter.split_text(text)
+    assert chunks[0].startswith("<!DOCTYPE html>")
+    assert chunks[1].startswith("<html>")
+    assert chunks[2].startswith("<head>")
 
 
-# def test_cpp_code_splitter() -> None:
-#     """Test case for code splitting using typescript"""
+def test_tsx_code_splitter() -> None:
+    """Test case for code splitting using typescript"""
 
-#     if "CI" in os.environ:
-#         return
+    if "CI" in os.environ:
+        return
 
-#     code_splitter = CodeSplitter(
-#         language="cpp", chunk_lines=4, chunk_lines_overlap=1, max_chars=50
-#     )
+    code_splitter = CodeSplitter(
+        language="typescript", chunk_lines=4, chunk_lines_overlap=1, max_chars=50
+    )
 
-#     text = """\
-# #include <iostream>
+    text = """\
+import React from 'react';
 
-# int main() {
-#     std::cout << "Hello, World!" << std::endl;
-#     return 0;
-# }"""
+interface Person {
+  name: string;
+  age: number;
+}
 
-#     chunks = code_splitter.split_text(text)
-#     assert chunks[0].startswith("#include <iostream>")
-#     assert chunks[1].startswith("int main()")
-#     assert chunks[2].startswith("{\n    std::cout")
+const ExampleComponent: React.FC = () => {
+  const person: Person = {
+    name: 'John Doe',
+    age: 30,
+  };
+
+  return (
+    <div>
+      <h1>Hello, {person.name}!</h1>
+      <p>You are {person.age} years old.</p>
+    </div>
+  );
+};
+
+export default ExampleComponent;"""
+
+    chunks = code_splitter.split_text(text)
+    assert chunks[0].startswith("import React from 'react';")
+    assert chunks[1].startswith("interface Person")
+
+
+def test_cpp_code_splitter() -> None:
+    """Test case for code splitting using typescript"""
+
+    if "CI" in os.environ:
+        return
+
+    code_splitter = CodeSplitter(
+        language="cpp", chunk_lines=4, chunk_lines_overlap=1, max_chars=50
+    )
+
+    text = """\
+#include <iostream>
+
+int main() {
+    std::cout << "Hello, World!" << std::endl;
+    return 0;
+}"""
+
+    chunks = code_splitter.split_text(text)
+    assert chunks[0].startswith("#include <iostream>")
+    assert chunks[1].startswith("int main()")
+    assert chunks[2].startswith("{\n    std::cout")

--- a/tests/text_splitter/test_code_splitter.py
+++ b/tests/text_splitter/test_code_splitter.py
@@ -1,7 +1,26 @@
 """Test text splitter."""
 import os
 
-from llama_index.text_splitter import CodeSplitter
+from llama_index.text_splitter.code_splitter import ELLIPSES_COMMENT, CodeSplitter, _generate_comment_line
+
+
+def test_generate_comment_line_python() -> None:
+    assert _generate_comment_line('Python', 'This is a Python comment') == '# This is a Python comment'
+
+def test_generate_comment_line_c_lowercase() -> None:
+    assert _generate_comment_line('c', 'This is a C comment') == '// This is a C comment'
+
+def test_generate_comment_line_java() -> None:
+    assert _generate_comment_line('Java', 'This is a Java comment') == '// This is a Java comment'
+
+def test_generate_comment_line_html() -> None:
+    assert _generate_comment_line('HTML', 'This is an HTML comment') == '<!-- This is an HTML comment -->'
+
+def test_generate_comment_line_unknown() -> None:
+    assert _generate_comment_line('Unknown', 'This is an unknown language comment') == '🦙This is an unknown language comment🦙'
+
+def test_generate_comment_line_unknown_random() -> None:
+    assert _generate_comment_line('asdf', 'This is an unknown language comment') == '🦙This is an unknown language comment🦙'
 
 
 def test_python_code_splitter() -> None:
@@ -45,9 +64,10 @@ class Foo:
         print("bar")"""
 
     chunks = code_splitter.split_text(text)
-    assert chunks[0] == "class Foo:\n    def foo(self):\n        print(\"foo\")"
-    assert chunks[1] == "class Foo:\n    def bar(self):\n        print(\"bar\")"
-    assert chunks[2] == "class Foo:\n    a: int = 1"
+    ellipsis_comment = _generate_comment_line('Python', ELLIPSES_COMMENT)
+    assert chunks[0] == f"class Foo:\n{ellipsis_comment}\n    def foo(self):\n        print(\"foo\")"
+    assert chunks[1] == f"class Foo:\n{ellipsis_comment}\n    def bar(self):\n        print(\"bar\")"
+    assert chunks[2] == f"class Foo:\n    a: int = 1\n{ellipsis_comment}"
 
 # def test_typescript_code_splitter() -> None:
 #     """Test case for code splitting using typescript"""

--- a/tests/text_splitter/test_code_splitter.py
+++ b/tests/text_splitter/test_code_splitter.py
@@ -11,7 +11,7 @@ def test_python_code_splitter() -> None:
         return
 
     code_splitter = CodeSplitter(
-        language="python", chunk_lines=4, chunk_lines_overlap=1, max_chars=30
+        language="python"
     )
 
     text = """\
@@ -25,6 +25,29 @@ def baz():
     assert chunks[0] == "def foo():\n    print(\"bar\")"
     assert chunks[1] == "def baz():\n    print(\"bbq\")"
 
+
+def test_python_code_splitter_class() -> None:
+    """Test case for code splitting using python including classes"""
+
+    if "CI" in os.environ:
+        return
+
+    code_splitter = CodeSplitter(
+        language="python"
+    )
+
+    text = """\
+class Foo:
+    a: int = 1
+    def foo(self):
+        print("foo")
+    def bar(self):
+        print("bar")"""
+
+    chunks = code_splitter.split_text(text)
+    assert chunks[0] == "class Foo:\n    def foo(self):\n        print(\"foo\")"
+    assert chunks[1] == "class Foo:\n    def bar(self):\n        print(\"bar\")"
+    assert chunks[2] == "class Foo:\n    a: int = 1"
 
 # def test_typescript_code_splitter() -> None:
 #     """Test case for code splitting using typescript"""

--- a/tests/text_splitter/test_code_splitter.py
+++ b/tests/text_splitter/test_code_splitter.py
@@ -22,8 +22,8 @@ def baz():
     print("bbq")"""
 
     chunks = code_splitter.split_text(text)
-    assert chunks[0].startswith("def foo():")
-    assert chunks[1].startswith("def baz():")
+    assert chunks[0] == "def foo():\n    print(\"bar\")"
+    assert chunks[1] == "def baz():\n    print(\"bbq\")"
 
 
 # def test_typescript_code_splitter() -> None:

--- a/tests/text_splitter/test_code_splitter.py
+++ b/tests/text_splitter/test_code_splitter.py
@@ -26,122 +26,122 @@ def baz():
     assert chunks[1].startswith("def baz():")
 
 
-def test_typescript_code_splitter() -> None:
-    """Test case for code splitting using typescript"""
+# def test_typescript_code_splitter() -> None:
+#     """Test case for code splitting using typescript"""
 
-    if "CI" in os.environ:
-        return
+#     if "CI" in os.environ:
+#         return
 
-    code_splitter = CodeSplitter(
-        language="typescript", chunk_lines=4, chunk_lines_overlap=1, max_chars=50
-    )
+#     code_splitter = CodeSplitter(
+#         language="typescript", chunk_lines=4, chunk_lines_overlap=1, max_chars=50
+#     )
 
-    text = """\
-function foo() {
-    console.log("bar");
-}
+#     text = """\
+# function foo() {
+#     console.log("bar");
+# }
 
-function baz() {
-    console.log("bbq");
-}"""
+# function baz() {
+#     console.log("bbq");
+# }"""
 
-    chunks = code_splitter.split_text(text)
-    assert chunks[0].startswith("function foo()")
-    assert chunks[1].startswith("function baz()")
-
-
-def test_html_code_splitter() -> None:
-    """Test case for code splitting using typescript"""
-
-    if "CI" in os.environ:
-        return
-
-    code_splitter = CodeSplitter(
-        language="html", chunk_lines=4, chunk_lines_overlap=1, max_chars=50
-    )
-
-    text = """\
-<!DOCTYPE html>
-<html>
-<head>
-    <title>My Example Page</title>
-</head>
-<body>
-    <h1>Welcome to My Example Page</h1>
-    <p>This is a basic HTML page example.</p>
-    <ul>
-        <li>Item 1</li>
-        <li>Item 2</li>
-        <li>Item 3</li>
-    </ul>
-    <img src="https://example.com/image.jpg" alt="Example Image">
-</body>
-</html>"""
-
-    chunks = code_splitter.split_text(text)
-    assert chunks[0].startswith("<!DOCTYPE html>")
-    assert chunks[1].startswith("<html>")
-    assert chunks[2].startswith("<head>")
+#     chunks = code_splitter.split_text(text)
+#     assert chunks[0].startswith("function foo()")
+#     assert chunks[1].startswith("function baz()")
 
 
-def test_tsx_code_splitter() -> None:
-    """Test case for code splitting using typescript"""
+# def test_html_code_splitter() -> None:
+#     """Test case for code splitting using typescript"""
 
-    if "CI" in os.environ:
-        return
+#     if "CI" in os.environ:
+#         return
 
-    code_splitter = CodeSplitter(
-        language="typescript", chunk_lines=4, chunk_lines_overlap=1, max_chars=50
-    )
+#     code_splitter = CodeSplitter(
+#         language="html", chunk_lines=4, chunk_lines_overlap=1, max_chars=50
+#     )
 
-    text = """\
-import React from 'react';
+#     text = """\
+# <!DOCTYPE html>
+# <html>
+# <head>
+#     <title>My Example Page</title>
+# </head>
+# <body>
+#     <h1>Welcome to My Example Page</h1>
+#     <p>This is a basic HTML page example.</p>
+#     <ul>
+#         <li>Item 1</li>
+#         <li>Item 2</li>
+#         <li>Item 3</li>
+#     </ul>
+#     <img src="https://example.com/image.jpg" alt="Example Image">
+# </body>
+# </html>"""
 
-interface Person {
-  name: string;
-  age: number;
-}
-
-const ExampleComponent: React.FC = () => {
-  const person: Person = {
-    name: 'John Doe',
-    age: 30,
-  };
-
-  return (
-    <div>
-      <h1>Hello, {person.name}!</h1>
-      <p>You are {person.age} years old.</p>
-    </div>
-  );
-};
-
-export default ExampleComponent;"""
-
-    chunks = code_splitter.split_text(text)
-    assert chunks[0].startswith("import React from 'react';")
-    assert chunks[1].startswith("interface Person")
+#     chunks = code_splitter.split_text(text)
+#     assert chunks[0].startswith("<!DOCTYPE html>")
+#     assert chunks[1].startswith("<html>")
+#     assert chunks[2].startswith("<head>")
 
 
-def test_cpp_code_splitter() -> None:
-    """Test case for code splitting using typescript"""
+# def test_tsx_code_splitter() -> None:
+#     """Test case for code splitting using typescript"""
 
-    if "CI" in os.environ:
-        return
+#     if "CI" in os.environ:
+#         return
 
-    code_splitter = CodeSplitter(
-        language="cpp", chunk_lines=4, chunk_lines_overlap=1, max_chars=50
-    )
+#     code_splitter = CodeSplitter(
+#         language="typescript", chunk_lines=4, chunk_lines_overlap=1, max_chars=50
+#     )
 
-    text = """\
-#include <iostream>
+#     text = """\
+# import React from 'react';
 
-int main() {
-    std::cout << "Hello, World!" << std::endl;
-    return 0;
-}"""
+# interface Person {
+#   name: string;
+#   age: number;
+# }
 
-    chunks = code_splitter.split_text(text)
-    assert chunks[0].startswith("#include <iostream>")
-    assert chunks[1].startswith("int main()")
-    assert chunks[2].startswith("{\n    std::cout")
+# const ExampleComponent: React.FC = () => {
+#   const person: Person = {
+#     name: 'John Doe',
+#     age: 30,
+#   };
+
+#   return (
+#     <div>
+#       <h1>Hello, {person.name}!</h1>
+#       <p>You are {person.age} years old.</p>
+#     </div>
+#   );
+# };
+
+# export default ExampleComponent;"""
+
+#     chunks = code_splitter.split_text(text)
+#     assert chunks[0].startswith("import React from 'react';")
+#     assert chunks[1].startswith("interface Person")
+
+
+# def test_cpp_code_splitter() -> None:
+#     """Test case for code splitting using typescript"""
+
+#     if "CI" in os.environ:
+#         return
+
+#     code_splitter = CodeSplitter(
+#         language="cpp", chunk_lines=4, chunk_lines_overlap=1, max_chars=50
+#     )
+
+#     text = """\
+# #include <iostream>
+
+# int main() {
+#     std::cout << "Hello, World!" << std::endl;
+#     return 0;
+# }"""
+
+#     chunks = code_splitter.split_text(text)
+#     assert chunks[0].startswith("#include <iostream>")
+#     assert chunks[1].startswith("int main()")
+#     assert chunks[2].startswith("{\n    std::cout")


### PR DESCRIPTION
# Description

This PR updates the CodeSplitter class to improve how code is split when it's inside a context, such as a function or a loop. Previously, the context would be lost when the code was split, making the chunks hard to understand. The update fixes this by including the 'signature' or 'header' of the context in each chunk where it is relevant.

Fixes #7419

## Type of Change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
