### PR TITLE
Added similarity_top_k argument to VectorIndexAutoRetriever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Added support for Azure Cognitive Search vector store (#7469)
 - Support delete in supabase (#6951)
 
+### Bug Fixes / Nits
+- Default to user-configurable top-k in `VectorIndexAutoRetriever` (#7556)
+
 ## [0.8.20] - 2023-09-04
 
 ### New Features

--- a/llama_index/indices/vector_store/retrievers/auto_retriever/auto_retriever.py
+++ b/llama_index/indices/vector_store/retrievers/auto_retriever/auto_retriever.py
@@ -42,9 +42,9 @@ class VectorIndexAutoRetriever(BaseRetriever):
         service_context: service context containing reference to LLMPredictor.
             Uses service context from index be default if None.
         similarity_top_k (int): number of top k results to return.
-        max_top_k (int): the maximum top_k allowed. The top_k set by LLM or similarity_top_k will be clamped
-            to this value.
-        
+        max_top_k (int):
+            the maximum top_k allowed. The top_k set by LLM or similarity_top_k will
+            be clamped to this value.
     """
 
     def __init__(
@@ -54,7 +54,7 @@ class VectorIndexAutoRetriever(BaseRetriever):
         prompt_template_str: Optional[str] = None,
         service_context: Optional[ServiceContext] = None,
         max_top_k: int = 10,
-        similarity_top_k: int = 2,
+        similarity_top_k: int = DEFAULT_SIMILARITY_TOP_K,
     ) -> None:
         self._index = index
         self._vector_store_info = vector_store_info
@@ -109,7 +109,9 @@ class VectorIndexAutoRetriever(BaseRetriever):
         if query_spec.top_k is None:
             similarity_top_k = self._similarity_top_k
         else:
-            similarity_top_k = min(query_spec.top_k, self._max_top_k, self._similarity_top_k)
+            similarity_top_k = min(
+                query_spec.top_k, self._max_top_k, self._similarity_top_k
+            )
 
         _logger.info(f"Using top_k: {similarity_top_k}")
 

--- a/llama_index/indices/vector_store/retrievers/auto_retriever/auto_retriever.py
+++ b/llama_index/indices/vector_store/retrievers/auto_retriever/auto_retriever.py
@@ -41,8 +41,10 @@ class VectorIndexAutoRetriever(BaseRetriever):
             Uses default template string if None.
         service_context: service context containing reference to LLMPredictor.
             Uses service context from index be default if None.
-        max_top_k: the maximum top_k allowed. The top_k set by LLM will be clamped
+        similarity_top_k (int): number of top k results to return.
+        max_top_k (int): the maximum top_k allowed. The top_k set by LLM or similarity_top_k will be clamped
             to this value.
+        
     """
 
     def __init__(
@@ -52,6 +54,7 @@ class VectorIndexAutoRetriever(BaseRetriever):
         prompt_template_str: Optional[str] = None,
         service_context: Optional[ServiceContext] = None,
         max_top_k: int = 10,
+        similarity_top_k: int = 2,
     ) -> None:
         self._index = index
         self._vector_store_info = vector_store_info
@@ -69,6 +72,7 @@ class VectorIndexAutoRetriever(BaseRetriever):
 
         # additional config
         self._max_top_k = max_top_k
+        self._similarity_top_k = similarity_top_k
 
     def _retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
         # prepare input
@@ -103,9 +107,9 @@ class VectorIndexAutoRetriever(BaseRetriever):
         _logger.info(f"Using filters: {filter_dict}")
 
         if query_spec.top_k is None:
-            similarity_top_k = DEFAULT_SIMILARITY_TOP_K
+            similarity_top_k = self._similarity_top_k
         else:
-            similarity_top_k = min(query_spec.top_k, self._max_top_k)
+            similarity_top_k = min(query_spec.top_k, self._max_top_k, self._similarity_top_k)
 
         _logger.info(f"Using top_k: {similarity_top_k}")
 


### PR DESCRIPTION
# Description

`VectorIndexAutoRetriever` was missing `similarity_top_k`.

It had `query_spec.top_k`  which can be set as shown below

````
nodes = retriever.retrieve(
    "Tell me about a celebrity from the United States, set top k to 10"
)
````
and `max_top_k` which sets the maximum number of top-k results that the retriever can return.

But if the `query_spec.top_k` is not given it was using default top_k of 2 irrespective of `max_top_k`.

Now, I have added a new argument called `similarity_top_k` which can be set in the VectorIndexAutoRetriever. And the overall top_k will be the min of `similarity_top_k` and `query_spec.top_k` with `max_top_k` limit. 

Fixes #7518

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense
