### PR TITLE
Bugfix MonsterAPI Pydantic version v2/v1 support. Doc Update

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,17 +1,19 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
 version: 2
 
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the "docs/" directory with Sphinx
 sphinx:
   configuration: docs/conf.py
 
-build:
-  image: testing
-
-# NOTE: only build default HTML
-# formats: all
-
 python:
-  version: 3.9
-  install:
-    - requirements: docs/requirements.txt
-    - method: pip
-      path: .
+   install:
+   - requirements: docs/requirements.txt

--- a/llama_index/llms/monsterapi.py
+++ b/llama_index/llms/monsterapi.py
@@ -1,5 +1,8 @@
 from typing import Any, Callable, Dict, Optional, Sequence
-from pydantic import Field, PrivateAttr
+try:
+    from pydantic.v1 import Field, PrivateAttr
+except ImportError:
+    from pydantic import Field, PrivateAttr
 
 
 from llama_index.callbacks import CallbackManager

--- a/llama_index/llms/monsterapi.py
+++ b/llama_index/llms/monsterapi.py
@@ -89,7 +89,7 @@ class MonsterLLM(CustomLLM):
 
         llm_models_enabled = [i for i, j in MODEL_TYPES.items() if j == "LLM"]
 
-        return MonsterClient(str(monster_api_key)), llm_models_enabled
+        return MonsterClient(monster_api_key), llm_models_enabled
 
     @property
     def metadata(self) -> LLMMetadata:

--- a/llama_index/llms/monsterapi.py
+++ b/llama_index/llms/monsterapi.py
@@ -1,4 +1,5 @@
 from typing import Any, Callable, Dict, Optional, Sequence
+
 try:
     from pydantic.v1 import Field, PrivateAttr
 except ImportError:


### PR DESCRIPTION
# Description

1. Pydantic version difference affect through import PrivateAttr.
2. string conversion of None bug fix.
3. Update sphinx docs to use build.os since build.image utility is outdated.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Retested through notebook (that tests end-to-end)

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
