### PR TITLE
Improve error logs for text splitters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## Unreleased
+
+### Bug Fixes / Nits
+- Raise informative error when metadata is too large during splitting (#7513)
+
 ## [0.8.16] - 2023-09-01
 
 ### Bug Fixes / Nits

--- a/llama_index/text_splitter/sentence_splitter.py
+++ b/llama_index/text_splitter/sentence_splitter.py
@@ -122,6 +122,21 @@ class SentenceSplitter(MetadataAwareTextSplitter):
     def split_text_metadata_aware(self, text: str, metadata_str: str) -> List[str]:
         metadata_len = len(self.tokenizer(metadata_str))
         effective_chunk_size = self.chunk_size - metadata_len
+        if effective_chunk_size <= 0:
+            raise ValueError(
+                f"Metadata length ({metadata_len}) is longer than chunk size "
+                f"({self.chunk_size}). Consider increasing the chunk size or "
+                "decreasing the size of your metadata to avoid this."
+            )
+        elif effective_chunk_size < 50:
+            print(
+                f"Metadata length ({metadata_len}) is close to chunk size "
+                f"({self.chunk_size}). Resulting chunks are less than 50 tokens. "
+                "Consider increasing the chunk size or decreasing the size of "
+                "your metadata to avoid this.",
+                flush=True,
+            )
+
         return self._split_text(text, chunk_size=effective_chunk_size)
 
     def split_text(self, text: str) -> List[str]:

--- a/llama_index/text_splitter/token_splitter.py
+++ b/llama_index/text_splitter/token_splitter.py
@@ -83,6 +83,21 @@ class TokenTextSplitter(MetadataAwareTextSplitter):
         """Split text into chunks, reserving space required for metadata str."""
         metadata_len = len(self.tokenizer(metadata_str)) + DEFAULT_METADATA_FORMAT_LEN
         effective_chunk_size = self.chunk_size - metadata_len
+        if effective_chunk_size <= 0:
+            raise ValueError(
+                f"Metadata length ({metadata_len}) is longer than chunk size "
+                f"({self.chunk_size}). Consider increasing the chunk size or "
+                "decreasing the size of your metadata to avoid this."
+            )
+        elif effective_chunk_size < 50:
+            print(
+                f"Metadata length ({metadata_len}) is close to chunk size "
+                f"({self.chunk_size}). Resulting chunks are less than 50 tokens. "
+                "Consider increasing the chunk size or decreasing the size of "
+                "your metadata to avoid this.",
+                flush=True,
+            )
+
         return self._split_text(text, chunk_size=effective_chunk_size)
 
     def split_text(self, text: str) -> List[str]:


### PR DESCRIPTION
# Description

If the metadata is too large, the effective chunk size will be negative, leading to a confusing maximum recursion error. This PR simply adds better error logging with more helpful advice on how to fix the problem.

Fixes https://github.com/jerryjliu/llama_index/issues/7505

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense
