### PR TITLE
fix simple web page reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## Unreleased
+
+### Bug Fixes / Nits
+- Ensure metadata is not `None` in `SimpleWebPageReader` (#7499)
+
 ## [0.8.15] - 2023-08-31
 
 ### New Features

--- a/llama_index/readers/web.py
+++ b/llama_index/readers/web.py
@@ -62,7 +62,7 @@ class SimpleWebPageReader(BaseReader):
             if self._metadata_fn is not None:
                 metadata = self._metadata_fn(url)
 
-            documents.append(Document(text=response, metadata=metadata))
+            documents.append(Document(text=response, metadata=metadata or {}))
 
         return documents
 


### PR DESCRIPTION
# Description

Small fix to ensure metadata is not `None` in `SimpleWebPageReader`

Fixes https://github.com/jerryjliu/llama_index/issues/7496

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

