### PR TITLE
feat: non-kg heterogeneous graph support in Graph RAG

### DIFF
--- a/docs/examples/query_engine/knowledge_graph_rag_query_engine.ipynb
+++ b/docs/examples/query_engine/knowledge_graph_rag_query_engine.ipynb
@@ -134,7 +134,7 @@
     "embedding_llm = LangchainEmbedding(\n",
     "    OpenAIEmbeddings(\n",
     "        model=\"text-embedding-ada-002\",\n",
-    "        deployment=\"nebula_docs_2_embedding\",\n",
+    "        deployment=\"INSERT DEPLOYMENT NAME\",\n",
     "        openai_api_key=openai.api_key,\n",
     "        openai_api_base=openai.api_base,\n",
     "        openai_api_type=openai.api_type,\n",

--- a/llama_index/graph_stores/falkordb.py
+++ b/llama_index/graph_stores/falkordb.py
@@ -57,7 +57,7 @@ class FalkorDBGraphStore(GraphStore):
         return result.result_set
 
     def get_rel_map(
-        self, subjs: Optional[List[str]] = None, depth: int = 2
+        self, subjs: Optional[List[str]] = None, depth: int = 2, limit: int = 30
     ) -> Dict[str, List[List[str]]]:
         """Get flat rel map."""
         # The flat means for multi-hop relation path, we could get
@@ -81,7 +81,7 @@ class FalkorDBGraphStore(GraphStore):
             WHERE n1.id IN $subjs
             WITH n1
             MATCH p=(n1)-[e*1..{depth}]->(z)
-            RETURN p
+            RETURN p LIMIT {limit}
         """
 
         data = self.query(query, params={"subjs": subjs})

--- a/llama_index/graph_stores/kuzu.py
+++ b/llama_index/graph_stores/kuzu.py
@@ -60,7 +60,7 @@ class KuzuGraphStore(GraphStore):
         return retval
 
     def get_rel_map(
-        self, subjs: Optional[List[str]] = None, depth: int = 2
+        self, subjs: Optional[List[str]] = None, depth: int = 2, limit: int = 30
     ) -> Dict[str, List[List[str]]]:
         """Get depth-aware rel map."""
         rel_wildcard = "r:%s*1..%d" % (self.rel_table_name, depth)
@@ -69,7 +69,7 @@ class KuzuGraphStore(GraphStore):
             rel_wildcard,
             self.node_table_name,
         )
-        return_clause = "RETURN n1, r, n2"
+        return_clause = "RETURN n1, r, n2 LIMIT %d" % limit
         params = []
         if subjs is not None:
             for i, curr_subj in enumerate(subjs):

--- a/llama_index/graph_stores/nebulagraph.py
+++ b/llama_index/graph_stores/nebulagraph.py
@@ -26,7 +26,7 @@ RETURN [src(e), dst(e)] AS sample_edge LIMIT 1
 rel_query_edge_type = Template(
     """
 MATCH (m)-[:`$edge_type`]->(n)
-  WHERE id(m) == "$src_id" AND id(n) == "$dst_id"
+  WHERE id(m) == $quote$src_id$quote AND id(n) == $quote$dst_id$quote
 RETURN "(:" + tags(m)[0] + ")-[:$edge_type]->(:" + tags(n)[0] + ")" AS rels
 """
 )
@@ -60,6 +60,16 @@ def prepare_subjs_param(
     subjs_list = []
     subjs_byte = ttypes.Value()
 
+    # filter non-digit string for INT64 vid type
+    if vid_type == "INT64":
+        subjs = [subj for subj in subjs if subj.isdigit()]
+        if len(subjs) == 0:
+            logger.warning(
+                f"KG is with INT64 vid type, but no digit string is provided."
+                f"Return empty subjs, and no query will be executed."
+                f"subjs: {subjs}"
+            )
+            return {}
     for subj in subjs:
         if not isinstance(subj, str):
             raise TypeError(f"Subject should be str, but got {type(subj).__name__}.")
@@ -100,8 +110,10 @@ class NebulaGraphStore(GraphStore):
         session_pool: Optional[Any] = None,
         space_name: Optional[str] = None,
         edge_types: Optional[List[str]] = ["relationship"],
-        rel_prop_names: Optional[List[str]] = ["relationship"],
+        rel_prop_names: Optional[List[str]] = ["relationship,"],
         tags: Optional[List[str]] = ["entity"],
+        tag_prop_names: Optional[List[str]] = ["name,"],
+        include_vid: bool = True,
         session_pool_kwargs: Optional[Dict[str, Any]] = {},
         **kwargs: Any,
     ) -> None:
@@ -112,6 +124,8 @@ class NebulaGraphStore(GraphStore):
             space_name: NebulaGraph space name.
             edge_types: Edge types.
             rel_prop_names: Relation property names corresponding to edge types.
+            tags: Tags.
+            tag_prop_names: Tag property names corresponding to tags.
             session_pool_kwargs: Keyword arguments for NebulaGraph session pool.
             **kwargs: Keyword arguments.
         """
@@ -133,20 +147,65 @@ class NebulaGraphStore(GraphStore):
 
         self._tags = tags or ["entity"]
         self._edge_types = edge_types or ["rel"]
-        self._rel_prop_names = rel_prop_names or ["predicate"]
+        self._rel_prop_names = rel_prop_names or ["predicate,"]
         if len(self._edge_types) != len(self._rel_prop_names):
             raise ValueError(
                 "edge_types and rel_prop_names to define relation and relation name"
-                "should be provided."
+                "should be provided, yet with same length."
             )
         if len(self._edge_types) == 0:
             raise ValueError("Length of `edge_types` should be greater than 0.")
+
+        if tag_prop_names is None or len(self._tags) != len(tag_prop_names):
+            raise ValueError(
+                "tag_prop_names to define tag and tag property name should be "
+                "provided, yet with same length."
+            )
+
+        if len(self._tags) == 0:
+            raise ValueError("Length of `tags` should be greater than 0.")
 
         # for building query
         self._edge_dot_rel = [
             f"`{edge_type}`.`{rel_prop_name}`"
             for edge_type, rel_prop_name in zip(self._edge_types, self._rel_prop_names)
         ]
+
+        self._edge_prop_map = {}
+        for edge_type, rel_prop_name in zip(self._edge_types, self._rel_prop_names):
+            self._edge_prop_map[edge_type] = [
+                prop.strip() for prop in rel_prop_name.split(",")
+            ]
+
+        # cypher string like: map{`follow`: "degree", `serve`: "start_year,end_year"}
+        self._edge_prop_map_cypher_string = (
+            "map{"
+            + ", ".join(
+                [
+                    f"`{edge_type}`: \"{','.join(rel_prop_names)}\""
+                    for edge_type, rel_prop_names in self._edge_prop_map.items()
+                ]
+            )
+            + "}"
+        )
+
+        # build tag_prop_names map
+        self._tag_prop_names_map = {}
+        for tag, prop_names in zip(self._tags, tag_prop_names or []):
+            if prop_names is not None:
+                self._tag_prop_names_map[tag] = f"`{tag}`.`{prop_names}`"
+        self._tag_prop_names: List[str] = list(
+            set(
+                [
+                    prop_name.strip()
+                    for prop_names in tag_prop_names or []
+                    if prop_names is not None
+                    for prop_name in prop_names.split(",")
+                ]
+            )
+        )
+
+        self._include_vid = include_vid
 
     def init_session_pool(self) -> Any:
         """Return NebulaGraph session pool."""
@@ -284,185 +343,118 @@ class NebulaGraphStore(GraphStore):
         Returns:
             Triplets.
         """
-        if self._vid_type == "INT64":
-            assert subj.isdigit(), (
-                "Subject should be a digit string in current "
-                "graph store, where vid type is INT64."
-            )
-            subj_field = str(int(subj))
-        else:
-            subj_field = f"{QUOTE}{subj}{QUOTE}"
-        if len(self._edge_types) == 1:
-            # edge_types = ["follow"]
-            # rel_prop_names = ["degree"]
-            # GO FROM "player100" OVER `follow``
-            # YIELD `follow`.`degree`` AS rel, dst(edge) AS obj
-            query = (
-                f"GO FROM {subj_field} OVER `{self._edge_types[0]}`"
-                f"YIELD `{self._edge_types[0]}`.`{self._rel_prop_names[0]}` AS rel, "
-                f"dst(edge) AS obj"
-            )
-        else:
-            # edge_types = ["follow", "serve"]
-            # rel_prop_names = ["degree", "start_year"]
-            # GO FROM "player100" OVER `follow`, `serve`
-            # YIELD [value IN [follow.degree,serve.start_year]
-            # WHERE value IS NOT EMPTY ][0] AS rel, dst(edge) AS obj
-            query = (
-                f"GO FROM {subj_field} OVER "
-                f"`{'`, `'.join(self._edge_types)}` "
-                f"YIELD "
-                f"[value IN [{', '.join(self._edge_dot_rel)}] "
-                f"WHERE value IS NOT EMPTY][0] AS rel, "
-                f"dst(edge) AS obj"
-            )
-        logger.debug(f"get()\nQuery: {query}")
-        result = self.execute(query)
-
-        # get raw data
-        rels = result.column_values("rel")
-        objs = result.column_values("obj")
-
-        # convert to list of list
-        return [[str(rel.cast()), str(obj.cast())] for rel, obj in zip(rels, objs)]
+        rel_map = self.get_flat_rel_map([subj], depth=1)
+        rels = list(rel_map.values())
+        if len(rels) == 0:
+            return []
+        return rels[0]
 
     def get_flat_rel_map(
-        self, subjs: Optional[List[str]] = None, depth: int = 2
+        self, subjs: Optional[List[str]] = None, depth: int = 2, limit: int = 30
     ) -> Dict[str, List[List[str]]]:
         """Get flat rel map."""
         # The flat means for multi-hop relation path, we could get
         # knowledge like: subj -rel-> obj -rel-> obj <-rel- obj.
         # This type of knowledge is useful for some tasks.
-        # +-------------+------------------------------------+
-        # | subj        | flattened_rels                     |
-        # +-------------+------------------------------------+
-        # | "player101" | [95, "player125", 2002, "team204"] |
-        # | "player100" | [1997, "team204"]                  |
+        # +---------------------+---------------------------------------------...-----+
+        # | subj                | flattened_rels                              ...     |
+        # +---------------------+---------------------------------------------...-----+
+        # | "{name:Tony Parker}"| "{name: Tony Parker}-[follow:{degree:95}]-> ...ili}"|
+        # | "{name:Tony Parker}"| "{name: Tony Parker}-[follow:{degree:95}]-> ...r}"  |
         # ...
-        # +-------------+------------------------------------+
         rel_map: Dict[Any, List[Any]] = {}
         if subjs is None or len(subjs) == 0:
             # unlike simple graph_store, we don't do get_all here
             return rel_map
 
-        if len(self._edge_types) == 1:
-            # WITH map{`true`: "-[", `false`: "<-["} AS arrow_l,
-            #      map{`true`: "]->", `false`: "]-"} AS arrow_r
-            # MATCH (s)-[e:follow*..2]-() WHERE id(s) IN ["player100", "player101"]
-            #   WITH id(s) AS subj, [rel in e | [
-            #      arrow_l[tostring(typeid(rel) > 0)] +
-            #         tostring(rel.degree)+
-            #      arrow_r[tostring(typeid(rel) > 0)],
-            #      CASE typeid(rel) > 0
-            #         WHEN true THEN dst(rel)
-            #         WHEN false THEN src(rel)
-            #      END
-            #      ]
-            #   ] AS rels
-            #   WITH
-            #       subj,
-            #       REDUCE(acc = collect(NULL), l in rels | acc + l) AS flattened_rels
-            # RETURN
-            #   subj,
-            #   REDUCE(acc = subj,l in flattened_rels|acc + ', ' + l) AS flattened_rels
-            query = (
-                f"WITH map{{`true`: '-[', `false`: '<-['}} AS arrow_l,"
-                f"     map{{`true`: ']->', `false`: ']-'}} AS arrow_r "
-                f"MATCH (s)-[e:`{self._edge_types[0]}`*..{depth}]-() "
-                f"  WHERE id(s) IN $subjs "
-                f"WITH "
-                f"id(s) AS subj,"
-                f"[rel IN e | "
-                f"  ["
-                f"  arrow_l[tostring(typeid(rel) > 0)] +"
-                f"      rel.`{self._rel_prop_names[0]}`+"
-                f"  arrow_r[tostring(typeid(rel) > 0)],"
-                f"  CASE typeid(rel) > 0"
-                f"    WHEN true THEN dst(rel)"
-                f"    WHEN false THEN src(rel)"
-                f"  END"
-                f"  ]"
-                f"] AS rels "
-                f"WITH "
-                f"  subj,"
-                f"  REDUCE(acc = collect(NULL), l in rels | acc + l)"
-                f"    AS flattened_rels"
-                f" RETURN"
-                f"  subj,"
-                f"  REDUCE(acc = subj, l in flattened_rels | acc + ', ' + l )"
-                f"    AS flattened_rels"
-            )
-        else:
-            # edge_types = ["follow", "serve"]
-            # rel_prop_names = ["degree", "start_year"]
-            # WITH map{`true`: "-[", `false`: "<-["} AS arrow_l,
-            #      map{`true`: "]->", `false`: "]-"} AS arrow_r
-            # MATCH (s)-[e:follow|serve*..2]-()
-            # WHERE id(s) IN ["player100", "player101"]
-            #   WITH id(s) AS subj,
-            #        [rel in e | [CASE type(rel)
-            #     WHEN "follow" THEN
-            #      arrow_l[tostring(typeid(rel) > 0)] +
-            #         tostring(rel.degree)+
-            #      arrow_r[tostring(typeid(rel) > 0)]
-            #     WHEN "serve" THEN
-            #      arrow_l[tostring(typeid(rel) > 0)] +
-            #         tostring(rel.start_year)+
-            #      arrow_r[tostring(typeid(rel) > 0)]
-            #     END,
-            #     CASE typeid(rel) > 0
-            #       WHEN true THEN dst(rel)
-            #       WHEN false THEN src(rel)
-            #     END
-            #     ]
-            # ] AS rels
-            #   WITH
-            #     subj,
-            #     REDUCE(acc = collect(NULL), l in rels | acc + l) AS
-            #       flattened_rels
-            # RETURN
-            #   subj,
-            #   REDUCE(acc = subj, l in flattened_rels | acc + ', ' + l ) AS
-            #       flattened_rels
-            _case_when_string = "".join(
-                [
-                    f"WHEN {QUOTE}{edge_type}{QUOTE} THEN "
-                    f"  arrow_l[tostring(typeid(rel) > 0)] +"
-                    f"  rel.`{rel_prop_name}` +"
-                    f"  arrow_r[tostring(typeid(rel) > 0)] "
-                    for edge_type, rel_prop_name in zip(
-                        self._edge_types, self._rel_prop_names
-                    )
-                ]
-            )
-            query = (
-                f"WITH map{{`true`: '-[', `false`: '<-['}} AS arrow_l,"
-                f"     map{{`true`: ']->', `false`: ']-'}} AS arrow_r "
-                f"MATCH (s)-[e:`{'`|`'.join(self._edge_types)}`*..{depth}]-() "
-                f"  WHERE id(s) IN $subjs "
-                f"  WITH "
-                f"    id(s) AS subj,"
-                f" [rel IN e | "
-                f"  [CASE type(rel) "
-                f"  {_case_when_string}"
-                f"  END, "
-                f"  CASE typeid(rel) > 0"
-                f"    WHEN true THEN dst(rel)"
-                f"    WHEN false THEN src(rel)"
-                f"  END"
-                f"  ] "
-                f"] AS rels "
-                f"  WITH"
-                f"    subj,"
-                f"    REDUCE(acc = collect(NULL), l in rels | acc + l) AS "
-                f"        flattened_rels"
-                f" RETURN"
-                f"  subj,"
-                f"  REDUCE(acc = subj, l in flattened_rels | acc + ', ' + l ) AS "
-                f"      flattened_rels"
-            )
+        # WITH map{`true`: "-[", `false`: "<-["} AS arrow_l,
+        #      map{`true`: "]->", `false`: "]-"} AS arrow_r,
+        #      map{`follow`: "degree", `serve`: "start_year,end_year"} AS edge_type_map
+        # MATCH p=(start)-[e:follow|serve*..2]-()
+        #     WHERE id(start) IN ["player100", "player101"]
+        #   WITH start, id(start) AS vid, nodes(p) AS nodes, e AS rels,
+        #     length(p) AS rel_count, arrow_l, arrow_r, edge_type_map
+        #   WITH
+        #     REDUCE(s = vid + '{', key IN [key_ in ["name"]
+        #       WHERE properties(start)[key_] IS NOT NULL]  | s + key + ': ' +
+        #         COALESCE(TOSTRING(properties(start)[key]), 'null') + ', ')
+        #         + '}'
+        #       AS subj,
+        #     [item in [i IN RANGE(0, rel_count - 1) | [nodes[i], nodes[i + 1],
+        #         rels[i], typeid(rels[i]) > 0, type(rels[i]) ]] | [
+        #      arrow_l[tostring(item[3])] +
+        #          item[4] + ':' +
+        #          REDUCE(s = '{', key IN SPLIT(edge_type_map[item[4]], ',') |
+        #            s + key + ': ' + COALESCE(TOSTRING(properties(item[2])[key]),
+        #            'null') + ', ') + '}'
+        #           +
+        #      arrow_r[tostring(item[3])],
+        #      REDUCE(s = id(item[1]) + '{', key IN [key_ in ["name"]
+        #           WHERE properties(item[1])[key_] IS NOT NULL]  | s + key + ': ' +
+        #           COALESCE(TOSTRING(properties(item[1])[key]), 'null') + ', ') + '}'
+        #      ]
+        #   ] AS rels
+        #   WITH
+        #       REPLACE(subj, ', }', '}') AS subj,
+        #       REDUCE(acc = collect(NULL), l in rels | acc + l) AS flattened_rels
+        #   RETURN
+        #     subj,
+        #     REPLACE(REDUCE(acc = subj,l in flattened_rels|acc + ' ' + l),
+        #       ', }', '}')
+        #       AS flattened_rels
+        #   LIMIT 30
+
+        # Based on self._include_vid
+        # {name: Tim Duncan} or player100{name: Tim Duncan} for entity
+        s_prefix = "vid + '{'" if self._include_vid else "'{'"
+        s1 = "id(item[1]) + '{'" if self._include_vid else "'{'"
+
+        query = (
+            f"WITH map{{`true`: '-[', `false`: '<-['}} AS arrow_l,"
+            f"     map{{`true`: ']->', `false`: ']-'}} AS arrow_r,"
+            f"     {self._edge_prop_map_cypher_string} AS edge_type_map "
+            f"MATCH p=(start)-[e:`{self._edge_types[0]}`*..{depth}]-() "
+            f"  WHERE id(start) IN $subjs "
+            f"WITH start, id(start) AS vid, nodes(p) AS nodes, e AS rels,"
+            f"  length(p) AS rel_count, arrow_l, arrow_r, edge_type_map "
+            f"WITH "
+            f"  REDUCE(s = {s_prefix}, key IN [key_ in {str(self._tag_prop_names)} "
+            f"    WHERE properties(start)[key_] IS NOT NULL]  | s + key + ': ' + "
+            f"      COALESCE(TOSTRING(properties(start)[key]), 'null') + ', ')"
+            f"      + '}}'"
+            f"    AS subj,"
+            f"  [item in [i IN RANGE(0, rel_count - 1)|[nodes[i], nodes[i + 1],"
+            f"      rels[i], typeid(rels[i]) > 0, type(rels[i]) ]] | ["
+            f"    arrow_l[tostring(item[3])] +"
+            f"      item[4] + ':' +"
+            f"      REDUCE(s = '{{', key IN SPLIT(edge_type_map[item[4]], ',') | "
+            f"        s + key + ': ' + COALESCE(TOSTRING(properties(item[2])[key]),"
+            f"        'null') + ', ') + '}}'"
+            f"      +"
+            f"    arrow_r[tostring(item[3])],"
+            f"    REDUCE(s = {s1}, key IN [key_ in "
+            f"        {str(self._tag_prop_names)} WHERE properties(item[1])[key_] "
+            f"        IS NOT NULL]  | s + key + ': ' + "
+            f"        COALESCE(TOSTRING(properties(item[1])[key]), 'null') + ', ')"
+            f"        + '}}'"
+            f"    ]"
+            f"  ] AS rels "
+            f"WITH "
+            f"  REPLACE(subj, ', }}', '}}') AS subj,"
+            f"  REDUCE(acc = collect(NULL), l in rels | acc + l) AS flattened_rels "
+            f"RETURN "
+            f"  subj,"
+            f"  REPLACE(REDUCE(acc = subj, l in flattened_rels | acc + ' ' + l), "
+            f"    ', }}', '}}') "
+            f"    AS flattened_rels"
+            f"  LIMIT {limit}"
+        )
         subjs_param = prepare_subjs_param(subjs, self._vid_type)
         logger.debug(f"get_flat_rel_map()\nsubjs_param: {subjs},\nquery: {query}")
+        if subjs_param == {}:
+            # This happens when subjs is None after prepare_subjs_param()
+            # Probably because vid type is INT64, but no digit string is provided.
+            return rel_map
         result = self.execute(query, subjs_param)
         if result is None:
             return rel_map
@@ -480,7 +472,7 @@ class NebulaGraphStore(GraphStore):
         return rel_map
 
     def get_rel_map(
-        self, subjs: Optional[List[str]] = None, depth: int = 2
+        self, subjs: Optional[List[str]] = None, depth: int = 2, limit: int = 30
     ) -> Dict[str, List[List[str]]]:
         """Get rel map."""
         # We put rels in a long list for depth>= 1, this is different from
@@ -492,7 +484,7 @@ class NebulaGraphStore(GraphStore):
             if len(subjs) == 0:
                 return {}
 
-        return self.get_flat_rel_map(subjs, depth)
+        return self.get_flat_rel_map(subjs, depth, limit)
 
     def upsert_triplet(self, subj: str, rel: str, obj: str) -> None:
         """Add triplet."""
@@ -650,7 +642,10 @@ class NebulaGraphStore(GraphStore):
             src_id, dst_id = sample_edge[0].cast()
             r = self.execute(
                 rel_query_edge_type.substitute(
-                    edge_type=edge_type_name, src_id=src_id, dst_id=dst_id
+                    edge_type=edge_type_name,
+                    src_id=src_id,
+                    dst_id=dst_id,
+                    quote="" if self._vid_type == "INT64" else QUOTE,
                 )
             ).column_values("rels")
             if len(r) > 0:

--- a/llama_index/graph_stores/nebulagraph.py
+++ b/llama_index/graph_stores/nebulagraph.py
@@ -480,7 +480,9 @@ class NebulaGraphStore(GraphStore):
         # But this makes more sense for multi-hop relation path.
 
         if subjs is not None:
-            subjs = [escape_str(subj) for subj in subjs]
+            subjs = [
+                escape_str(subj) for subj in subjs if isinstance(subj, str) and subj
+            ]
             if len(subjs) == 0:
                 return {}
 

--- a/llama_index/graph_stores/nebulagraph.py
+++ b/llama_index/graph_stores/nebulagraph.py
@@ -413,7 +413,7 @@ class NebulaGraphStore(GraphStore):
             f"WITH map{{`true`: '-[', `false`: '<-['}} AS arrow_l,"
             f"     map{{`true`: ']->', `false`: ']-'}} AS arrow_r,"
             f"     {self._edge_prop_map_cypher_string} AS edge_type_map "
-            f"MATCH p=(start)-[e:`{self._edge_types[0]}`*..{depth}]-() "
+            f"MATCH p=(start)-[e:`{'`|`'.join(self._edge_types)}`*..{depth}]-() "
             f"  WHERE id(start) IN $subjs "
             f"WITH start, id(start) AS vid, nodes(p) AS nodes, e AS rels,"
             f"  length(p) AS rel_count, arrow_l, arrow_r, edge_type_map "

--- a/llama_index/graph_stores/neo4j.py
+++ b/llama_index/graph_stores/neo4j.py
@@ -108,7 +108,7 @@ class Neo4jGraphStore(GraphStore):
         return retval
 
     def get_rel_map(
-        self, subjs: Optional[List[str]] = None, depth: int = 2
+        self, subjs: Optional[List[str]] = None, depth: int = 2, limit: int = 30
     ) -> Dict[str, List[List[str]]]:
         """Get flat rel map."""
         # The flat means for multi-hop relation path, we could get
@@ -133,7 +133,7 @@ class Neo4jGraphStore(GraphStore):
             "UNWIND relationships(p) AS rel "
             "WITH n1.id AS subj, p, apoc.coll.flatten(apoc.coll.toSet("
             "collect([type(rel), endNode(rel).id]))) AS flattened_rels "
-            "RETURN subj, collect(flattened_rels) AS flattened_rels "
+            f"RETURN subj, collect(flattened_rels) AS flattened_rels LIMIT {limit}"
         )
 
         data = list(self.query(query, {"subjs": subjs}))

--- a/llama_index/graph_stores/simple.py
+++ b/llama_index/graph_stores/simple.py
@@ -29,25 +29,42 @@ class SimpleGraphStoreData(DataClassJsonMixin):
     graph_dict: Dict[str, List[List[str]]] = field(default_factory=dict)
 
     def get_rel_map(
-        self, subjs: Optional[List[str]] = None, depth: int = 2
+        self, subjs: Optional[List[str]] = None, depth: int = 2, limit: int = 30
     ) -> Dict[str, List[List[str]]]:
         """Get subjects' rel map in max depth."""
         if subjs is None:
             subjs = list(self.graph_dict.keys())
         rel_map = {}
         for subj in subjs:
-            rel_map[subj] = self._get_rel_map(subj, depth=depth)
-        return rel_map
+            rel_map[subj] = self._get_rel_map(subj, depth=depth, limit=limit)
+        # TBD, truncate the rel_map in a spread way, now just truncate based
+        # on iteration order
+        rel_count = 0
+        return_map = {}
+        for subj in rel_map:
+            if rel_count + len(rel_map[subj]) > limit:
+                return_map[subj] = rel_map[subj][: limit - rel_count]
+                break
+            else:
+                return_map[subj] = rel_map[subj]
+                rel_count += len(rel_map[subj])
+        return return_map
 
-    def _get_rel_map(self, subj: str, depth: int = 2) -> List[List[str]]:
+    def _get_rel_map(
+        self, subj: str, depth: int = 2, limit: int = 30
+    ) -> List[List[str]]:
         """Get one subect's rel map in max depth."""
         if depth == 0:
             return []
         rel_map = []
+        rel_count = 0
         if subj in self.graph_dict:
             for rel, obj in self.graph_dict[subj]:
+                if rel_count >= limit:
+                    break
                 rel_map.append([subj, rel, obj])
                 rel_map += self._get_rel_map(obj, depth=depth - 1)
+                rel_count += 1
         return rel_map
 
 
@@ -94,10 +111,10 @@ class SimpleGraphStore(GraphStore):
         return self._data.graph_dict.get(subj, [])
 
     def get_rel_map(
-        self, subjs: Optional[List[str]] = None, depth: int = 2
+        self, subjs: Optional[List[str]] = None, depth: int = 2, limit: int = 30
     ) -> Dict[str, List[List[str]]]:
         """Get depth-aware rel map."""
-        return self._data.get_rel_map(subjs=subjs, depth=depth)
+        return self._data.get_rel_map(subjs=subjs, depth=depth, limit=limit)
 
     def upsert_triplet(self, subj: str, rel: str, obj: str) -> None:
         """Add triplet."""

--- a/llama_index/graph_stores/types.py
+++ b/llama_index/graph_stores/types.py
@@ -37,7 +37,7 @@ class GraphStore(Protocol):
         ...
 
     def get_rel_map(
-        self, subjs: Optional[List[str]] = None, depth: int = 2
+        self, subjs: Optional[List[str]] = None, depth: int = 2, limit: int = 30
     ) -> Dict[str, List[List[str]]]:
         """Get depth-aware rel map."""
         ...

--- a/llama_index/indices/knowledge_graph/retrievers.py
+++ b/llama_index/indices/knowledge_graph/retrievers.py
@@ -108,7 +108,13 @@ class KGTableRetriever(BaseRetriever):
         self.max_knowledge_sequence = max_knowledge_sequence
         self._verbose = kwargs.get("verbose", False)
         refresh_schema = kwargs.get("refresh_schema", False)
-        self._graph_schema = self._graph_store.get_schema(refresh=refresh_schema)
+        try:
+            self._graph_schema = self._graph_store.get_schema(refresh=refresh_schema)
+        except NotImplementedError:
+            self._graph_schema = None
+        except Exception as e:
+            logger.warn(f"Failed to get graph schema: {e}")
+            self._graph_schema = None
 
     def _get_keywords(self, query_str: str) -> List[str]:
         """Extract keywords."""
