### PR TITLE
Allow langchain splitter in simple node parser

### DIFF
--- a/llama_index/bridge/langchain.py
+++ b/llama_index/bridge/langchain.py
@@ -53,7 +53,7 @@ from langchain.sql_database import SQLDatabase
 from langchain.input import get_color_mapping, print_text
 
 # input & output
-from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain.text_splitter import RecursiveCharacterTextSplitter, TextSplitter
 from langchain.tools import BaseTool, StructuredTool, Tool
 
 __all__ = [
@@ -110,4 +110,5 @@ __all__ = [
     "BaseCache",
     "Document",
     "RecursiveCharacterTextSplitter",
+    "TextSplitter",
 ]

--- a/llama_index/indices/service_context.py
+++ b/llama_index/indices/service_context.py
@@ -18,6 +18,7 @@ from llama_index.node_parser.interface import NodeParser
 from llama_index.node_parser.sentence_window import SentenceWindowNodeParser
 from llama_index.node_parser.simple import SimpleNodeParser
 from llama_index.prompts.base import BasePromptTemplate
+from llama_index.text_splitter.types import TextSplitter
 
 logger = logging.getLogger(__name__)
 
@@ -283,7 +284,9 @@ class ServiceContext:
         metadata_extractor_dict = None
         extractor_dicts = None
         text_splitter_dict = None
-        if isinstance(self.node_parser, SimpleNodeParser):
+        if isinstance(self.node_parser, SimpleNodeParser) and isinstance(
+            self.node_parser.text_splitter, TextSplitter
+        ):
             text_splitter_dict = self.node_parser.text_splitter.to_dict()
 
         if isinstance(self.node_parser, (SimpleNodeParser, SentenceWindowNodeParser)):

--- a/llama_index/node_parser/loading.py
+++ b/llama_index/node_parser/loading.py
@@ -5,12 +5,12 @@ from llama_index.node_parser.simple import SimpleNodeParser
 from llama_index.node_parser.sentence_window import SentenceWindowNodeParser
 from llama_index.node_parser.extractors.metadata_extractors import MetadataExtractor
 from llama_index.text_splitter.sentence_splitter import SentenceSplitter
-from llama_index.text_splitter.types import TextSplitter
+from llama_index.text_splitter.types import SplitterType
 
 
 def load_parser(
     data: dict,
-    text_splitter: Optional[TextSplitter] = None,
+    text_splitter: Optional[SplitterType] = None,
     metadata_extractor: Optional[MetadataExtractor] = None,
 ) -> NodeParser:
     parser_name = data.get("class_name", None)

--- a/llama_index/node_parser/node_utils.py
+++ b/llama_index/node_parser/node_utils.py
@@ -13,8 +13,7 @@ from llama_index.schema import (
     NodeRelationship,
     TextNode,
 )
-from llama_index.text_splitter import TextSplitter
-from llama_index.text_splitter.types import MetadataAwareTextSplitter
+from llama_index.text_splitter.types import MetadataAwareTextSplitter, SplitterType
 from llama_index.utils import truncate_text
 
 logger = logging.getLogger(__name__)
@@ -94,7 +93,7 @@ def build_nodes_from_splits(
 
 def get_nodes_from_document(
     document: BaseNode,
-    text_splitter: TextSplitter,
+    text_splitter: SplitterType,
     include_metadata: bool = True,
     include_prev_next_rel: bool = False,
 ) -> List[TextNode]:
@@ -115,7 +114,7 @@ def get_nodes_from_document(
 
 def get_nodes_from_node(
     node: BaseNode,
-    text_splitter: TextSplitter,
+    text_splitter: SplitterType,
     include_metadata: bool = True,
     include_prev_next_rel: bool = False,
     ref_doc: Optional[BaseNode] = None,

--- a/llama_index/node_parser/simple.py
+++ b/llama_index/node_parser/simple.py
@@ -1,7 +1,6 @@
 """Simple node parser."""
-from typing import List, Optional, Sequence, Union
+from typing import List, Optional, Sequence
 
-from llama_index.bridge.langchain import TextSplitter as LC_TextSplitter
 from llama_index.bridge.pydantic import Field
 from llama_index.callbacks.base import CallbackManager
 from llama_index.callbacks.schema import CBEventType, EventPayload
@@ -9,10 +8,8 @@ from llama_index.node_parser.extractors.metadata_extractors import MetadataExtra
 from llama_index.node_parser.interface import NodeParser
 from llama_index.node_parser.node_utils import get_nodes_from_document
 from llama_index.schema import BaseNode, Document
-from llama_index.text_splitter import TextSplitter, get_default_text_splitter
+from llama_index.text_splitter import get_default_text_splitter, SplitterType
 from llama_index.utils import get_tqdm_iterable
-
-SplitterType = Union[TextSplitter, LC_TextSplitter]
 
 
 class SimpleNodeParser(NodeParser):

--- a/llama_index/node_parser/simple.py
+++ b/llama_index/node_parser/simple.py
@@ -1,8 +1,8 @@
 """Simple node parser."""
-from typing import List, Optional, Sequence
+from typing import List, Optional, Sequence, Union
 
+from llama_index.bridge.langchain import TextSplitter as LC_TextSplitter
 from llama_index.bridge.pydantic import Field
-
 from llama_index.callbacks.base import CallbackManager
 from llama_index.callbacks.schema import CBEventType, EventPayload
 from llama_index.node_parser.extractors.metadata_extractors import MetadataExtractor
@@ -11,6 +11,8 @@ from llama_index.node_parser.node_utils import get_nodes_from_document
 from llama_index.schema import BaseNode, Document
 from llama_index.text_splitter import TextSplitter, get_default_text_splitter
 from llama_index.utils import get_tqdm_iterable
+
+SplitterType = Union[TextSplitter, LC_TextSplitter]
 
 
 class SimpleNodeParser(NodeParser):
@@ -25,7 +27,7 @@ class SimpleNodeParser(NodeParser):
 
     """
 
-    text_splitter: TextSplitter = Field(
+    text_splitter: SplitterType = Field(
         description="The text splitter to use when splitting documents."
     )
     include_metadata: bool = Field(
@@ -46,7 +48,7 @@ class SimpleNodeParser(NodeParser):
         cls,
         chunk_size: Optional[int] = None,
         chunk_overlap: Optional[int] = None,
-        text_splitter: Optional[TextSplitter] = None,
+        text_splitter: Optional[SplitterType] = None,
         include_metadata: bool = True,
         include_prev_next_rel: bool = True,
         callback_manager: Optional[CallbackManager] = None,

--- a/llama_index/text_splitter/__init__.py
+++ b/llama_index/text_splitter/__init__.py
@@ -5,7 +5,7 @@ from llama_index.constants import DEFAULT_CHUNK_OVERLAP, DEFAULT_CHUNK_SIZE
 from llama_index.text_splitter.code_splitter import CodeSplitter
 from llama_index.text_splitter.sentence_splitter import SentenceSplitter
 from llama_index.text_splitter.token_splitter import TokenTextSplitter
-from llama_index.text_splitter.types import TextSplitter
+from llama_index.text_splitter.types import TextSplitter, SplitterType
 
 
 def get_default_text_splitter(
@@ -31,4 +31,5 @@ __all__ = [
     "TokenTextSplitter",
     "SentenceSplitter",
     "CodeSplitter",
+    "SplitterType",
 ]

--- a/llama_index/text_splitter/types.py
+++ b/llama_index/text_splitter/types.py
@@ -1,7 +1,8 @@
 """Text splitter implementations."""
 from abc import ABC, abstractmethod
-from typing import List
+from typing import List, Union
 
+from llama_index.bridge.langchain import TextSplitter as LC_TextSplitter
 from llama_index.schema import BaseComponent
 
 
@@ -18,3 +19,6 @@ class MetadataAwareTextSplitter(TextSplitter):
     @abstractmethod
     def split_text_metadata_aware(self, text: str, metadata_str: str) -> List[str]:
         ...
+
+
+SplitterType = Union[TextSplitter, LC_TextSplitter]


### PR DESCRIPTION
# Description

Allows the use of langchain splitters in SimpleNodeParser

(Note: This will not work when using to/from dict however)

Fixes https://github.com/jerryjliu/llama_index/issues/7506

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested in terminal
- [x] I stared at the code and made sure it makes sense
