### PR TITLE
define node_id as a setter, update docs

### DIFF
--- a/docs/core_modules/data_modules/documents_and_nodes/usage_documents.md
+++ b/docs/core_modules/data_modules/documents_and_nodes/usage_documents.md
@@ -70,7 +70,7 @@ documents = SimpleDirectoryReader('./data', file_metadata=filename_fn).load_data
 
 ### Customizing the id
 
-As detailed in the section [Document Management](../index/document_management.md), the doc `id_` is used to enable effecient refreshing of documents in the index. When using the `SimpleDirectoryReader`, you can automatically set the doc `id_` to be the full path to each document:
+As detailed in the section [Document Management](../index/document_management.md), the `doc_id` is used to enable effecient refreshing of documents in the index. When using the `SimpleDirectoryReader`, you can automatically set the doc `doc_id` to be the full path to each document:
 
 ```python
 from llama_index import SimpleDirectoryReader
@@ -79,11 +79,13 @@ documents = SimpleDirectoryReader("./data", filename_as_id=True).load_data()
 print([x.doc_id for x in documents])
 ```
 
-You can also set the `id_` of any `Document` or `TextNode` directly!
+You can also set the `doc_id` of any `Document` directly!
 
 ```python
-document.id_ = "My new document id!"
+document.doc_id = "My new document id!"
 ```
+
+Note: the ID can also be set through the `node_id` or `id_` property on a Document object, similar to a `TextNode` object.
 
 ### Advanced - Metadata Customization
 

--- a/docs/core_modules/data_modules/documents_and_nodes/usage_nodes.md
+++ b/docs/core_modules/data_modules/documents_and_nodes/usage_nodes.md
@@ -40,8 +40,7 @@ Each node has an `node_id` property that is automatically generated if not manua
 a variety of purposes; this includes being able to update nodes in storage, being able to define relationships
 between nodes (through `IndexNode`), and more.
 
-
-You can also get and set the `node_id` of any `TextNode` directly (and also `Document` objects as well)!
+You can also get and set the `node_id` of any `TextNode` directly.
 
 ```python
 print(node.node_id)

--- a/docs/core_modules/data_modules/documents_and_nodes/usage_nodes.md
+++ b/docs/core_modules/data_modules/documents_and_nodes/usage_nodes.md
@@ -33,3 +33,20 @@ The `RelatedNodeInfo` class can also store additional `metadata` if needed:
 ```python
 node2.relationships[NodeRelationship.PARENT] = RelatedNodeInfo(node_id=node1.node_id, metadata={"key": "val"})
 ```
+
+### Customizing the ID
+
+Each node has an `node_id` property that is automatically generated if not manually specified. This ID can be used for 
+a variety of purposes; this includes being able to update nodes in storage, being able to define relationships
+between nodes (through `IndexNode`), and more.
+
+
+You can also get and set the `node_id` of any `TextNode` directly (and also `Document` objects as well)!
+
+```python
+print(node.node_id)
+node.node_id = "My new node_id!"
+
+```
+
+

--- a/llama_index/schema.py
+++ b/llama_index/schema.py
@@ -160,6 +160,10 @@ class BaseNode(BaseComponent):
     def node_id(self) -> str:
         return self.id_
 
+    @node_id.setter
+    def node_id(self, value: str) -> None:
+        self.id_ = value
+
     @property
     def source_node(self) -> Optional[RelatedNodeInfo]:
         """Source object node.


### PR DESCRIPTION
slightly cleaner UX imo to set node_id as opposed to `id_`. Also this wasn't documented in the docs, so i updated both the Node and documents section 