@@ -285,8 +291,9 @@ class KGTableRetriever(BaseRetriever):
         rel_node_info = {
             "kg_rel_texts": rel_texts,
             "kg_rel_map": cur_rel_map,
-            "kg_schema": self._graph_schema,
         }
+        if self._graph_schema:
+            rel_node_info["kg_schema"] = self._graph_schema
         rel_info_text = "\n".join(
             [
                 str(item)
@@ -449,7 +456,13 @@ class KnowledgeGraphRAGRetriever(BaseRetriever):
         self._max_knowledge_sequence = max_knowledge_sequence
         self._verbose = verbose
         refresh_schema = kwargs.get("refresh_schema", False)
-        self._graph_schema = self._graph_store.get_schema(refresh=refresh_schema)
+        try:
+            self._graph_schema = self._graph_store.get_schema(refresh=refresh_schema)
+        except NotImplementedError:
+            self._graph_schema = None
+        except Exception as e:
+            logger.warn(f"Failed to get graph schema: {e}")
+            self._graph_schema = None
 
     def _process_entities(
         self,

--- a/llama_index/indices/knowledge_graph/retrievers.py
+++ b/llama_index/indices/knowledge_graph/retrievers.py
@@ -107,6 +107,8 @@ class KGTableRetriever(BaseRetriever):
         self.use_global_node_triplets = use_global_node_triplets
         self.max_knowledge_sequence = max_knowledge_sequence
         self._verbose = kwargs.get("verbose", False)
+        refresh_schema = kwargs.get("refresh_schema", False)
+        self._graph_schema = self._graph_store.get_schema(refresh=refresh_schema)
 
     def _get_keywords(self, query_str: str) -> List[str]:
         """Extract keywords."""
@@ -283,6 +285,7 @@ class KGTableRetriever(BaseRetriever):
         rel_node_info = {
             "kg_rel_texts": rel_texts,
             "kg_rel_map": cur_rel_map,
+            "kg_schema": self._graph_schema,
         }
         rel_info_text = "\n".join(
             [
@@ -445,6 +448,8 @@ class KnowledgeGraphRAGRetriever(BaseRetriever):
         self._graph_traversal_depth = graph_traversal_depth
         self._max_knowledge_sequence = max_knowledge_sequence
         self._verbose = verbose
+        refresh_schema = kwargs.get("refresh_schema", False)
+        self._graph_schema = self._graph_store.get_schema(refresh=refresh_schema)
 
     def _process_entities(
         self,
@@ -666,7 +671,10 @@ class KnowledgeGraphRAGRetriever(BaseRetriever):
                 metadata={
                     "kg_rel_text": knowledge_sequence,
                     "kg_rel_map": rel_map,
+                    "kg_schema": self._graph_schema,
                 },
+                excluded_embed_metadata_keys=["kg_rel_map", "kg_rel_text"],
+                excluded_llm_metadata_keys=["kg_rel_map", "kg_rel_text"],
             )
         )
         return [node]

--- a/llama_index/indices/knowledge_graph/retrievers.py
+++ b/llama_index/indices/knowledge_graph/retrievers.py
@@ -385,7 +385,7 @@ class KnowledgeGraphRAGRetriever(BaseRetriever):
         retriever_mode: Optional[str] = "keyword",
         with_nl2graphquery: bool = False,
         graph_traversal_depth: int = 2,
-        max_knowledge_sequence: int = 30,
+        max_knowledge_sequence: int = REL_TEXT_LIMIT,
         verbose: bool = False,
         **kwargs: Any,
     ) -> None:
@@ -600,7 +600,7 @@ class KnowledgeGraphRAGRetriever(BaseRetriever):
         """Get knowledge sequence from entities."""
         # Get SubGraph from Graph Store as Knowledge Sequence
         rel_map: Optional[Dict] = self._graph_store.get_rel_map(
-            entities, self._graph_traversal_depth
+            entities, self._graph_traversal_depth, limit=self._max_knowledge_sequence
         )
         logger.debug(f"rel_map: {rel_map}")
 
@@ -613,9 +613,6 @@ class KnowledgeGraphRAGRetriever(BaseRetriever):
         else:
             logger.info("> No knowledge sequence extracted from entities.")
             return [], None
-        # truncate knowledge sequence
-        if len(knowledge_sequence) > self._max_knowledge_sequence:
-            knowledge_sequence = knowledge_sequence[: self._max_knowledge_sequence]
 
         return knowledge_sequence, rel_map
 
@@ -626,9 +623,9 @@ class KnowledgeGraphRAGRetriever(BaseRetriever):
         # Get SubGraph from Graph Store as Knowledge Sequence
         # TBD: async in graph store
         rel_map: Optional[Dict] = self._graph_store.get_rel_map(
-            entities, self._graph_traversal_depth
+            entities, self._graph_traversal_depth, limit=self._max_knowledge_sequence
         )
-        logger.debug(f"rel_map: {rel_map}")
+        logger.debug(f"rel_map from GraphStore:\n{rel_map}")
 
         # Build Knowledge Sequence
         knowledge_sequence = []
@@ -639,9 +636,6 @@ class KnowledgeGraphRAGRetriever(BaseRetriever):
         else:
             logger.info("> No knowledge sequence extracted from entities.")
             return [], None
-        # truncate knowledge sequence
-        if len(knowledge_sequence) > self._max_knowledge_sequence:
-            knowledge_sequence = knowledge_sequence[: self._max_knowledge_sequence]
 
         return knowledge_sequence, rel_map
 

--- a/llama_index/indices/knowledge_graph/retrievers.py
+++ b/llama_index/indices/knowledge_graph/retrievers.py
@@ -111,10 +111,10 @@ class KGTableRetriever(BaseRetriever):
         try:
             self._graph_schema = self._graph_store.get_schema(refresh=refresh_schema)
         except NotImplementedError:
-            self._graph_schema = None
+            self._graph_schema = ""
         except Exception as e:
             logger.warn(f"Failed to get graph schema: {e}")
-            self._graph_schema = None
+            self._graph_schema = ""
 
     def _get_keywords(self, query_str: str) -> List[str]:
         """Extract keywords."""
@@ -292,8 +292,8 @@ class KGTableRetriever(BaseRetriever):
             "kg_rel_texts": rel_texts,
             "kg_rel_map": cur_rel_map,
         }
-        if self._graph_schema:
-            rel_node_info["kg_schema"] = self._graph_schema
+        if self._graph_schema != "":
+            rel_node_info["kg_schema"] = {"schema": self._graph_schema}
         rel_info_text = "\n".join(
             [
                 str(item)
@@ -459,10 +459,10 @@ class KnowledgeGraphRAGRetriever(BaseRetriever):
         try:
             self._graph_schema = self._graph_store.get_schema(refresh=refresh_schema)
         except NotImplementedError:
-            self._graph_schema = None
+            self._graph_schema = ""
         except Exception as e:
             logger.warn(f"Failed to get graph schema: {e}")
-            self._graph_schema = None
+            self._graph_schema = ""
 
     def _process_entities(
         self,
@@ -677,15 +677,17 @@ class KnowledgeGraphRAGRetriever(BaseRetriever):
         if self._verbose:
             print_text(f"Graph RAG context:\n{context_string}\n", color="blue")
 
+        rel_node_info = {
+            "kg_rel_map": rel_map,
+            "kg_rel_text": knowledge_sequence,
+        }
+        if self._graph_schema != "":
+            rel_node_info["kg_schema"] = {"schema": self._graph_schema}
         node = NodeWithScore(
             node=TextNode(
                 text=context_string,
                 score=1.0,
-                metadata={
-                    "kg_rel_text": knowledge_sequence,
-                    "kg_rel_map": rel_map,
-                    "kg_schema": self._graph_schema,
-                },
+                metadata=rel_node_info,
                 excluded_embed_metadata_keys=["kg_rel_map", "kg_rel_text"],
                 excluded_llm_metadata_keys=["kg_rel_map", "kg_rel_text"],
             )


### PR DESCRIPTION
# Description

- add impl. nebula graph_store on the general graph, follow-up of #7402
- fixed int vid schema fetching in NebulaGraph
- fixed graph_store get_rel_map node metadata explosion, in a large subgraph retrieval, the metadata will be too large
  - now rel_map metadata will be excluded
- graph schema will be included as metadata of node

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [x] ~~Added~~ [new notebook](https://colab.research.google.com/drive/1rFeJX9WHArtf7zFEl5C5BCEYUQ2Q2LFe?usp=sharing) (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
