### PR TITLE
Update root.md to use get_response_synthesizer expected type.

### DIFF
--- a/docs/core_modules/query_modules/response_synthesizers/root.md
+++ b/docs/core_modules/query_modules/response_synthesizers/root.md
@@ -16,9 +16,9 @@ Use a response synthesizer on it's own:
 
 ```python
 from llama_index.schema import Node
-from llama_index.response_synthesizers import get_response_synthesizer
+from llama_index.response_synthesizers import ResponseMode, get_response_synthesizer
 
-response_synthesizer = get_response_synthesizer(response_mode='compact')
+response_synthesizer = get_response_synthesizer(response_mode=ResponseMode.COMPACT)
 
 response = response_synthesizer.synthesize("query text", nodes=[Node(text="text"), ...])
 ```


### PR DESCRIPTION
# Description

As in the title, the type for the kwarg `response_mode` expected an object of type `ResponseMode`, so I have updated the doc accordingly.

Fixes # (issue)

## Type of Change

Documentation update.

# How Has This Been Tested?

I have run this code locally, and the type checker doesn't complain any more.