### PR TITLE
support both str and templates for query_wrapper_prompt in HF LLMs

### DIFF
--- a/llama_index/llms/huggingface.py
+++ b/llama_index/llms/huggingface.py
@@ -1,6 +1,6 @@
 import logging
 from threading import Thread
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
 
 try:
     from pydantic.v1 import Field, PrivateAttr
@@ -15,6 +15,7 @@ from llama_index.llms.base import (
     llm_completion_callback,
 )
 from llama_index.llms.custom import CustomLLM
+from llama_index.prompts.base import PromptTemplate
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +42,8 @@ class HuggingFaceLLM(CustomLLM):
     query_wrapper_prompt: str = Field(
         description=(
             "The query wrapper prompt, containing the query placeholder. "
-            "The model card on HuggingFace should specify if this is needed."
+            "The model card on HuggingFace should specify if this is needed. "
+            "Should contain a `{query_str}` placeholder."
         ),
     )
     tokenizer_name: str = Field(
@@ -86,7 +88,7 @@ class HuggingFaceLLM(CustomLLM):
         context_window: int = 4096,
         max_new_tokens: int = 256,
         system_prompt: str = "",
-        query_wrapper_prompt: str = "",
+        query_wrapper_prompt: Union[str, PromptTemplate] = "{query_str}",
         tokenizer_name: str = "StabilityAI/stablelm-tuned-alpha-3b",
         model_name: str = "StabilityAI/stablelm-tuned-alpha-3b",
         model: Optional[Any] = None,
@@ -150,6 +152,9 @@ class HuggingFaceLLM(CustomLLM):
                 return False
 
         self._stopping_criteria = StoppingCriteriaList([StopOnTokens()])
+
+        if isinstance(query_wrapper_prompt, PromptTemplate):
+            query_wrapper_prompt = query_wrapper_prompt.template
 
         super().__init__(
             context_window=context_window,


### PR DESCRIPTION
# Description

Recent changes removed support for input template objects on the `query_wrapper_prompt`

This pr brings back support for both

Fixes https://github.com/jerryjliu/llama_index/issues/7439
