### PR TITLE
inherit prompt helper from global context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes / Nits
 - Fixed small `_index` bug in `ElasticSearchReader` (#7570)
+- Fixed bug with prompt helper settings in global service contexts (#7576)
 
 ## [0.8.21] - 2023-09-06
 

--- a/llama_index/indices/service_context.py
+++ b/llama_index/indices/service_context.py
@@ -239,11 +239,13 @@ class ServiceContext:
         embed_model = resolve_embed_model(embed_model)
         embed_model.callback_manager = callback_manager
 
-        prompt_helper = prompt_helper or _get_default_prompt_helper(
-            llm_metadata=llm_predictor.metadata,
-            context_window=context_window,
-            num_output=num_output,
-        )
+        prompt_helper = prompt_helper or service_context.prompt_helper
+        if context_window is not None or num_output is not None:
+            prompt_helper = _get_default_prompt_helper(
+                llm_metadata=llm_predictor.metadata,
+                context_window=context_window,
+                num_output=num_output,
+            )
 
         node_parser = node_parser or service_context.node_parser
         if chunk_size is not None or chunk_overlap is not None:


### PR DESCRIPTION
# Description

Any changes to the prompt helper were not being respected in the global service context

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense
