### PR TITLE
fix: kg rag should work on all graph stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes / Nits
 - Only convert newlines to spaces for text 001 embedding models in OpenAI (#7484)
+- Fix `KnowledgeGraphRagRetriever` for non-nebula indexes (#7488)
 
 ## [0.8.14] - 2023-08-30
 

--- a/llama_index/indices/knowledge_graph/retrievers.py
+++ b/llama_index/indices/knowledge_graph/retrievers.py
@@ -626,7 +626,7 @@ class KnowledgeGraphRAGRetriever(BaseRetriever):
         knowledge_sequence = []
         if rel_map:
             knowledge_sequence.extend(
-                [rel_obj for rel_objs in rel_map.values() for rel_obj in rel_objs]
+                [str(rel_obj) for rel_objs in rel_map.values() for rel_obj in rel_objs]
             )
         else:
             logger.info("> No knowledge sequence extracted from entities.")
@@ -649,7 +649,7 @@ class KnowledgeGraphRAGRetriever(BaseRetriever):
         knowledge_sequence = []
         if rel_map:
             knowledge_sequence.extend(
-                [rel_obj for rel_objs in rel_map.values() for rel_obj in rel_objs]
+                [str(rel_obj) for rel_objs in rel_map.values() for rel_obj in rel_objs]
             )
         else:
             logger.info("> No knowledge sequence extracted from entities.")


### PR DESCRIPTION
# Description

This change fixed kg rag retriever on all graph_store, similar approaches had already been done in KG Table retrievers, but I forgot to handle this divisive behavior when impl. this one.

Fixes https://github.com/jerryjliu/llama_index/issues/7483

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [x] [notebook](https://colab.research.google.com/drive/1E9tqUX6CJecNwWFxCYZgSPMxuyUHS725?usp=sharing) (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
