### PR TITLE
fix: minor change on the documentation

### DIFF
--- a/docs/end_to_end_tutorials/usage_pattern.md
+++ b/docs/end_to_end_tutorials/usage_pattern.md
@@ -7,6 +7,7 @@ The general usage pattern of LlamaIndex is as follows:
 3. Construct Index (from Nodes or Documents)
 4. [Optional, Advanced] Building indices on top of other indices
 5. Query the index
+6. Parsing the response
 
 ## 1. Load in Documents
 
@@ -445,7 +446,7 @@ query_engine = RetrieverQueryEngine.from_args(
 response = query_engine.query("What did the author do growing up?")
 ```
 
-## 5. Parsing the response
+## 6. Parsing the response
 
 The object returned is a [`Response` object](/api_reference/response.rst).
 The object contains both the response text as well as the "sources" of the response:


### PR DESCRIPTION
# Description

On the [usage pattern page](https://gpt-index.readthedocs.io/en/latest/end_to_end_tutorials/usage_pattern.html) in the docs, Parsing the response starts with a 5 even though it is the 6th section. Also, it is not listed at the top table of contents.

Fixes #7512 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
