### PR TITLE
Fix refine streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes / Nits
 - Default to user-configurable top-k in `VectorIndexAutoRetriever` (#7556)
 - Catch validation errors for structured responses (#7523)
+- Fix streaming refine template (#7561)
 
 ## [0.8.20] - 2023-09-04
 

--- a/llama_index/llm_predictor/mock.py
+++ b/llama_index/llm_predictor/mock.py
@@ -62,7 +62,7 @@ def _mock_refine(max_tokens: int, prompt: BasePromptTemplate, prompt_args: Dict)
     else:
         existing_answer = prompt_args["existing_answer"]
     num_ctx_tokens = len(globals_helper.tokenizer(prompt_args["context_msg"]))
-    num_exist_tokens = len(globals_helper.tokenizer(existing_answer))
+    num_exist_tokens = len(globals_helper.tokenizer(existing_answer))  # type: ignore
     token_limit = min(num_ctx_tokens + num_exist_tokens, max_tokens)
     return " ".join(["answer"] * token_limit)
 
@@ -132,7 +132,8 @@ class MockLLMPredictor(BaseLLMPredictor):
             output = _mock_query_keyword_extract(prompt_args)
         elif prompt_str == PromptType.KNOWLEDGE_TRIPLET_EXTRACT:
             output = _mock_knowledge_graph_triplet_extract(
-                prompt_args, int(prompt.kwargs.get("max_knowledge_triplets", 2))
+                prompt_args,
+                int(prompt.kwargs.get("max_knowledge_triplets", 2)),  # type: ignore
             )
         elif prompt_str == PromptType.CUSTOM:
             # we don't know specific prompt type, return generic response

--- a/llama_index/llm_predictor/mock.py
+++ b/llama_index/llm_predictor/mock.py
@@ -62,7 +62,7 @@ def _mock_refine(max_tokens: int, prompt: BasePromptTemplate, prompt_args: Dict)
     else:
         existing_answer = prompt_args["existing_answer"]
     num_ctx_tokens = len(globals_helper.tokenizer(prompt_args["context_msg"]))
-    num_exist_tokens = len(globals_helper.tokenizer(existing_answer))  # type: ignore
+    num_exist_tokens = len(globals_helper.tokenizer(existing_answer))
     token_limit = min(num_ctx_tokens + num_exist_tokens, max_tokens)
     return " ".join(["answer"] * token_limit)
 
@@ -133,7 +133,7 @@ class MockLLMPredictor(BaseLLMPredictor):
         elif prompt_str == PromptType.KNOWLEDGE_TRIPLET_EXTRACT:
             output = _mock_knowledge_graph_triplet_extract(
                 prompt_args,
-                int(prompt.kwargs.get("max_knowledge_triplets", 2)),  # type: ignore
+                int(prompt.kwargs.get("max_knowledge_triplets", 2)),
             )
         elif prompt_str == PromptType.CUSTOM:
             # we don't know specific prompt type, return generic response

--- a/llama_index/prompts/base.py
+++ b/llama_index/prompts/base.py
@@ -3,7 +3,7 @@
 
 from abc import ABC, abstractmethod
 from copy import deepcopy
-from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from llama_index.bridge.pydantic import BaseModel
 
@@ -21,7 +21,7 @@ from llama_index.types import BaseOutputParser
 class BasePromptTemplate(BaseModel, ABC):
     metadata: Dict[str, Any]
     template_vars: List[str]
-    kwargs: Dict[str, Union[str, Generator]]
+    kwargs: Dict[str, str]
     output_parser: Optional[BaseOutputParser]
 
     class Config:
@@ -92,11 +92,6 @@ class PromptTemplate(BasePromptTemplate):
             **kwargs,
         }
 
-        # handle token generators
-        for kwarg in self.template_vars:
-            if isinstance(all_kwargs[kwarg], Generator):
-                all_kwargs[kwarg] = "".join(all_kwargs[kwarg])
-
         return self.template.format(**all_kwargs)
 
     def format_messages(
@@ -158,11 +153,6 @@ class ChatPromptTemplate(BasePromptTemplate):
             **self.kwargs,
             **kwargs,
         }
-
-        # handle token generators
-        for kwarg in self.template_vars:
-            if isinstance(all_kwargs[kwarg], Generator):
-                all_kwargs[kwarg] = "".join(all_kwargs[kwarg])
 
         messages = []
         for message_template in self.message_templates:

--- a/llama_index/prompts/base.py
+++ b/llama_index/prompts/base.py
@@ -73,8 +73,15 @@ class PromptTemplate(BasePromptTemplate):
 
     def partial_format(self, **kwargs: Any) -> "PromptTemplate":
         """Partially format the prompt."""
+        # NOTE: this is a hack to get around deepcopy failing on output parser
+        output_parser = self.output_parser
+        self.output_parser = None
+
         prompt = deepcopy(self)
         prompt.kwargs.update(kwargs)
+
+        # NOTE: put the output parser back
+        prompt.output_parser = output_parser
         return prompt
 
     def format(self, llm: Optional[LLM] = None, **kwargs: Any) -> str:

--- a/llama_index/response_synthesizers/refine.py
+++ b/llama_index/response_synthesizers/refine.py
@@ -240,14 +240,17 @@ class Refine(BaseSynthesizer):
                         f"Validation error on structured response: {e}", exc_info=True
                     )
             else:
+                # TODO: structured response not supported for streaming
+                if isinstance(response, Generator):
+                    response = "".join(response)
+
+                refine_template = self._refine_template.partial_format(
+                    query_str=query_str, existing_answer=response
+                )
+
                 response = self._service_context.llm_predictor.stream(
                     refine_template,
                     context_msg=cur_text_chunk,
-                )
-                query_satisfied = True
-            if query_satisfied:
-                refine_template = self._refine_template.partial_format(
-                    query_str=query_str, existing_answer=response
                 )
 
         return response


### PR DESCRIPTION
# Description

When generators are passed to a prompt, pydantic will complain. This happens right now if you set top k to 4 and streaming=True in a query engine.

This solution delays converting the generator to a string until the template is formatted.

Fixes https://github.com/jerryjliu/llama_index/issues/7551

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested in a notebook
- [x] I stared at the code and made sure it makes sense
