### PR TITLE
Clean up vector store interface to use `BaseNode` instead of `NodeWithEmbedding`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 - Fixed small `_index` bug in `ElasticSearchReader` (#7570)
 - Fixed bug with prompt helper settings in global service contexts (#7576)
 
+### Breaking/Deprecated API Changes
+- Clean up vector store interface to use `BaseNode` instead of `NodeWithEmbedding`
+  - For majority of users, this is a no-op change
+  - For users directly operating with the `VectorStore` abstraction and manually constructing `NodeWithEmbedding` objects, this is a minor breaking change. Use `TextNode` with `embedding` set directly, instead of `NodeWithEmbedding`.
+
 ## [0.8.21] - 2023-09-06
 
 ### New Features

--- a/benchmarks/vector_stores/bench_simple_vector_store.py
+++ b/benchmarks/vector_stores/bench_simple_vector_store.py
@@ -10,7 +10,7 @@ from llama_index.vector_stores.types import (
 from llama_index.vector_stores.simple import SimpleVectorStore
 
 
-def generate_vectors(
+def generate_nodes(
     num_vectors: int = 100, embedding_length: int = 1536
 ) -> List[TextNode]:
     random.seed(42)  # Make this reproducible
@@ -28,12 +28,12 @@ def bench_simple_vector_store(
     """Benchmark simple vector store."""
     print("Benchmarking SimpleVectorStore\n---------------------------")
     for num_vector in num_vectors:
-        vectors = generate_vectors(num_vectors=num_vector)
+        nodes = generate_nodes(num_vectors=num_vector)
 
-        vector_store = SimpleVectorStore(vectors=vectors)
+        vector_store = SimpleVectorStore()
 
         time1 = time.time()
-        vector_store.add(embedding_results=vectors)
+        vector_store.add(nodes=nodes)
         time2 = time.time()
         print(f"Adding {num_vector} vectors took {time2 - time1} seconds")
 
@@ -44,7 +44,7 @@ def bench_simple_vector_store(
         ]:
             time1 = time.time()
             query = VectorStoreQuery(
-                query_embedding=vectors[0].embedding, similarity_top_k=10, mode=mode
+                query_embedding=nodes[0].get_embedding(), similarity_top_k=10, mode=mode
             )
             vector_store.query(query=query)
             time2 = time.time()

--- a/benchmarks/vector_stores/bench_simple_vector_store.py
+++ b/benchmarks/vector_stores/bench_simple_vector_store.py
@@ -4,7 +4,6 @@ from typing import List
 from llama_index.schema import TextNode
 
 from llama_index.vector_stores.types import (
-    NodeWithEmbedding,
     VectorStoreQuery,
     VectorStoreQueryMode,
 )
@@ -13,11 +12,10 @@ from llama_index.vector_stores.simple import SimpleVectorStore
 
 def generate_vectors(
     num_vectors: int = 100, embedding_length: int = 1536
-) -> List[NodeWithEmbedding]:
+) -> List[TextNode]:
     random.seed(42)  # Make this reproducible
     return [
-        NodeWithEmbedding(
-            node=TextNode(),
+        TextNode(
             embedding=[random.uniform(0, 1) for _ in range(embedding_length)],
         )
         for _ in range(num_vectors)

--- a/llama_index/indices/vector_store/base.py
+++ b/llama_index/indices/vector_store/base.py
@@ -14,7 +14,7 @@ from llama_index.indices.service_context import ServiceContext
 from llama_index.schema import BaseNode, ImageNode, IndexNode, MetadataMode
 from llama_index.storage.docstore.types import RefDocInfo
 from llama_index.storage.storage_context import StorageContext
-from llama_index.vector_stores.types import NodeWithEmbedding, VectorStore
+from llama_index.vector_stores.types import VectorStore
 
 
 class VectorStoreIndex(BaseIndex[IndexDict]):
@@ -87,7 +87,7 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
         self,
         nodes: Sequence[BaseNode],
         show_progress: bool = False,
-    ) -> List[NodeWithEmbedding]:
+    ) -> List[BaseNode]:
         """Get tuples of id, node, and embedding.
 
         Allows us to store these nodes in a vector store.
@@ -115,7 +115,8 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
         results = []
         for node in nodes:
             embedding = id_to_embed_map[node.node_id]
-            result = NodeWithEmbedding(node=node, embedding=embedding)
+            result = node.copy()
+            result.embedding = embedding
             results.append(result)
         return results
 
@@ -123,7 +124,7 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
         self,
         nodes: Sequence[BaseNode],
         show_progress: bool = False,
-    ) -> List[NodeWithEmbedding]:
+    ) -> List[BaseNode]:
         """Asynchronously get tuples of id, node, and embedding.
 
         Allows us to store these nodes in a vector store.
@@ -155,7 +156,8 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
         results = []
         for node in nodes:
             embedding = id_to_embed_map[node.node_id]
-            result = NodeWithEmbedding(node=node, embedding=embedding)
+            result = node.copy()
+            result.embedding = embedding
             results.append(result)
         return results
 
@@ -178,15 +180,23 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
         # index struct and document store
         if not self._vector_store.stores_text or self._store_nodes_override:
             for result, new_id in zip(embedding_results, new_ids):
-                index_struct.add_node(result.node, text_id=new_id)
-                self._docstore.add_documents([result.node], allow_update=True)
+                # NOTE: remove embedding from node to avoid duplication
+                node = result.copy()
+                node.embedding = None
+
+                index_struct.add_node(node, text_id=new_id)
+                self._docstore.add_documents([node], allow_update=True)
         else:
             # NOTE: if the vector store keeps text,
             # we only need to add image and index nodes
             for result, new_id in zip(embedding_results, new_ids):
                 if isinstance(result.node, (ImageNode, IndexNode)):
-                    index_struct.add_node(result.node, text_id=new_id)
-                    self._docstore.add_documents([result.node], allow_update=True)
+                    # NOTE: remove embedding from node to avoid duplication
+                    node = result.copy()
+                    node.embedding = None
+
+                    index_struct.add_node(node, text_id=new_id)
+                    self._docstore.add_documents([node], allow_update=True)
 
     def _add_nodes_to_index(
         self,
@@ -205,15 +215,23 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
             # NOTE: if the vector store doesn't store text,
             # we need to add the nodes to the index struct and document store
             for result, new_id in zip(embedding_results, new_ids):
-                index_struct.add_node(result.node, text_id=new_id)
-                self._docstore.add_documents([result.node], allow_update=True)
+                # NOTE: remove embedding from node to avoid duplication
+                node = result.copy()
+                node.embedding = None
+
+                index_struct.add_node(node, text_id=new_id)
+                self._docstore.add_documents([node], allow_update=True)
         else:
             # NOTE: if the vector store keeps text,
             # we only need to add image and index nodes
             for result, new_id in zip(embedding_results, new_ids):
                 if isinstance(result.node, (ImageNode, IndexNode)):
-                    index_struct.add_node(result.node, text_id=new_id)
-                    self._docstore.add_documents([result.node], allow_update=True)
+                    # NOTE: remove embedding from node to avoid duplication
+                    node = result.copy()
+                    node.embedding = None
+
+                    index_struct.add_node(node, text_id=new_id)
+                    self._docstore.add_documents([node], allow_update=True)
 
     def _build_index_from_nodes(self, nodes: Sequence[BaseNode]) -> IndexDict:
         """Build index from nodes."""

--- a/llama_index/indices/vector_store/base.py
+++ b/llama_index/indices/vector_store/base.py
@@ -220,7 +220,9 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
                 node_without_embedding.embedding = None
 
                 index_struct.add_node(node_without_embedding, text_id=new_id)
-                self._docstore.add_documents([node_without_embedding], allow_update=True)
+                self._docstore.add_documents(
+                    [node_without_embedding], allow_update=True
+                )
         else:
             # NOTE: if the vector store keeps text,
             # we only need to add image and index nodes
@@ -231,7 +233,9 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
                     node_without_embedding.embedding = None
 
                     index_struct.add_node(node_without_embedding, text_id=new_id)
-                    self._docstore.add_documents([node_without_embedding], allow_update=True)
+                    self._docstore.add_documents(
+                        [node_without_embedding], allow_update=True
+                    )
 
     def _build_index_from_nodes(self, nodes: Sequence[BaseNode]) -> IndexDict:
         """Build index from nodes."""

--- a/llama_index/vector_stores/awadb.py
+++ b/llama_index/vector_stores/awadb.py
@@ -5,8 +5,7 @@ An index that is built on top of an existing vector store.
 """
 import logging
 import uuid
-
-from typing import Any, List, Set, Optional
+from typing import Any, List, Optional, Set
 
 from llama_index.schema import BaseNode, MetadataMode, TextNode
 from llama_index.vector_stores.types import (
@@ -84,12 +83,12 @@ class AwaDBVectorStore(VectorStore):
 
     def add(
         self,
-        embedding_results: List[BaseNode],
+        nodes: List[BaseNode],
     ) -> List[str]:
-        """Add embedding results to AwaDB.
+        """Add nodes to AwaDB.
 
         Args:
-            embedding_results: List[BaseNode]: list of nodes with embeddings
+            nodes: List[BaseNode]: list of nodes with embeddings
 
         Returns:
             Added node ids
@@ -101,15 +100,15 @@ class AwaDBVectorStore(VectorStore):
         metadatas = []
         ids = []
         texts = []
-        for result in embedding_results:
-            embeddings.append(result.get_embedding())
+        for node in nodes:
+            embeddings.append(node.get_embedding())
             metadatas.append(
                 node_to_metadata_dict(
-                    result.node, remove_text=True, flat_metadata=self.flat_metadata
+                    node, remove_text=True, flat_metadata=self.flat_metadata
                 )
             )
-            ids.append(result.id)
-            texts.append(result.node.get_content(metadata_mode=MetadataMode.NONE) or "")
+            ids.append(node.node_id)
+            texts.append(node.get_content(metadata_mode=MetadataMode.NONE) or "")
 
         self.awadb_client.AddTexts(
             "embedding_text",

--- a/llama_index/vector_stores/awadb.py
+++ b/llama_index/vector_stores/awadb.py
@@ -8,9 +8,8 @@ import uuid
 
 from typing import Any, List, Set, Optional
 
-from llama_index.schema import MetadataMode, TextNode
+from llama_index.schema import BaseNode, MetadataMode, TextNode
 from llama_index.vector_stores.types import (
-    NodeWithEmbedding,
     VectorStore,
     VectorStoreQuery,
     VectorStoreQueryResult,
@@ -85,12 +84,12 @@ class AwaDBVectorStore(VectorStore):
 
     def add(
         self,
-        embedding_results: List[NodeWithEmbedding],
+        embedding_results: List[BaseNode],
     ) -> List[str]:
         """Add embedding results to AwaDB.
 
         Args:
-            embedding_results: List[NodeWithEmbedding]: list of embedding results
+            embedding_results: List[BaseNode]: list of nodes with embeddings
 
         Returns:
             Added node ids
@@ -103,7 +102,7 @@ class AwaDBVectorStore(VectorStore):
         ids = []
         texts = []
         for result in embedding_results:
-            embeddings.append(result.embedding)
+            embeddings.append(result.get_embedding())
             metadatas.append(
                 node_to_metadata_dict(
                     result.node, remove_text=True, flat_metadata=self.flat_metadata

--- a/llama_index/vector_stores/bagel.py
+++ b/llama_index/vector_stores/bagel.py
@@ -57,9 +57,7 @@ class BagelVectorStore(VectorStore):
 
         self._collection = collection
 
-    def add(
-        self, nodes: List[BaseNode], **kwargs: Any
-    ) -> List[str]:
+    def add(self, nodes: List[BaseNode], **kwargs: Any) -> List[str]:
         """
         Add a list of nodes with embeddings to the vector store.
 
@@ -88,10 +86,7 @@ class BagelVectorStore(VectorStore):
                     flat_metadata=self.flat_metadata,
                 )
             )
-            documents.append(
-                node.get_content(metadata_mode=MetadataMode.NONE)
-                or ""
-            )
+            documents.append(node.get_content(metadata_mode=MetadataMode.NONE) or "")
 
         self._collection.add(
             ids=ids, embeddings=embeddings, metadatas=metadatas, documents=documents

--- a/llama_index/vector_stores/bagel.py
+++ b/llama_index/vector_stores/bagel.py
@@ -2,10 +2,9 @@ import logging
 import math
 from typing import Any, List
 
-from llama_index.schema import MetadataMode, TextNode
+from llama_index.schema import BaseNode, MetadataMode, TextNode
 from llama_index.vector_stores.types import (
     MetadataFilters,
-    NodeWithEmbedding,
     VectorStore,
     VectorStoreQuery,
     VectorStoreQueryResult,
@@ -59,7 +58,7 @@ class BagelVectorStore(VectorStore):
         self._collection = collection
 
     def add(
-        self, embedding_results: List[NodeWithEmbedding], **kwargs: Any
+        self, nodes: List[BaseNode], **kwargs: Any
     ) -> List[str]:
         """
         Add a list of nodes with embeddings to the vector store.
@@ -79,18 +78,18 @@ class BagelVectorStore(VectorStore):
         metadatas = []
         documents = []
 
-        for node_with_embedding in embedding_results:
-            ids.append(node_with_embedding.id)
-            embeddings.append(node_with_embedding.embedding)
+        for node in nodes:
+            ids.append(node.node_id)
+            embeddings.append(node.get_embedding())
             metadatas.append(
                 node_to_metadata_dict(
-                    node_with_embedding.node,
+                    node,
                     remove_text=True,
                     flat_metadata=self.flat_metadata,
                 )
             )
             documents.append(
-                node_with_embedding.node.get_content(metadata_mode=MetadataMode.NONE)
+                node.get_content(metadata_mode=MetadataMode.NONE)
                 or ""
             )
 

--- a/llama_index/vector_stores/bagel.py
+++ b/llama_index/vector_stores/bagel.py
@@ -62,7 +62,7 @@ class BagelVectorStore(VectorStore):
         Add a list of nodes with embeddings to the vector store.
 
         Args:
-            embedding_results: List of nodes with embeddings.
+            nodes: List of nodes with embeddings.
             kwargs: Additional arguments.
 
         Returns:

--- a/llama_index/vector_stores/cassandra.py
+++ b/llama_index/vector_stores/cassandra.py
@@ -108,7 +108,7 @@ class CassandraVectorStore(VectorStore):
         self,
         nodes: List[BaseNode],
     ) -> List[str]:
-        """Add embedding results to index.
+        """Add nodes to index.
 
         Args
             nodes: List[BaseNode]: list of node with embeddings

--- a/llama_index/vector_stores/cassandra.py
+++ b/llama_index/vector_stores/cassandra.py
@@ -125,9 +125,7 @@ class CassandraVectorStore(VectorStore):
                 flat_metadata=self.flat_metadata,
             )
             node_ids.append(node.node_id)
-            node_contents.append(
-                node.get_content(metadata_mode=MetadataMode.NONE)
-            )
+            node_contents.append(node.get_content(metadata_mode=MetadataMode.NONE))
             node_metadatas.append(metadata)
             node_embeddings.append(node.get_embedding())
 

--- a/llama_index/vector_stores/cassandra.py
+++ b/llama_index/vector_stores/cassandra.py
@@ -9,7 +9,7 @@ import logging
 from typing import Any, cast, Dict, Iterable, List, Optional, TypeVar
 
 
-from llama_index.schema import MetadataMode
+from llama_index.schema import BaseNode, MetadataMode
 from llama_index.vector_stores.utils import (
     metadata_dict_to_node,
     node_to_metadata_dict,
@@ -21,7 +21,6 @@ from llama_index.indices.query.embedding_utils import (
 from llama_index.vector_stores.types import (
     MetadataFilters,
     ExactMatchFilter,
-    NodeWithEmbedding,
     VectorStore,
     VectorStoreQuery,
     VectorStoreQueryMode,
@@ -107,30 +106,30 @@ class CassandraVectorStore(VectorStore):
 
     def add(
         self,
-        embedding_results: List[NodeWithEmbedding],
+        nodes: List[BaseNode],
     ) -> List[str]:
         """Add embedding results to index.
 
         Args
-            embedding_results: List[NodeWithEmbedding]: list of embedding results
+            nodes: List[BaseNode]: list of node with embeddings
 
         """
         node_ids = []
         node_contents = []
         node_metadatas = []
         node_embeddings = []
-        for result in embedding_results:
+        for node in nodes:
             metadata = node_to_metadata_dict(
-                result.node,
+                node,
                 remove_text=True,
                 flat_metadata=self.flat_metadata,
             )
-            node_ids.append(result.id)
+            node_ids.append(node.node_id)
             node_contents.append(
-                result.node.get_content(metadata_mode=MetadataMode.NONE)
+                node.get_content(metadata_mode=MetadataMode.NONE)
             )
             node_metadatas.append(metadata)
-            node_embeddings.append(result.embedding)
+            node_embeddings.append(node.get_embedding())
 
         _logger.debug(f"Adding {len(node_ids)} rows to table")
         # Concurrent batching of inserts:

--- a/llama_index/vector_stores/chatgpt_plugin.py
+++ b/llama_index/vector_stores/chatgpt_plugin.py
@@ -6,9 +6,8 @@ from typing import Any, Dict, List, Optional
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
-from llama_index.schema import MetadataMode, NodeRelationship, RelatedNodeInfo, TextNode
+from llama_index.schema import BaseNode, MetadataMode, NodeRelationship, RelatedNodeInfo, TextNode
 from llama_index.vector_stores.types import (
-    NodeWithEmbedding,
     VectorStore,
     VectorStoreQuery,
     VectorStoreQueryResult,
@@ -16,23 +15,23 @@ from llama_index.vector_stores.types import (
 from llama_index.utils import get_tqdm_iterable
 
 
-def convert_docs_to_json(embedding_results: List[NodeWithEmbedding]) -> List[Dict]:
+def convert_docs_to_json(nodes: List[BaseNode]) -> List[Dict]:
     """Convert docs to JSON."""
     docs = []
-    for embedding_result in embedding_results:
+    for node in nodes:
         # TODO: add information for other fields as well
         # fields taken from
         # https://rb.gy/nmac9u
         doc_dict = {
-            "id": embedding_result.id,
-            "text": embedding_result.node.get_content(metadata_mode=MetadataMode.NONE),
+            "id": node.node_id,
+            "text": node.get_content(metadata_mode=MetadataMode.NONE),
             # NOTE: this is the doc_id to reference document
-            "source_id": embedding_result.ref_doc_id,
+            "source_id": node.ref_doc_id,
             # "url": "...",
             # "created_at": ...,
             # "author": "..."",
         }
-        metadata = embedding_result.node.metadata
+        metadata = node.metadata
         if metadata is not None:
             if "source" in metadata:
                 doc_dict["source"] = metadata["source"]
@@ -88,12 +87,12 @@ class ChatGPTRetrievalPluginClient(VectorStore):
 
     def add(
         self,
-        embedding_results: List[NodeWithEmbedding],
+        nodes: List[BaseNode],
     ) -> List[str]:
         """Add embedding_results to index."""
         headers = {"Authorization": f"Bearer {self._bearer_token}"}
 
-        docs_to_upload = convert_docs_to_json(embedding_results)
+        docs_to_upload = convert_docs_to_json(nodes)
         iterable_docs = get_tqdm_iterable(
             range(0, len(docs_to_upload), self._batch_size),
             show_progress=True,
@@ -107,7 +106,7 @@ class ChatGPTRetrievalPluginClient(VectorStore):
                 json={"documents": docs_to_upload[i:i_end]},
             )
 
-        return [result.id for result in embedding_results]
+        return [result.node_id for result in nodes]
 
     def delete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:
         """

--- a/llama_index/vector_stores/chatgpt_plugin.py
+++ b/llama_index/vector_stores/chatgpt_plugin.py
@@ -6,7 +6,13 @@ from typing import Any, Dict, List, Optional
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
-from llama_index.schema import BaseNode, MetadataMode, NodeRelationship, RelatedNodeInfo, TextNode
+from llama_index.schema import (
+    BaseNode,
+    MetadataMode,
+    NodeRelationship,
+    RelatedNodeInfo,
+    TextNode,
+)
 from llama_index.vector_stores.types import (
     VectorStore,
     VectorStoreQuery,

--- a/llama_index/vector_stores/chatgpt_plugin.py
+++ b/llama_index/vector_stores/chatgpt_plugin.py
@@ -95,7 +95,7 @@ class ChatGPTRetrievalPluginClient(VectorStore):
         self,
         nodes: List[BaseNode],
     ) -> List[str]:
-        """Add embedding_results to index."""
+        """Add nodes to index."""
         headers = {"Authorization": f"Bearer {self._bearer_token}"}
 
         docs_to_upload = convert_docs_to_json(nodes)

--- a/llama_index/vector_stores/chroma.py
+++ b/llama_index/vector_stores/chroma.py
@@ -120,7 +120,7 @@ class ChromaVectorStore(BasePydanticVectorStore):
         return "ChromaVectorStore"
 
     def add(self, nodes: List[BaseNode]) -> List[str]:
-        """Add embedding results to index.
+        """Add nodes to index.
 
         Args
             nodes: List[BaseNode]: list of nodes with embeddings

--- a/llama_index/vector_stores/chroma.py
+++ b/llama_index/vector_stores/chroma.py
@@ -141,9 +141,7 @@ class ChromaVectorStore(BasePydanticVectorStore):
                 )
             )
             ids.append(node.node_id)
-            documents.append(
-                node.get_content(metadata_mode=MetadataMode.NONE)
-            )
+            documents.append(node.get_content(metadata_mode=MetadataMode.NONE))
 
         self._collection.add(
             embeddings=embeddings,

--- a/llama_index/vector_stores/cogsearch.py
+++ b/llama_index/vector_stores/cogsearch.py
@@ -4,11 +4,10 @@ from typing import Any, List, cast, Dict, Callable, Optional, Tuple, Union
 import enum
 from enum import auto
 
-from llama_index.schema import MetadataMode, TextNode
+from llama_index.schema import BaseNode, MetadataMode, TextNode
 from llama_index.vector_stores.types import (
     MetadataFilters,
     ExactMatchFilter,
-    NodeWithEmbedding,
     VectorStore,
     VectorStoreQuery,
     VectorStoreQueryResult,
@@ -399,12 +398,12 @@ class CognitiveSearchVectorStore(VectorStore):
 
     def add(
         self,
-        embedding_results: List[NodeWithEmbedding],
+        nodes: List[BaseNode],
     ) -> List[str]:
         """Add embedding results to index associated with the configured search client.
 
         Args
-            embedding_results: List[NodeWithEmbedding]: list of embedding results
+            nodes: List[BaseNode]: nodes with embeddings
 
         """
 
@@ -414,18 +413,18 @@ class CognitiveSearchVectorStore(VectorStore):
         documents = []
         ids = []
 
-        for embedding in embedding_results:
-            logger.debug(f"Processing embedding: {embedding.id}")
-            ids.append(embedding.id)
+        for node in nodes:
+            logger.debug(f"Processing embedding: {node.node_id}")
+            ids.append(node.node_id)
 
-            index_document = self._create_index_document(embedding)
+            index_document = self._create_index_document(node)
 
             documents.append(index_document)
 
             if len(documents) >= 10:
                 logger.info(
                     f"Uploading batch of size {len(documents)}, "
-                    f"current progress {len(ids)} of {len(embedding_results)}"
+                    f"current progress {len(ids)} of {len(nodes)}"
                 )
                 self._search_client.merge_or_upload_documents(documents)
                 documents = []
@@ -434,23 +433,23 @@ class CognitiveSearchVectorStore(VectorStore):
         if len(documents) > 0:
             logger.info(
                 f"Uploading remaining batch of size {len(documents)}, "
-                f"current progress {len(ids)} of {len(embedding_results)}"
+                f"current progress {len(ids)} of {len(nodes)}"
             )
             self._search_client.merge_or_upload_documents(documents)
             documents = []
 
         return ids
 
-    def _create_index_document(self, embedding: NodeWithEmbedding) -> Dict[str, Any]:
+    def _create_index_document(self, node: BaseNode) -> Dict[str, Any]:
         """Create Cognitive Search index document from embedding result"""
         doc: Dict[str, Any] = {}
-        doc["id"] = embedding.id
-        doc["chunk"] = embedding.node.get_content(metadata_mode=MetadataMode.NONE) or ""
-        doc["embedding"] = embedding.embedding
-        doc["doc_id"] = embedding.ref_doc_id
+        doc["id"] = node.node_id
+        doc["chunk"] = node.get_content(metadata_mode=MetadataMode.NONE) or ""
+        doc["embedding"] = node.get_embedding()
+        doc["doc_id"] = node.ref_doc_id
 
         node_metadata = node_to_metadata_dict(
-            embedding.node,
+            node,
             remove_text=True,
             flat_metadata=self.flat_metadata,
         )

--- a/llama_index/vector_stores/cogsearch.py
+++ b/llama_index/vector_stores/cogsearch.py
@@ -400,7 +400,7 @@ class CognitiveSearchVectorStore(VectorStore):
         self,
         nodes: List[BaseNode],
     ) -> List[str]:
-        """Add embedding results to index associated with the configured search client.
+        """Add nodes to index associated with the configured search client.
 
         Args
             nodes: List[BaseNode]: nodes with embeddings

--- a/llama_index/vector_stores/deeplake.py
+++ b/llama_index/vector_stores/deeplake.py
@@ -6,9 +6,8 @@ An index that is built within DeepLake.
 import logging
 from typing import Any, List, Optional, cast
 
-from llama_index.schema import MetadataMode
+from llama_index.schema import BaseNode, MetadataMode
 from llama_index.vector_stores.types import (
-    NodeWithEmbedding,
     VectorStoreQuery,
     VectorStoreQueryResult,
 )
@@ -124,11 +123,11 @@ class DeepLakeVectorStore(VectorStoreBase):
         """
         return self.vectorstore.dataset
 
-    def add(self, embedding_results: List[NodeWithEmbedding]) -> List[str]:
+    def add(self, nodes: List[BaseNode]) -> List[str]:
         """Add the embeddings and their nodes into DeepLake.
 
         Args:
-            embedding_results (List[NodeWithEmbedding]): The embeddings and their data
+            nodes (List[BaseNode]): List of nodes with embeddings
                 to insert.
 
         Returns:
@@ -139,15 +138,15 @@ class DeepLakeVectorStore(VectorStoreBase):
         id_ = []
         text = []
 
-        for result in embedding_results:
-            embedding.append(result.embedding)
+        for node in nodes:
+            embedding.append(node.get_embedding())
             metadata.append(
                 node_to_metadata_dict(
-                    result.node, remove_text=False, flat_metadata=self.flat_metadata
+                    node, remove_text=False, flat_metadata=self.flat_metadata
                 )
             )
-            id_.append(result.id)
-            text.append(result.node.get_content(metadata_mode=MetadataMode.NONE))
+            id_.append(node.node_id)
+            text.append(node.get_content(metadata_mode=MetadataMode.NONE))
 
         kwargs = {
             "embedding": embedding,

--- a/llama_index/vector_stores/docarray/base.py
+++ b/llama_index/vector_stores/docarray/base.py
@@ -118,9 +118,7 @@ class DocArrayVectorStore(VectorStore, ABC):
         docs = DocList[self._schema](  # type: ignore[name-defined]
             self._schema(
                 id=node.node_id,
-                metadata=node_to_metadata_dict(
-                    node, flat_metadata=self.flat_metadata
-                ),
+                metadata=node_to_metadata_dict(node, flat_metadata=self.flat_metadata),
                 text=node.get_content(metadata_mode=MetadataMode.NONE),
                 embedding=node.get_embedding(),
             )

--- a/llama_index/vector_stores/dynamodb.py
+++ b/llama_index/vector_stores/dynamodb.py
@@ -73,7 +73,7 @@ class DynamoDBVectorStore(VectorStore):
         return item[self._key_value]
 
     def add(self, nodes: List[BaseNode]) -> List[str]:
-        """Add embedding_results to index."""
+        """Add nodes to index."""
         response = []
         for node in nodes:
             self._kvstore.put(

--- a/llama_index/vector_stores/dynamodb.py
+++ b/llama_index/vector_stores/dynamodb.py
@@ -1,6 +1,7 @@
 """DynamoDB vector store index."""
 from __future__ import annotations
 from typing import Optional, List, Any, cast, Dict
+from llama_index.schema import BaseNode
 
 from llama_index.storage.kvstore.dynamodb_kvstore import DynamoDBKVStore
 
@@ -10,7 +11,6 @@ from llama_index.indices.query.embedding_utils import (
 )
 
 from llama_index.vector_stores.types import (
-    NodeWithEmbedding,
     VectorStore,
     VectorStoreQuery,
     VectorStoreQueryMode,
@@ -72,21 +72,21 @@ class DynamoDBVectorStore(VectorStore):
         item = cast(Dict[str, List[float]], item)
         return item[self._key_value]
 
-    def add(self, embedding_results: List[NodeWithEmbedding]) -> List[str]:
+    def add(self, nodes: List[BaseNode]) -> List[str]:
         """Add embedding_results to index."""
         response = []
-        for result in embedding_results:
+        for node in nodes:
             self._kvstore.put(
-                key=result.id,
-                val={self._key_value: result.embedding},
+                key=node.node_id,
+                val={self._key_value: node.get_embedding()},
                 collection=self._collection_embedding,
             )
             self._kvstore.put(
-                key=result.id,
-                val={self._key_value: result.ref_doc_id},
+                key=node.node_id,
+                val={self._key_value: node.ref_doc_id},
                 collection=self._collection_text_id_to_doc_id,
             )
-            response.append(result.id)
+            response.append(node.node_id)
         return response
 
     def delete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:

--- a/llama_index/vector_stores/elasticsearch.py
+++ b/llama_index/vector_stores/elasticsearch.py
@@ -290,7 +290,7 @@ class ElasticsearchStore(VectorStore):
         metadatas: List[dict] = []
         ids: List[str] = []
         for node in nodes:
-            ids.append(node.id)
+            ids.append(node.node_id)
             embeddings.append(node.get_embedding())
             texts.append(node.get_content(metadata_mode=MetadataMode.NONE))
             metadatas.append(node_to_metadata_dict(node, remove_text=True))

--- a/llama_index/vector_stores/epsilla.py
+++ b/llama_index/vector_stores/epsilla.py
@@ -2,10 +2,9 @@
 import logging
 from typing import Any, List, Optional
 
-from llama_index.schema import MetadataMode, TextNode
+from llama_index.schema import BaseNode, MetadataMode, TextNode
 from llama_index.vector_stores.types import (
     DEFAULT_PERSIST_DIR,
-    NodeWithEmbedding,
     VectorStore,
     VectorStoreQuery,
     VectorStoreQueryMode,
@@ -148,37 +147,37 @@ class EpsillaVectorStore(VectorStore):
 
     def add(
         self,
-        embedding_results: List[NodeWithEmbedding],
+        nodes: List[BaseNode],
     ) -> List[str]:
         """
-        Add embedding results to Epsilla vector store.
+        Add nodes to Epsilla vector store.
 
         Args
-            embedding_results: List[NodeWithEmbedding]: list of embedding results.
+            nodes: List[BaseNode]: list of nodes with embeddings
 
         Returns:
             List[str]: List of ids inserted.
         """
         # If the collection doesnt exist yet, create the collection
-        if not self._collection_created and len(embedding_results) > 0:
-            dimension = len(embedding_results[0].embedding)
+        if not self._collection_created and len(nodes) > 0:
+            dimension = len(nodes[0].embedding)
             self._create_collection(dimension)
 
-        elif len(embedding_results) == 0:
+        elif len(nodes) == 0:
             return []
 
         ids = []
         records = []
-        for result in embedding_results:
-            ids.append(result.id)
-            text = result.node.get_content(metadata_mode=MetadataMode.NONE)
-            metadata_dict = node_to_metadata_dict(result.node, remove_text=True)
+        for node in nodes:
+            ids.append(node.node_id)
+            text = node.get_content(metadata_mode=MetadataMode.NONE)
+            metadata_dict = node_to_metadata_dict(node, remove_text=True)
             metadata = metadata_dict["_node_content"]
             record = {
-                "id": result.id,
-                DEFAULT_DOC_ID_KEY: result.ref_doc_id,
+                "id": node.node_id,
+                DEFAULT_DOC_ID_KEY: node.ref_doc_id,
                 DEFAULT_TEXT_KEY: text,
-                DEFAULT_EMBEDDING_KEY: result.embedding,
+                DEFAULT_EMBEDDING_KEY: node.get_embedding(),
                 "metadata": metadata,
             }
             records.append(record)

--- a/llama_index/vector_stores/epsilla.py
+++ b/llama_index/vector_stores/epsilla.py
@@ -160,7 +160,7 @@ class EpsillaVectorStore(VectorStore):
         """
         # If the collection doesnt exist yet, create the collection
         if not self._collection_created and len(nodes) > 0:
-            dimension = len(nodes[0].embedding)
+            dimension = len(nodes[0].get_embedding())
             self._create_collection(dimension)
 
         elif len(nodes) == 0:

--- a/llama_index/vector_stores/faiss.py
+++ b/llama_index/vector_stores/faiss.py
@@ -11,11 +11,11 @@ from fsspec.implementations.local import LocalFileSystem
 from typing import Any, List, cast, Optional
 
 import numpy as np
+from llama_index.schema import BaseNode
 
 from llama_index.vector_stores.types import (
     DEFAULT_PERSIST_DIR,
     DEFAULT_PERSIST_FNAME,
-    NodeWithEmbedding,
     VectorStore,
     VectorStoreQuery,
     VectorStoreQueryResult,
@@ -90,19 +90,19 @@ class FaissVectorStore(VectorStore):
 
     def add(
         self,
-        embedding_results: List[NodeWithEmbedding],
+        nodes: List[BaseNode],
     ) -> List[str]:
-        """Add embedding results to index.
+        """Add nodes to index.
 
         NOTE: in the Faiss vector store, we do not store text in Faiss.
 
         Args
-            embedding_results: List[NodeWithEmbedding]: list of embedding results
+            nodes: List[BaseNode]: list of nodes with embeddings
 
         """
         new_ids = []
-        for result in embedding_results:
-            text_embedding = result.embedding
+        for node in nodes:
+            text_embedding = node.get_embedding()
             text_embedding_np = np.array(text_embedding, dtype="float32")[np.newaxis, :]
             new_id = str(self._faiss_index.ntotal)
             self._faiss_index.add(text_embedding_np)

--- a/llama_index/vector_stores/lancedb.py
+++ b/llama_index/vector_stores/lancedb.py
@@ -1,7 +1,13 @@
 """LanceDB vector store."""
 from typing import Any, List, Optional
 
-from llama_index.schema import BaseNode, MetadataMode, NodeRelationship, RelatedNodeInfo, TextNode
+from llama_index.schema import (
+    BaseNode,
+    MetadataMode,
+    NodeRelationship,
+    RelatedNodeInfo,
+    TextNode,
+)
 from llama_index.vector_stores.types import (
     MetadataFilters,
     VectorStore,

--- a/llama_index/vector_stores/lancedb.py
+++ b/llama_index/vector_stores/lancedb.py
@@ -1,10 +1,9 @@
 """LanceDB vector store."""
 from typing import Any, List, Optional
 
-from llama_index.schema import MetadataMode, NodeRelationship, RelatedNodeInfo, TextNode
+from llama_index.schema import BaseNode, MetadataMode, NodeRelationship, RelatedNodeInfo, TextNode
 from llama_index.vector_stores.types import (
     MetadataFilters,
-    NodeWithEmbedding,
     VectorStore,
     VectorStoreQuery,
     VectorStoreQueryResult,
@@ -79,23 +78,23 @@ class LanceDBVectorStore(VectorStore):
 
     def add(
         self,
-        embedding_results: List[NodeWithEmbedding],
+        nodes: List[BaseNode],
     ) -> List[str]:
         data = []
         ids = []
-        for result in embedding_results:
+        for node in nodes:
             metadata = node_to_metadata_dict(
-                result.node, remove_text=True, flat_metadata=self.flat_metadata
+                node, remove_text=True, flat_metadata=self.flat_metadata
             )
             append_data = {
-                "id": result.id,
-                "doc_id": result.ref_doc_id,
-                "vector": result.embedding,
-                "text": result.node.get_content(metadata_mode=MetadataMode.NONE),
+                "id": node.node_id,
+                "doc_id": node.ref_doc_id,
+                "vector": node.get_embedding(),
+                "text": node.get_content(metadata_mode=MetadataMode.NONE),
             }
             append_data.update(metadata)
             data.append(append_data)
-            ids.append(result.id)
+            ids.append(node.node_id)
 
         if self.table_name in self.connection.table_names():
             tbl = self.connection.open_table(self.table_name)

--- a/llama_index/vector_stores/metal.py
+++ b/llama_index/vector_stores/metal.py
@@ -126,9 +126,7 @@ class MetalVectorStore(VectorStore):
             ids.append(node.node_id)
 
             metadata = {}
-            metadata["text"] = (
-                node.get_content(metadata_mode=MetadataMode.NONE) or ""
-            )
+            metadata["text"] = node.get_content(metadata_mode=MetadataMode.NONE) or ""
 
             additional_metadata = node_to_metadata_dict(
                 node, remove_text=True, flat_metadata=self.flat_metadata

--- a/llama_index/vector_stores/milvus.py
+++ b/llama_index/vector_stores/milvus.py
@@ -7,7 +7,13 @@ import logging
 from typing import Any, List, Optional
 from uuid import uuid4
 
-from llama_index.schema import BaseNode, MetadataMode, NodeRelationship, RelatedNodeInfo, TextNode
+from llama_index.schema import (
+    BaseNode,
+    MetadataMode,
+    NodeRelationship,
+    RelatedNodeInfo,
+    TextNode,
+)
 from llama_index.vector_stores.types import (
     VectorStore,
     VectorStoreQuery,
@@ -326,7 +332,7 @@ class MilvusVectorStore(VectorStore):
 
         # If the collection doesnt exist yet, create the collection, index, and load it
         if self.collection is None and len(nodes) != 0:
-            self.dim = len(nodes[0].embedding)
+            self.dim = len(nodes[0].get_embedding())
             self._create_collection()
             self._create_index()
             assert self.collection is not None
@@ -346,7 +352,7 @@ class MilvusVectorStore(VectorStore):
             ids.append(node.node_id)
             doc_ids.append(node.ref_doc_id)
             texts.append(node.get_content(metadata_mode=MetadataMode.NONE))
-            embeddings.append(node.embedding)
+            embeddings.append(node.get_embedding())
 
             # Store node without text
             metadata = node_to_metadata_dict(node, remove_text=True)

--- a/llama_index/vector_stores/mongodb.py
+++ b/llama_index/vector_stores/mongodb.py
@@ -8,10 +8,9 @@ import logging
 import os
 from typing import Any, Dict, List, Optional, cast
 
-from llama_index.schema import MetadataMode, TextNode
+from llama_index.schema import BaseNode, MetadataMode, TextNode
 from llama_index.vector_stores.types import (
     MetadataFilters,
-    NodeWithEmbedding,
     VectorStore,
     VectorStoreQuery,
     VectorStoreQueryResult,
@@ -93,32 +92,29 @@ class MongoDBAtlasVectorSearch(VectorStore):
 
     def add(
         self,
-        embedding_results: List[NodeWithEmbedding],
+        nodes: List[BaseNode],
     ) -> List[str]:
         """Add embedding results to index.
 
         Args
-            embedding_results: List[NodeWithEmbedding]: list of embedding results
+            nodes: List[BaseNode]: list of nodes with embeddings
 
         """
         ids = []
         data_to_insert = []
-        for result in embedding_results:
-            node_id = result.id
-            node = result.node
-
+        for node in nodes:
             metadata = node_to_metadata_dict(
                 node, remove_text=True, flat_metadata=self.flat_metadata
             )
 
             entry = {
-                self._id_key: node_id,
-                self._embedding_key: result.embedding,
+                self._id_key: node.node_id,
+                self._embedding_key: node.get_embedding(),
                 self._text_key: node.get_content(metadata_mode=MetadataMode.NONE) or "",
                 self._metadata_key: metadata,
             }
             data_to_insert.append(entry)
-            ids.append(node_id)
+            ids.append(node.node_id)
         logger.debug("Inserting data into MongoDB: %s", data_to_insert)
         insert_result = self._collection.insert_many(
             data_to_insert, **self._insert_kwargs

--- a/llama_index/vector_stores/mongodb.py
+++ b/llama_index/vector_stores/mongodb.py
@@ -94,7 +94,7 @@ class MongoDBAtlasVectorSearch(VectorStore):
         self,
         nodes: List[BaseNode],
     ) -> List[str]:
-        """Add embedding results to index.
+        """Add nodes to index.
 
         Args
             nodes: List[BaseNode]: list of nodes with embeddings

--- a/llama_index/vector_stores/myscale.py
+++ b/llama_index/vector_stores/myscale.py
@@ -13,7 +13,13 @@ from llama_index.readers.myscale import (
     escape_str,
     format_list_to_string,
 )
-from llama_index.schema import BaseNode, MetadataMode, NodeRelationship, RelatedNodeInfo, TextNode
+from llama_index.schema import (
+    BaseNode,
+    MetadataMode,
+    NodeRelationship,
+    RelatedNodeInfo,
+    TextNode,
+)
 from llama_index.utils import iter_batch
 from llama_index.vector_stores.types import (
     VectorStore,
@@ -187,7 +193,7 @@ class MyScaleVectorStore(VectorStore):
             return []
 
         if not self._index_existed:
-            self._create_index(len(nodes[0].embedding))
+            self._create_index(len(nodes[0].get_embedding()))
 
         for result_batch in iter_batch(nodes, self.config.batch_size):
             insert_statement = self._build_insert_statement(values=result_batch)

--- a/llama_index/vector_stores/myscale.py
+++ b/llama_index/vector_stores/myscale.py
@@ -182,7 +182,7 @@ class MyScaleVectorStore(VectorStore):
         self,
         nodes: List[BaseNode],
     ) -> List[str]:
-        """Add embedding results to index.
+        """Add nodes to index.
 
         Args
             nodes: List[BaseNode]: list of nodes with embeddings

--- a/llama_index/vector_stores/myscale.py
+++ b/llama_index/vector_stores/myscale.py
@@ -13,10 +13,9 @@ from llama_index.readers.myscale import (
     escape_str,
     format_list_to_string,
 )
-from llama_index.schema import MetadataMode, NodeRelationship, RelatedNodeInfo, TextNode
+from llama_index.schema import BaseNode, MetadataMode, NodeRelationship, RelatedNodeInfo, TextNode
 from llama_index.utils import iter_batch
 from llama_index.vector_stores.types import (
-    NodeWithEmbedding,
     VectorStore,
     VectorStoreQuery,
     VectorStoreQueryResult,
@@ -98,25 +97,25 @@ class MyScaleVectorStore(VectorStore):
 
         # schema column name, type, and construct format method
         self.column_config: Dict = {
-            "id": {"type": "String", "extract_func": lambda x: x.id},
+            "id": {"type": "String", "extract_func": lambda x: x.node_id},
             "doc_id": {"type": "String", "extract_func": lambda x: x.ref_doc_id},
             "text": {
                 "type": "String",
                 "extract_func": lambda x: escape_str(
-                    x.node.get_content(metadata_mode=MetadataMode.NONE) or ""
+                    x.get_content(metadata_mode=MetadataMode.NONE) or ""
                 ),
             },
             "vector": {
                 "type": "Array(Float32)",
-                "extract_func": lambda x: format_list_to_string(x.embedding),
+                "extract_func": lambda x: format_list_to_string(x.get_embedding()),
             },
             "node_info": {
                 "type": "JSON",
-                "extract_func": lambda x: json.dumps(x.node.node_info),
+                "extract_func": lambda x: json.dumps(x.node_info),
             },
             "metadata": {
                 "type": "JSON",
-                "extract_func": lambda x: json.dumps(x.node.metadata),
+                "extract_func": lambda x: json.dumps(x.metadata),
             },
         }
 
@@ -153,7 +152,7 @@ class MyScaleVectorStore(VectorStore):
 
     def _build_insert_statement(
         self,
-        values: List[NodeWithEmbedding],
+        values: List[BaseNode],
     ) -> str:
         _data = []
         for item in values:
@@ -175,26 +174,26 @@ class MyScaleVectorStore(VectorStore):
 
     def add(
         self,
-        embedding_results: List[NodeWithEmbedding],
+        nodes: List[BaseNode],
     ) -> List[str]:
         """Add embedding results to index.
 
         Args
-            embedding_results: List[NodeWithEmbedding]: list of embedding results
+            nodes: List[BaseNode]: list of nodes with embeddings
 
         """
 
-        if not embedding_results:
+        if not nodes:
             return []
 
         if not self._index_existed:
-            self._create_index(len(embedding_results[0].embedding))
+            self._create_index(len(nodes[0].embedding))
 
-        for result_batch in iter_batch(embedding_results, self.config.batch_size):
+        for result_batch in iter_batch(nodes, self.config.batch_size):
             insert_statement = self._build_insert_statement(values=result_batch)
             self._client.command(insert_statement)
 
-        return [result.id for result in embedding_results]
+        return [result.node_id for result in nodes]
 
     def delete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:
         """

--- a/llama_index/vector_stores/neo4jvector.py
+++ b/llama_index/vector_stores/neo4jvector.py
@@ -1,8 +1,7 @@
 from typing import Any, Dict, List, Optional
 
-from llama_index.schema import MetadataMode
+from llama_index.schema import BaseNode, MetadataMode
 from llama_index.vector_stores.types import (
-    NodeWithEmbedding,
     VectorStore,
     VectorStoreQuery,
     VectorStoreQueryResult,
@@ -24,15 +23,15 @@ def sort_by_index_name(
     return sorted(lst, key=lambda x: x.get("index_name") != index_name)
 
 
-def clean_params(params: List[NodeWithEmbedding]) -> List[Dict[str, Any]]:
-    """Convert NodeWithEmbedding object to a dictionary to be imported into Neo4j"""
+def clean_params(params: List[BaseNode]) -> List[Dict[str, Any]]:
+    """Convert BaseNode object to a dictionary to be imported into Neo4j"""
     clean_params = []
     for record in params:
-        text = record.node.get_content(metadata_mode=MetadataMode.NONE)
-        embedding = record.embedding
-        id = record.node.node_id
+        text = record.get_content(metadata_mode=MetadataMode.NONE)
+        embedding = record.get_embedding()
+        id = record.node_id
         metadata = node_to_metadata_dict(
-            record.node, remove_text=True, flat_metadata=False
+            record, remove_text=True, flat_metadata=False
         )
         # Remove redundant metadata information
         for k in ["document_id", "doc_id"]:
@@ -224,8 +223,8 @@ class Neo4jVectorStore(VectorStore):
             except CypherSyntaxError as e:
                 raise ValueError(f"Cypher Statement is not valid\n{e}")
 
-    def add(self, embedding_results: List[NodeWithEmbedding]) -> List[str]:
-        ids = [r.id for r in embedding_results]
+    def add(self, nodes: List[BaseNode]) -> List[str]:
+        ids = [r.node_id for r in nodes]
         import_query = (
             "UNWIND $data AS row "
             "CALL { WITH row "
@@ -240,7 +239,7 @@ class Neo4jVectorStore(VectorStore):
 
         self.database_query(
             import_query,
-            params={"data": clean_params(embedding_results)},
+            params={"data": clean_params(nodes)},
         )
 
         return ids

--- a/llama_index/vector_stores/neo4jvector.py
+++ b/llama_index/vector_stores/neo4jvector.py
@@ -30,9 +30,7 @@ def clean_params(params: List[BaseNode]) -> List[Dict[str, Any]]:
         text = record.get_content(metadata_mode=MetadataMode.NONE)
         embedding = record.get_embedding()
         id = record.node_id
-        metadata = node_to_metadata_dict(
-            record, remove_text=True, flat_metadata=False
-        )
+        metadata = node_to_metadata_dict(record, remove_text=True, flat_metadata=False)
         # Remove redundant metadata information
         for k in ["document_id", "doc_id"]:
             del metadata[k]

--- a/llama_index/vector_stores/opensearch.py
+++ b/llama_index/vector_stores/opensearch.py
@@ -227,9 +227,7 @@ class OpensearchVectorClient:
             self._os_client.indices.create(index=self._index, body=idx_conf)
             self._os_client.indices.refresh(index=self._index)
 
-    def index_results(
-        self, nodes: List[BaseNode], **kwargs: Any
-    ) -> List[str]:
+    def index_results(self, nodes: List[BaseNode], **kwargs: Any) -> List[str]:
         """Store results in the index."""
 
         embeddings: List[List[float]] = []

--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -10,10 +10,9 @@ from functools import partial
 from typing import Any, Callable, Dict, List, Optional, cast
 
 from llama_index.bridge.pydantic import PrivateAttr
-from llama_index.schema import MetadataMode, TextNode
+from llama_index.schema import BaseNode, MetadataMode, TextNode
 from llama_index.vector_stores.types import (
     MetadataFilters,
-    NodeWithEmbedding,
     BasePydanticVectorStore,
     VectorStoreQuery,
     VectorStoreQueryMode,
@@ -228,19 +227,18 @@ class PineconeVectorStore(BasePydanticVectorStore):
 
     def add(
         self,
-        embedding_results: List[NodeWithEmbedding],
+        nodes: List[BaseNode],
     ) -> List[str]:
-        """Add embedding results to index.
+        """Add nodes to index.
 
         Args
-            embedding_results: List[NodeWithEmbedding]: list of embedding results
+            nodes: List[BaseNode]: list of nodes with embeddings
 
         """
         ids = []
         entries = []
-        for result in embedding_results:
-            node_id = result.id
-            node = result.node
+        for node in nodes:
+            node_id = node.node_id
 
             metadata = node_to_metadata_dict(
                 node, remove_text=False, flat_metadata=self.flat_metadata
@@ -248,7 +246,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
 
             entry = {
                 ID_KEY: node_id,
-                VECTOR_KEY: result.embedding,
+                VECTOR_KEY: node.get_embedding(),
                 METADATA_KEY: metadata,
             }
             if self.add_sparse_vector:

--- a/llama_index/vector_stores/qdrant.py
+++ b/llama_index/vector_stores/qdrant.py
@@ -7,10 +7,9 @@ import logging
 from typing import Any, List, Optional, cast
 
 from llama_index.bridge.pydantic import Field, PrivateAttr
-from llama_index.schema import TextNode
+from llama_index.schema import BaseNode, TextNode
 from llama_index.utils import iter_batch
 from llama_index.vector_stores.types import (
-    NodeWithEmbedding,
     BasePydanticVectorStore,
     VectorStoreQuery,
     VectorStoreQueryResult,
@@ -116,32 +115,30 @@ class QdrantVectorStore(BasePydanticVectorStore):
     def class_name(cls) -> str:
         return "QdraantVectorStore"
 
-    def add(self, embedding_results: List[NodeWithEmbedding]) -> List[str]:
-        """Add embedding results to index.
+    def add(self, nodes: List[BaseNode]) -> List[str]:
+        """Add nodes to index.
 
         Args
-            embedding_results: List[NodeWithEmbedding]: list of embedding results
+            nodes: List[BaseNode]: list of nodes with embeddings
 
         """
         from qdrant_client.http import models as rest
 
-        if len(embedding_results) > 0 and not self._collection_initialized:
+        if len(nodes) > 0 and not self._collection_initialized:
             self._create_collection(
                 collection_name=self.collection_name,
-                vector_size=len(embedding_results[0].embedding),
+                vector_size=len(nodes[0].get_embedding()),
             )
 
         ids = []
-        for result_batch in iter_batch(embedding_results, self.batch_size):
+        for node_batch in iter_batch(nodes, self.batch_size):
             node_ids = []
             vectors = []
             payloads = []
-            for result in result_batch:
-                assert isinstance(result, NodeWithEmbedding)
-                assert isinstance(result.node, TextNode)
-                node_ids.append(result.id)
-                vectors.append(result.embedding)
-                node = result.node
+            for node in node_batch:
+                assert isinstance(node, BaseNode)
+                node_ids.append(node.node_id)
+                vectors.append(node.get_embedding())
 
                 metadata = node_to_metadata_dict(
                     node, remove_text=False, flat_metadata=self.flat_metadata

--- a/llama_index/vector_stores/redis.py
+++ b/llama_index/vector_stores/redis.py
@@ -128,7 +128,7 @@ class RedisVectorStore(VectorStore):
         return self._redis_client
 
     def add(self, nodes: List[BaseNode]) -> List[str]:
-        """Add embedding results to the index.
+        """Add nodes to the index.
 
         Args:
             nodes (List[BaseNode]): List of nodes with embeddings

--- a/llama_index/vector_stores/redis.py
+++ b/llama_index/vector_stores/redis.py
@@ -14,10 +14,9 @@ from llama_index.readers.redis.utils import (
     convert_bytes,
     get_redis_query,
 )
-from llama_index.schema import MetadataMode, NodeRelationship, RelatedNodeInfo, TextNode
+from llama_index.schema import BaseNode, MetadataMode, NodeRelationship, RelatedNodeInfo, TextNode
 from llama_index.vector_stores.types import (
     MetadataFilters,
-    NodeWithEmbedding,
     VectorStore,
     VectorStoreQuery,
     VectorStoreQueryResult,
@@ -122,12 +121,11 @@ class RedisVectorStore(VectorStore):
         """Return the redis client instance"""
         return self._redis_client
 
-    def add(self, embedding_results: List[NodeWithEmbedding]) -> List[str]:
+    def add(self, nodes: List[BaseNode]) -> List[str]:
         """Add embedding results to the index.
 
         Args:
-            embedding_results (List[NodeWithEmbedding]): List of embedding results to
-                add to the index.
+            nodes (List[BaseNode]): List of nodes with embeddings 
 
         Returns:
             List[str]: List of ids of the documents added to the index.
@@ -136,11 +134,11 @@ class RedisVectorStore(VectorStore):
             ValueError: If the index already exists and overwrite is False.
         """
         # check to see if empty document list was passed
-        if len(embedding_results) == 0:
+        if len(nodes) == 0:
             return []
 
         # set vector dim for creation if index doesn't exist
-        self._index_args["dims"] = len(embedding_results[0].embedding)
+        self._index_args["dims"] = len(nodes[0].embedding)
 
         if self._index_exists():
             if self._overwrite:
@@ -152,20 +150,20 @@ class RedisVectorStore(VectorStore):
             self._create_index()
 
         ids = []
-        for result in embedding_results:
+        for node in nodes:
             mapping = {
-                "id": result.id,
-                "doc_id": result.ref_doc_id,
-                "text": result.node.get_content(metadata_mode=MetadataMode.NONE),
-                self._vector_key: array_to_buffer(result.embedding),
+                "id": node.node_id,
+                "doc_id": node.ref_doc_id,
+                "text": node.get_content(metadata_mode=MetadataMode.NONE),
+                self._vector_key: array_to_buffer(node.get_embedding()),
             }
             additional_metadata = node_to_metadata_dict(
-                result.node, remove_text=True, flat_metadata=self.flat_metadata
+                node, remove_text=True, flat_metadata=self.flat_metadata
             )
             mapping.update(additional_metadata)
 
-            ids.append(result.id)
-            key = "_".join([self._prefix, str(result.id)])
+            ids.append(node.node_id)
+            key = "_".join([self._prefix, str(node.node_id)])
             self._redis_client.hset(key, mapping=mapping)  # type: ignore
 
         _logger.info(f"Added {len(ids)} documents to index {self._index_name}")

--- a/llama_index/vector_stores/redis.py
+++ b/llama_index/vector_stores/redis.py
@@ -14,7 +14,13 @@ from llama_index.readers.redis.utils import (
     convert_bytes,
     get_redis_query,
 )
-from llama_index.schema import BaseNode, MetadataMode, NodeRelationship, RelatedNodeInfo, TextNode
+from llama_index.schema import (
+    BaseNode,
+    MetadataMode,
+    NodeRelationship,
+    RelatedNodeInfo,
+    TextNode,
+)
 from llama_index.vector_stores.types import (
     MetadataFilters,
     VectorStore,
@@ -125,7 +131,7 @@ class RedisVectorStore(VectorStore):
         """Add embedding results to the index.
 
         Args:
-            nodes (List[BaseNode]): List of nodes with embeddings 
+            nodes (List[BaseNode]): List of nodes with embeddings
 
         Returns:
             List[str]: List of ids of the documents added to the index.
@@ -138,7 +144,7 @@ class RedisVectorStore(VectorStore):
             return []
 
         # set vector dim for creation if index doesn't exist
-        self._index_args["dims"] = len(nodes[0].embedding)
+        self._index_args["dims"] = len(nodes[0].get_embedding())
 
         if self._index_exists():
             if self._overwrite:

--- a/llama_index/vector_stores/rocksetdb.py
+++ b/llama_index/vector_stores/rocksetdb.py
@@ -4,8 +4,8 @@ from time import sleep
 from enum import Enum
 from typing import List, Any, Optional, TypeVar, Type
 from types import ModuleType
+from llama_index.schema import BaseNode
 from llama_index.vector_stores.types import (
-    NodeWithEmbedding,
     VectorStore,
     VectorStoreQuery,
     VectorStoreQueryResult,
@@ -123,11 +123,11 @@ class RocksetVectorStore(VectorStore):
     def client(self) -> Any:
         return self.rs
 
-    def add(self, embedding_results: List[NodeWithEmbedding]) -> List[str]:
+    def add(self, nodes: List[BaseNode]) -> List[str]:
         """Stores vectors in the collection
 
         Args:
-            embedding_results (List[NodeWithEmbedding]): The embedding nodes to store
+            nodes (List[BaseNode]): List of nodes with embeddings
 
         Returns:
             Stored node IDs (List[str])
@@ -139,13 +139,13 @@ class RocksetVectorStore(VectorStore):
                 workspace=self.workspace,
                 data=[
                     {
-                        self.embedding_col: result.embedding,
-                        "_id": result.id,
+                        self.embedding_col: node.get_embedding(),
+                        "_id": node.node_id,
                         self.metadata_col: node_to_metadata_dict(
-                            result.node, text_field=self.text_key
+                            node, text_field=self.text_key
                         ),
                     }
-                    for result in embedding_results
+                    for node in nodes
                 ],
             ).data
         ]

--- a/llama_index/vector_stores/simple.py
+++ b/llama_index/vector_stores/simple.py
@@ -103,7 +103,7 @@ class SimpleVectorStore(VectorStore):
         """Add embedding_results to index."""
         for node in nodes:
             self._data.embedding_dict[node.node_id] = node.get_embedding()
-            self._data.text_id_to_ref_doc_id[node.node_id] = node.ref_doc_id
+            self._data.text_id_to_ref_doc_id[node.node_id] = node.ref_doc_id or "None"
         return [node.node_id for node in nodes]
 
     def delete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:

--- a/llama_index/vector_stores/simple.py
+++ b/llama_index/vector_stores/simple.py
@@ -100,7 +100,7 @@ class SimpleVectorStore(VectorStore):
         self,
         nodes: List[BaseNode],
     ) -> List[str]:
-        """Add embedding_results to index."""
+        """Add nodes to index."""
         for node in nodes:
             self._data.embedding_dict[node.node_id] = node.get_embedding()
             self._data.text_id_to_ref_doc_id[node.node_id] = node.ref_doc_id or "None"

--- a/llama_index/vector_stores/simple.py
+++ b/llama_index/vector_stores/simple.py
@@ -14,10 +14,10 @@ from llama_index.indices.query.embedding_utils import (
     get_top_k_embeddings_learner,
     get_top_k_mmr_embeddings,
 )
+from llama_index.schema import BaseNode
 from llama_index.vector_stores.types import (
     DEFAULT_PERSIST_DIR,
     DEFAULT_PERSIST_FNAME,
-    NodeWithEmbedding,
     VectorStore,
     VectorStoreQuery,
     VectorStoreQueryMode,
@@ -98,13 +98,13 @@ class SimpleVectorStore(VectorStore):
 
     def add(
         self,
-        embedding_results: List[NodeWithEmbedding],
+        nodes: List[BaseNode],
     ) -> List[str]:
         """Add embedding_results to index."""
-        for result in embedding_results:
-            self._data.embedding_dict[result.id] = result.embedding
-            self._data.text_id_to_ref_doc_id[result.id] = result.ref_doc_id
-        return [result.id for result in embedding_results]
+        for node in nodes:
+            self._data.embedding_dict[node.node_id] = node.get_embedding()
+            self._data.text_id_to_ref_doc_id[node.node_id] = node.ref_doc_id
+        return [node.node_id for node in nodes]
 
     def delete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:
         """

--- a/llama_index/vector_stores/supabase.py
+++ b/llama_index/vector_stores/supabase.py
@@ -83,7 +83,7 @@ class SupabaseVectorStore(VectorStore):
         """Add nodes to index.
 
         Args
-            nodes: List[BaseNode]: list of nodes with embeddings 
+            nodes: List[BaseNode]: list of nodes with embeddings
 
         """
         if self._collection is None:

--- a/llama_index/vector_stores/supabase.py
+++ b/llama_index/vector_stores/supabase.py
@@ -3,10 +3,9 @@ import math
 from typing import Any, List
 
 from llama_index.constants import DEFAULT_EMBEDDING_DIM
-from llama_index.schema import TextNode
+from llama_index.schema import BaseNode, TextNode
 from llama_index.vector_stores.types import (
     MetadataFilters,
-    NodeWithEmbedding,
     VectorStore,
     VectorStoreQuery,
     VectorStoreQueryResult,
@@ -80,11 +79,11 @@ class SupabaseVectorStore(VectorStore):
             vecs_filter[f.key] = {"$eq": f.value}
         return vecs_filter
 
-    def add(self, embedding_results: List[NodeWithEmbedding]) -> List[str]:
-        """Add embedding results to index.
+    def add(self, nodes: List[BaseNode]) -> List[str]:
+        """Add nodes to index.
 
         Args
-            embedding_results: List[NodeWithEmbedding]: list of embedding results
+            nodes: List[BaseNode]: list of nodes with embeddings 
 
         """
         if self._collection is None:
@@ -93,15 +92,15 @@ class SupabaseVectorStore(VectorStore):
         data = []
         ids = []
 
-        for result in embedding_results:
+        for node in nodes:
             # NOTE: keep text in metadata dict since there's no special field in
             #       Supabase Vector.
             metadata_dict = node_to_metadata_dict(
-                result.node, remove_text=False, flat_metadata=self.flat_metadata
+                node, remove_text=False, flat_metadata=self.flat_metadata
             )
 
-            data.append((result.id, result.embedding, metadata_dict))
-            ids.append(result.id)
+            data.append((node.node_id, node.get_embedding(), metadata_dict))
+            ids.append(node.node_id)
 
         self._collection.upsert(records=data)
 

--- a/llama_index/vector_stores/tair.py
+++ b/llama_index/vector_stores/tair.py
@@ -166,7 +166,7 @@ class TairVectorStore(VectorStore):
             self._tair_client.tvs_hset(
                 self._index_name,
                 "%s#%s" % (node.ref_doc_id, node.node_id),
-                vector=node.embedding,
+                vector=node.get_embedding(),
                 is_binary=False,
                 **attributes,
             )

--- a/llama_index/vector_stores/tair.py
+++ b/llama_index/vector_stores/tair.py
@@ -5,7 +5,13 @@ An index that is built on top of Alibaba Cloud's Tair database.
 import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from llama_index.schema import BaseNode, MetadataMode, NodeRelationship, RelatedNodeInfo, TextNode
+from llama_index.schema import (
+    BaseNode,
+    MetadataMode,
+    NodeRelationship,
+    RelatedNodeInfo,
+    TextNode,
+)
 from llama_index.vector_stores.types import (
     MetadataFilters,
     VectorStore,

--- a/llama_index/vector_stores/types.py
+++ b/llama_index/vector_stores/types.py
@@ -141,7 +141,7 @@ class VectorStore(Protocol):
         self,
         nodes: List[BaseNode],
     ) -> List[str]:
-        """Add embedding results to vector store."""
+        """Add nodes with embedding to vector store."""
         ...
 
     async def async_add(
@@ -149,7 +149,7 @@ class VectorStore(Protocol):
         nodes: List[BaseNode],
     ) -> List[str]:
         """
-        Asynchronously add embedding results to vector store.
+        Asynchronously add nodes with embedding to vector store.
         NOTE: this is not implemented for all vector stores. If not implemented,
         it will just call add synchronously.
         """

--- a/llama_index/vector_stores/types.py
+++ b/llama_index/vector_stores/types.py
@@ -7,14 +7,14 @@ from typing import Any, List, Optional, Protocol, Sequence, Union, runtime_check
 import fsspec
 
 from llama_index.bridge.pydantic import BaseModel, StrictFloat, StrictInt, StrictStr
-from llama_index.schema import BaseNode, BaseComponent
+from llama_index.schema import BaseNode, BaseComponent, TextNode
 
 DEFAULT_PERSIST_DIR = "./storage"
 DEFAULT_PERSIST_FNAME = "vector_store.json"
 
 
 # legacy: kept for backward compatibility
-NodeWithEmbedding = BaseNode
+NodeWithEmbedding = TextNode
 
 
 @dataclass

--- a/llama_index/vector_stores/types.py
+++ b/llama_index/vector_stores/types.py
@@ -13,26 +13,8 @@ DEFAULT_PERSIST_DIR = "./storage"
 DEFAULT_PERSIST_FNAME = "vector_store.json"
 
 
-@dataclass
-class NodeWithEmbedding:
-    """Node with embedding.
-
-    Args:
-        node (Node): Node
-        embedding (List[float]): Embedding
-
-    """
-
-    node: BaseNode
-    embedding: List[float]
-
-    @property
-    def id(self) -> str:
-        return self.node.node_id
-
-    @property
-    def ref_doc_id(self) -> str:
-        return self.node.ref_doc_id or "None"
+# legacy: kept for backward compatibility
+NodeWithEmbedding = BaseNode
 
 
 @dataclass

--- a/llama_index/vector_stores/types.py
+++ b/llama_index/vector_stores/types.py
@@ -221,20 +221,20 @@ class BasePydanticVectorStore(BaseComponent, ABC):
     @abstractmethod
     def add(
         self,
-        embedding_results: List[NodeWithEmbedding],
+        nodes: List[BaseNode],
     ) -> List[str]:
         """Add embedding results to vector store."""
 
     async def async_add(
         self,
-        embedding_results: List[NodeWithEmbedding],
+        nodes: List[BaseNode],
     ) -> List[str]:
         """
         Asynchronously add embedding results to vector store.
         NOTE: this is not implemented for all vector stores. If not implemented,
         it will just call add synchronously.
         """
-        return self.add(embedding_results)
+        return self.add(nodes)
 
     @abstractmethod
     def delete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:

--- a/llama_index/vector_stores/types.py
+++ b/llama_index/vector_stores/types.py
@@ -205,14 +205,14 @@ class BasePydanticVectorStore(BaseComponent, ABC):
         self,
         nodes: List[BaseNode],
     ) -> List[str]:
-        """Add embedding results to vector store."""
+        """Add nodes to vector store."""
 
     async def async_add(
         self,
         nodes: List[BaseNode],
     ) -> List[str]:
         """
-        Asynchronously add embedding results to vector store.
+        Asynchronously add nodes to vector store.
         NOTE: this is not implemented for all vector stores. If not implemented,
         it will just call add synchronously.
         """

--- a/llama_index/vector_stores/types.py
+++ b/llama_index/vector_stores/types.py
@@ -157,21 +157,21 @@ class VectorStore(Protocol):
 
     def add(
         self,
-        embedding_results: List[NodeWithEmbedding],
+        nodes: List[BaseNode],
     ) -> List[str]:
         """Add embedding results to vector store."""
         ...
 
     async def async_add(
         self,
-        embedding_results: List[NodeWithEmbedding],
+        nodes: List[BaseNode],
     ) -> List[str]:
         """
         Asynchronously add embedding results to vector store.
         NOTE: this is not implemented for all vector stores. If not implemented,
         it will just call add synchronously.
         """
-        return self.add(embedding_results)
+        return self.add(nodes)
 
     def delete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:
         """

--- a/llama_index/vector_stores/typesense.py
+++ b/llama_index/vector_stores/typesense.py
@@ -106,14 +106,12 @@ class TypesenseVectorStore(VectorStore):
         upsert_docs = []
         for node in nodes:
             doc = {
-                "id": node.id,
-                "vec": node.embedding,
-                f"{self._text_key}": node.node.get_content(
-                    metadata_mode=MetadataMode.NONE
-                ),
+                "id": node.node_id,
+                "vec": node.get_embedding(),
+                f"{self._text_key}": node.get_content(metadata_mode=MetadataMode.NONE),
                 "ref_doc_id": node.ref_doc_id,
                 f"{self._metadata_key}": node_to_metadata_dict(
-                    node.node, remove_text=True, flat_metadata=self.flat_metadata
+                    node, remove_text=True, flat_metadata=self.flat_metadata
                 ),
             }
             upsert_docs.append(doc)

--- a/llama_index/vector_stores/typesense.py
+++ b/llama_index/vector_stores/typesense.py
@@ -8,10 +8,9 @@ import logging
 from typing import Any, Callable, List, Optional, cast
 
 from llama_index import utils
-from llama_index.schema import MetadataMode, TextNode
+from llama_index.schema import BaseNode, MetadataMode, TextNode
 from llama_index.vector_stores.types import (
     MetadataFilters,
-    NodeWithEmbedding,
     VectorStore,
     VectorStoreQuery,
     VectorStoreQueryMode,
@@ -104,10 +103,10 @@ class TypesenseVectorStore(VectorStore):
         )
 
     def _create_upsert_docs(
-        self, embedding_results: List[NodeWithEmbedding]
+        self, nodes: List[BaseNode]
     ) -> List[dict]:
         upsert_docs = []
-        for node in embedding_results:
+        for node in nodes:
             doc = {
                 "id": node.id,
                 "vec": node.embedding,
@@ -134,18 +133,18 @@ class TypesenseVectorStore(VectorStore):
 
     def add(
         self,
-        embedding_results: List[NodeWithEmbedding],
+        nodes: List[BaseNode],
     ) -> List[str]:
-        """Add embedding results to index.
+        """Add nodes to index.
 
         Args
-            embedding_results: List[NodeWithEmbedding]: list of embedding results
+            nodes: List[BaseNode]: list of nodes with embeddings
 
         """
         from typesense.collection import Collection
         from typesense.exceptions import ObjectNotFound
 
-        docs = self._create_upsert_docs(embedding_results)
+        docs = self._create_upsert_docs(nodes)
 
         try:
             collection = cast(Collection, self.collection)
@@ -154,13 +153,13 @@ class TypesenseVectorStore(VectorStore):
             )
         except ObjectNotFound:
             # Create the collection if it doesn't already exist
-            num_dim = len(embedding_results[0].embedding)
+            num_dim = len(nodes[0].get_embedding())
             self._create_collection(num_dim)
             collection.documents.import_(
                 docs, {"action": "upsert"}, batch_size=self._batch_size
             )
 
-        return [result.id for result in embedding_results]
+        return [node.node_id for node in nodes]
 
     def delete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:
         """

--- a/llama_index/vector_stores/typesense.py
+++ b/llama_index/vector_stores/typesense.py
@@ -102,9 +102,7 @@ class TypesenseVectorStore(VectorStore):
             {"name": self._collection_name, "fields": fields}
         )
 
-    def _create_upsert_docs(
-        self, nodes: List[BaseNode]
-    ) -> List[dict]:
+    def _create_upsert_docs(self, nodes: List[BaseNode]) -> List[dict]:
         upsert_docs = []
         for node in nodes:
             doc = {

--- a/llama_index/vector_stores/weaviate.py
+++ b/llama_index/vector_stores/weaviate.py
@@ -9,9 +9,9 @@ from typing import Any, Dict, List, Optional, cast
 from uuid import uuid4
 
 from llama_index.bridge.pydantic import Field, PrivateAttr
+from llama_index.schema import BaseNode
 from llama_index.vector_stores.types import (
     MetadataFilters,
-    NodeWithEmbedding,
     BasePydanticVectorStore,
     VectorStoreQuery,
     VectorStoreQueryMode,
@@ -166,22 +166,15 @@ class WeaviateVectorStore(BasePydanticVectorStore):
 
     def add(
         self,
-        embedding_results: List[NodeWithEmbedding],
+        nodes: List[BaseNode],
     ) -> List[str]:
-        """Add embedding results to index.
+        """Add nodes to index.
 
-        Args
-            embedding_results: List[NodeWithEmbedding]: list of embedding results
+        Args:
+            nodes: List[BaseNode]: list of nodes with embeddings
 
         """
-        for result in embedding_results:
-            node = result.node
-            embedding = result.embedding
-            # TODO: always store embedding in node
-            node.embedding = embedding
-
-        nodes = [r.node for r in embedding_results]
-        ids = [r.id for r in embedding_results]
+        ids = [r.node_id for r in nodes]
 
         with self._client.batch as batch:
             for node in nodes:

--- a/llama_index/vector_stores/weaviate_utils.py
+++ b/llama_index/vector_stores/weaviate_utils.py
@@ -154,7 +154,7 @@ def add_node(
     )
     metadata.update(additional_metadata)
 
-    vector = node.embedding
+    vector = node.get_embedding()
     id = node.node_id
 
     # if batch object is provided (via a context manager), use that instead

--- a/llama_index/vector_stores/zep.py
+++ b/llama_index/vector_stores/zep.py
@@ -1,9 +1,8 @@
 import logging
 from typing import Any, List, Optional, TYPE_CHECKING, Tuple
 
-from llama_index.schema import TextNode, MetadataMode
+from llama_index.schema import BaseNode, TextNode, MetadataMode
 from llama_index.vector_stores.types import (
-    NodeWithEmbedding,
     VectorStore,
     VectorStoreQuery,
     VectorStoreQueryResult,
@@ -91,38 +90,38 @@ class ZepVectorStore(VectorStore):
             )
 
     def _prepare_documents(
-        self, embedding_results: List[NodeWithEmbedding]
+        self, nodes: List[BaseNode]
     ) -> Tuple[List["ZepDocument"], List[str]]:
         from zep_python.document import Document as ZepDocument
 
         docs: List["ZepDocument"] = []
         ids: List[str] = []
 
-        for result in embedding_results:
+        for node in nodes:
             metadata_dict = node_to_metadata_dict(
-                result.node, remove_text=True, flat_metadata=self.flat_metadata
+                node, remove_text=True, flat_metadata=self.flat_metadata
             )
 
-            if len(result.node.get_content()) == 0:
+            if len(node.get_content()) == 0:
                 raise ValueError("No content to add to Zep")
 
             docs.append(
                 ZepDocument(
-                    document_id=result.id,
-                    content=result.node.get_content(metadata_mode=MetadataMode.NONE),
-                    embedding=result.embedding,
+                    document_id=node.node_id,
+                    content=node.get_content(metadata_mode=MetadataMode.NONE),
+                    embedding=node.get_embedding(),
                     metadata=metadata_dict,
                 )
             )
-            ids.append(result.id)
+            ids.append(node.node_id)
 
         return docs, ids
 
-    def add(self, embedding_results: List[NodeWithEmbedding]) -> List[str]:
-        """Add a list of embedding results to the collection.
+    def add(self, nodes: List[BaseNode]) -> List[str]:
+        """Add nodes to the collection.
 
         Args:
-            embedding_results (List[NodeWithEmbedding]): Embedding results to add.
+            nodes (List[BaseNode]): List of nodes with embeddings.
 
         Returns:
             List[str]: List of IDs of the added documents.
@@ -135,7 +134,7 @@ class ZepVectorStore(VectorStore):
         if self._collection.is_auto_embedded:
             raise ValueError("Collection is auto embedded, cannot add embeddings")
 
-        docs, ids = self._prepare_documents(embedding_results)
+        docs, ids = self._prepare_documents(nodes)
 
         self._collection.add_documents(docs)
 
@@ -143,12 +142,12 @@ class ZepVectorStore(VectorStore):
 
     async def async_add(
         self,
-        embedding_results: List[NodeWithEmbedding],
+        nodes: List[BaseNode],
     ) -> List[str]:
-        """Asynchronously add a list of embedding results to the collection.
+        """Asynchronously add nodes to the collection.
 
         Args:
-            embedding_results (List[NodeWithEmbedding]): Embedding results to add.
+            nodes (List[BaseNode]): List of nodes with embeddings.
 
         Returns:
             List[str]: List of IDs of the added documents.
@@ -161,7 +160,7 @@ class ZepVectorStore(VectorStore):
         if self._collection.is_auto_embedded:
             raise ValueError("Collection is auto embedded, cannot add embeddings")
 
-        docs, ids = self._prepare_documents(embedding_results)
+        docs, ids = self._prepare_documents(nodes)
 
         await self._collection.aadd_documents(docs)
 

--- a/tests/indices/composability/test_utils.py
+++ b/tests/indices/composability/test_utils.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional
+from llama_index.schema import BaseNode
 
 from llama_index.vector_stores.types import (
-    NodeWithEmbedding,
     VectorStore,
     VectorStoreQuery,
     VectorStoreQueryResult,
@@ -24,7 +24,7 @@ class MockVectorStore(VectorStore):
 
     def add(
         self,
-        embedding_results: List[NodeWithEmbedding],
+        nodes: List[BaseNode],
     ) -> List[str]:
         """Add embedding results to vector store."""
         raise NotImplementedError()

--- a/tests/indices/composability/test_utils.py
+++ b/tests/indices/composability/test_utils.py
@@ -26,7 +26,7 @@ class MockVectorStore(VectorStore):
         self,
         nodes: List[BaseNode],
     ) -> List[str]:
-        """Add embedding results to vector store."""
+        """Add nodes to vector store."""
         raise NotImplementedError()
 
     def delete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:

--- a/tests/indices/vector_store/test_deeplake.py
+++ b/tests/indices/vector_store/test_deeplake.py
@@ -116,8 +116,8 @@ def test_backwards_compatibility() -> None:
     )
     metadatas = [metadata.update({"doc_id": "2"}) for metadata in metadatas]
     node = TextNode(
-        text="test node text", 
-        metadata={"key": "value", "doc_id": "1"}, 
+        text="test node text",
+        metadata={"key": "value", "doc_id": "1"},
         id_="1",
         embedding=[1.0 for i in range(EMBEDDING_DIM)],
     )

--- a/tests/indices/vector_store/test_deeplake.py
+++ b/tests/indices/vector_store/test_deeplake.py
@@ -9,7 +9,6 @@ from llama_index.indices.vector_store.base import VectorStoreIndex
 from llama_index.schema import Document, TextNode
 from llama_index.storage.storage_context import StorageContext
 from llama_index.vector_stores import DeepLakeVectorStore
-from llama_index.vector_stores.types import NodeWithEmbedding
 
 try:
     import deeplake
@@ -65,12 +64,10 @@ def test_build_deeplake(
 
     node = nodes[0].node
 
-    result = NodeWithEmbedding(
-        node=node,
-        embedding=[1.0 for i in range(EMBEDDING_DIM)],
-    )
-    results = [result for i in range(NUMBER_OF_DATA)]
-    vector_store.add(results)
+    node_with_embedding = node.copy()
+    node_with_embedding.embedding = [1.0 for i in range(EMBEDDING_DIM)]
+    new_nodes = [node_with_embedding for i in range(NUMBER_OF_DATA)]
+    vector_store.add(new_nodes)
     assert len(vector_store.vectorstore) == 14
 
     ref_doc_id = str(node.ref_doc_id)
@@ -119,14 +116,13 @@ def test_backwards_compatibility() -> None:
     )
     metadatas = [metadata.update({"doc_id": "2"}) for metadata in metadatas]
     node = TextNode(
-        text="test node text", metadata={"key": "value", "doc_id": "1"}, id_="1"
-    )
-    result = NodeWithEmbedding(
-        node=node,
+        text="test node text", 
+        metadata={"key": "value", "doc_id": "1"}, 
+        id_="1",
         embedding=[1.0 for i in range(EMBEDDING_DIM)],
     )
 
-    results = [result for i in range(10)]
+    nodes = [node for i in range(10)]
 
     dataset_path = "local_ds1"
     ds = deeplake.empty(dataset_path)
@@ -150,6 +146,6 @@ def test_backwards_compatibility() -> None:
         verbose=False,
     )
 
-    vectorstore.add(results)
+    vectorstore.add(nodes)
     assert len(vectorstore.vectorstore) == 20
     deeplake.delete(dataset_path)

--- a/tests/indices/vector_store/test_faiss.py
+++ b/tests/indices/vector_store/test_faiss.py
@@ -10,7 +10,7 @@ from llama_index.indices.vector_store.base import VectorStoreIndex
 from llama_index.schema import Document, TextNode
 from llama_index.storage.storage_context import StorageContext
 from llama_index.vector_stores.faiss import FaissVectorStore
-from llama_index.vector_stores.types import NodeWithEmbedding, VectorStoreQuery
+from llama_index.vector_stores.types import VectorStoreQuery
 
 try:
     import faiss
@@ -73,10 +73,10 @@ def test_persist(tmp_path: Path) -> None:
 
     vector_store.add(
         [
-            NodeWithEmbedding(
-                node=TextNode(text="test text"),
+            TextNode(
+                text="test text",
                 embedding=[0, 0, 0, 1, 1],
-            )
+            ),
         ]
     )
 

--- a/tests/indices/vector_store/test_simple.py
+++ b/tests/indices/vector_store/test_simple.py
@@ -1,5 +1,4 @@
 """Test vector store indexes."""
-
 from typing import Any, List, cast
 from llama_index.indices.loading import load_index_from_storage
 

--- a/tests/storage/test_storage_context.py
+++ b/tests/storage/test_storage_context.py
@@ -1,18 +1,15 @@
 from llama_index.data_structs.data_structs import IndexDict
 from llama_index.schema import TextNode
 from llama_index.storage.storage_context import StorageContext
-from llama_index.vector_stores.types import NodeWithEmbedding
 
 
 def test_storage_context_dict() -> None:
     storage_context = StorageContext.from_defaults()
 
     # add
-    node = TextNode(text="test")
+    node = TextNode(text="test", embedding=[0.0, 0.0, 0.0])
     index_struct = IndexDict()
-    storage_context.vector_store.add(
-        [NodeWithEmbedding(node=node, embedding=[0.0, 0.0, 0.0])]
-    )
+    storage_context.vector_store.add([node])
     storage_context.docstore.add_documents([node])
     storage_context.index_store.add_index_struct(index_struct)
 

--- a/tests/vector_stores/test_cassandra.py
+++ b/tests/vector_stores/test_cassandra.py
@@ -4,7 +4,6 @@ import unittest
 from unittest.mock import MagicMock
 
 from llama_index.schema import NodeRelationship, RelatedNodeInfo, TextNode
-from llama_index.vector_stores.types import NodeWithEmbedding
 from llama_index.vector_stores.types import VectorStoreQuery
 from llama_index.vector_stores.types import VectorStoreQueryMode
 
@@ -37,16 +36,12 @@ class TestCassandraVectorStore(unittest.TestCase):
 
         vector_store.add(
             [
-                NodeWithEmbedding(
-                    node=TextNode(
-                        text="test node text",
-                        id_="test node id",
-                        relationships={
-                            NodeRelationship.SOURCE: RelatedNodeInfo(
-                                node_id="test doc id"
-                            )
-                        },
-                    ),
+                TextNode(
+                    text="test node text",
+                    id_="test node id",
+                    relationships={
+                        NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test doc id")
+                    },
                     embedding=[0.5, 0.5],
                 )
             ]

--- a/tests/vector_stores/test_cogsearch.py
+++ b/tests/vector_stores/test_cogsearch.py
@@ -2,7 +2,6 @@ from unittest.mock import MagicMock
 from typing import Any, List, Optional
 
 from llama_index.schema import NodeRelationship, RelatedNodeInfo, TextNode
-from llama_index.vector_stores.types import NodeWithEmbedding
 
 from llama_index.vector_stores import CognitiveSearchVectorStore
 from llama_index.vector_stores.cogsearch import IndexManagement
@@ -36,20 +35,16 @@ def create_mock_vector_store(
     return vector_store
 
 
-def create_sample_documents(n: int) -> List[NodeWithEmbedding]:
-    nodes: List[NodeWithEmbedding] = []
+def create_sample_documents(n: int) -> List[TextNode]:
+    nodes: List[TextNode] = []
 
     for i in range(n):
         nodes.append(
-            NodeWithEmbedding(
-                node=TextNode(
-                    text=f"test node text {i}",
-                    relationships={
-                        NodeRelationship.SOURCE: RelatedNodeInfo(
-                            node_id=f"test doc id {i}"
-                        )
-                    },
-                ),
+            TextNode(
+                text=f"test node text {i}",
+                relationships={
+                    NodeRelationship.SOURCE: RelatedNodeInfo(node_id=f"test doc id {i}")
+                },
                 embedding=[0.5, 0.5],
             )
         )

--- a/tests/vector_stores/test_docarray.py
+++ b/tests/vector_stores/test_docarray.py
@@ -12,7 +12,6 @@ from llama_index.vector_stores import (
 from llama_index.vector_stores.types import (
     ExactMatchFilter,
     MetadataFilters,
-    NodeWithEmbedding,
     VectorStoreQuery,
 )
 
@@ -20,53 +19,41 @@ docarray = pytest.importorskip("docarray")
 
 
 @pytest.fixture
-def node_embeddings() -> List[NodeWithEmbedding]:
+def node_embeddings() -> List[TextNode]:
     return [
-        NodeWithEmbedding(
+        TextNode(
+            text="lorem ipsum",
+            id_="c330d77f-90bd-4c51-9ed2-57d8d693b3b0",
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-0")},
+            metadata={
+                "author": "Stephen King",
+                "theme": "Friendship",
+            },
             embedding=[1.0, 0.0, 0.0],
-            node=TextNode(
-                text="lorem ipsum",
-                id_="c330d77f-90bd-4c51-9ed2-57d8d693b3b0",
-                relationships={
-                    NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-0")
-                },
-                metadata={
-                    "author": "Stephen King",
-                    "theme": "Friendship",
-                },
-            ),
         ),
-        NodeWithEmbedding(
+        TextNode(
+            text="lorem ipsum",
+            id_="c3d1e1dd-8fb4-4b8f-b7ea-7fa96038d39d",
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-1")},
+            metadata={
+                "director": "Francis Ford Coppola",
+                "theme": "Mafia",
+            },
             embedding=[0.0, 1.0, 0.0],
-            node=TextNode(
-                text="lorem ipsum",
-                id_="c3d1e1dd-8fb4-4b8f-b7ea-7fa96038d39d",
-                relationships={
-                    NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-1")
-                },
-                metadata={
-                    "director": "Francis Ford Coppola",
-                    "theme": "Mafia",
-                },
-            ),
         ),
-        NodeWithEmbedding(
+        TextNode(
+            text="lorem ipsum",
+            id_="c3ew11cd-8fb4-4b8f-b7ea-7fa96038d39d",
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-2")},
+            metadata={
+                "director": "Christopher Nolan",
+            },
             embedding=[0.0, 0.0, 1.0],
-            node=TextNode(
-                text="lorem ipsum",
-                id_="c3ew11cd-8fb4-4b8f-b7ea-7fa96038d39d",
-                relationships={
-                    NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-2")
-                },
-                metadata={
-                    "director": "Christopher Nolan",
-                },
-            ),
         ),
     ]
 
 
-def test_hnsw(node_embeddings: List[NodeWithEmbedding], tmp_path: Path) -> None:
+def test_hnsw(node_embeddings: List[TextNode], tmp_path: Path) -> None:
     docarray_vector_store = DocArrayHnswVectorStore(work_dir=str(tmp_path), dim=3)
     docarray_vector_store.add(node_embeddings)
     assert docarray_vector_store.num_docs() == 3
@@ -89,7 +76,7 @@ def test_hnsw(node_embeddings: List[NodeWithEmbedding], tmp_path: Path) -> None:
     assert new_vector_store.num_docs() == 1
 
 
-def test_in_memory(node_embeddings: List[NodeWithEmbedding], tmp_path: Path) -> None:
+def test_in_memory(node_embeddings: List[TextNode], tmp_path: Path) -> None:
     docarray_vector_store = DocArrayInMemoryVectorStore()
     docarray_vector_store.add(node_embeddings)
     assert docarray_vector_store.num_docs() == 3
@@ -116,7 +103,7 @@ def test_in_memory(node_embeddings: List[NodeWithEmbedding], tmp_path: Path) -> 
     assert new_vector_store.num_docs() == 1
 
 
-def test_in_memory_filters(node_embeddings: List[NodeWithEmbedding]) -> None:
+def test_in_memory_filters(node_embeddings: List[TextNode]) -> None:
     docarray_vector_store = DocArrayInMemoryVectorStore()
     docarray_vector_store.add(node_embeddings)
     assert docarray_vector_store.num_docs() == 3
@@ -133,7 +120,7 @@ def test_in_memory_filters(node_embeddings: List[NodeWithEmbedding]) -> None:
     assert rf == "test-1"
 
 
-def test_hnsw_filters(node_embeddings: List[NodeWithEmbedding], tmp_path: Path) -> None:
+def test_hnsw_filters(node_embeddings: List[TextNode], tmp_path: Path) -> None:
     docarray_vector_store = DocArrayHnswVectorStore(work_dir=str(tmp_path), dim=3)
     docarray_vector_store.add(node_embeddings)
     assert docarray_vector_store.num_docs() == 3

--- a/tests/vector_stores/test_elasticsearch.py
+++ b/tests/vector_stores/test_elasticsearch.py
@@ -10,7 +10,6 @@ from llama_index.vector_stores import ElasticsearchStore
 from llama_index.vector_stores.types import (
     ExactMatchFilter,
     MetadataFilters,
-    NodeWithEmbedding,
     VectorStoreQuery,
     VectorStoreQueryMode,
 )
@@ -80,48 +79,36 @@ def elasticsearch_connection() -> Union[dict, Generator[dict, None, None]]:
 
 
 @pytest.fixture(scope="session")
-def node_embeddings() -> List[NodeWithEmbedding]:
+def node_embeddings() -> List[TextNode]:
     return [
-        NodeWithEmbedding(
+        TextNode(
+            text="lorem ipsum",
+            id_="c330d77f-90bd-4c51-9ed2-57d8d693b3b0",
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-0")},
+            metadata={
+                "author": "Stephen King",
+                "theme": "Friendship",
+            },
             embedding=[1.0, 0.0, 0.0],
-            node=TextNode(
-                text="lorem ipsum",
-                id_="c330d77f-90bd-4c51-9ed2-57d8d693b3b0",
-                relationships={
-                    NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-0")
-                },
-                metadata={
-                    "author": "Stephen King",
-                    "theme": "Friendship",
-                },
-            ),
         ),
-        NodeWithEmbedding(
+        TextNode(
+            text="lorem ipsum",
+            id_="c3d1e1dd-8fb4-4b8f-b7ea-7fa96038d39d",
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-1")},
+            metadata={
+                "director": "Francis Ford Coppola",
+                "theme": "Mafia",
+            },
             embedding=[0.0, 1.0, 0.0],
-            node=TextNode(
-                text="lorem ipsum",
-                id_="c3d1e1dd-8fb4-4b8f-b7ea-7fa96038d39d",
-                relationships={
-                    NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-1")
-                },
-                metadata={
-                    "director": "Francis Ford Coppola",
-                    "theme": "Mafia",
-                },
-            ),
         ),
-        NodeWithEmbedding(
+        TextNode(
+            text="lorem ipsum",
+            id_="c3ew11cd-8fb4-4b8f-b7ea-7fa96038d39d",
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-2")},
+            metadata={
+                "director": "Christopher Nolan",
+            },
             embedding=[0.0, 0.0, 1.0],
-            node=TextNode(
-                text="lorem ipsum",
-                id_="c3ew11cd-8fb4-4b8f-b7ea-7fa96038d39d",
-                relationships={
-                    NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-2")
-                },
-                metadata={
-                    "director": "Christopher Nolan",
-                },
-            ),
         ),
     ]
 
@@ -143,7 +130,7 @@ def test_instance_creation(index_name: str, elasticsearch_connection: Dict) -> N
 def test_add_to_es_and_query(
     index_name: str,
     elasticsearch_connection: Dict,
-    node_embeddings: List[NodeWithEmbedding],
+    node_embeddings: List[TextNode],
 ) -> None:
     es_store = ElasticsearchStore(
         **elasticsearch_connection,
@@ -164,7 +151,7 @@ def test_add_to_es_and_query(
 def test_add_to_es_and_text_query(
     index_name: str,
     elasticsearch_connection: Dict,
-    node_embeddings: List[NodeWithEmbedding],
+    node_embeddings: List[TextNode],
 ) -> None:
     es_store = ElasticsearchStore(
         **elasticsearch_connection,
@@ -187,7 +174,7 @@ def test_add_to_es_and_text_query(
 def test_add_to_es_and_hybrid_query(
     index_name: str,
     elasticsearch_connection: Dict,
-    node_embeddings: List[NodeWithEmbedding],
+    node_embeddings: List[TextNode],
 ) -> None:
     es_store = ElasticsearchStore(
         **elasticsearch_connection,
@@ -213,7 +200,7 @@ def test_add_to_es_and_hybrid_query(
 def test_add_to_es_query_with_filters(
     index_name: str,
     elasticsearch_connection: Dict,
-    node_embeddings: List[NodeWithEmbedding],
+    node_embeddings: List[TextNode],
 ) -> None:
     es_store = ElasticsearchStore(
         **elasticsearch_connection,
@@ -242,7 +229,7 @@ def test_add_to_es_query_with_filters(
 def test_add_to_es_query_with_es_filters(
     index_name: str,
     elasticsearch_connection: Dict,
-    node_embeddings: List[NodeWithEmbedding],
+    node_embeddings: List[TextNode],
 ) -> None:
     es_store = ElasticsearchStore(
         **elasticsearch_connection,
@@ -266,7 +253,7 @@ def test_add_to_es_query_with_es_filters(
 def test_add_to_es_query_and_delete(
     index_name: str,
     elasticsearch_connection: Dict,
-    node_embeddings: List[NodeWithEmbedding],
+    node_embeddings: List[TextNode],
 ) -> None:
     es_store = ElasticsearchStore(
         **elasticsearch_connection,

--- a/tests/vector_stores/test_epsilla.py
+++ b/tests/vector_stores/test_epsilla.py
@@ -10,37 +10,29 @@ except ImportError:
 
 from llama_index.schema import NodeRelationship, RelatedNodeInfo, TextNode
 from llama_index.vector_stores import EpsillaVectorStore
-from llama_index.vector_stores.types import NodeWithEmbedding, VectorStoreQuery
+from llama_index.vector_stores.types import VectorStoreQuery
 
 
 @pytest.fixture
-def node_embeddings() -> List[NodeWithEmbedding]:
+def node_embeddings() -> List[TextNode]:
     return [
-        NodeWithEmbedding(
+        TextNode(
+            text="epsilla test text 0.",
+            id_="1",
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-0")},
+            metadata={
+                "date": "2023-08-02",
+            },
             embedding=[1.0, 0.0],
-            node=TextNode(
-                text="epsilla test text 0.",
-                id_="1",
-                relationships={
-                    NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-0")
-                },
-                metadata={
-                    "date": "2023-08-02",
-                },
-            ),
         ),
-        NodeWithEmbedding(
+        TextNode(
+            text="epsilla test text 1.",
+            id_="2",
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-1")},
+            metadata={
+                "date": "2023-08-11",
+            },
             embedding=[0.0, 1.0],
-            node=TextNode(
-                text="epsilla test text 1.",
-                id_="2",
-                relationships={
-                    NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-1")
-                },
-                metadata={
-                    "date": "2023-08-11",
-                },
-            ),
         ),
     ]
 

--- a/tests/vector_stores/test_epsilla.py
+++ b/tests/vector_stores/test_epsilla.py
@@ -56,8 +56,8 @@ def test_add_data_and_query() -> None:
     assert vector_store._collection_name == "test_collection"
     assert vector_store._collection_created is not True
 
-    embedding_results = node_embeddings()
-    ids = vector_store.add(embedding_results)
+    nodes = node_embeddings()
+    ids = vector_store.add(nodes)
 
     assert vector_store._collection_created is True
     assert ids is ["1", "2"]

--- a/tests/vector_stores/test_postgres.py
+++ b/tests/vector_stores/test_postgres.py
@@ -9,7 +9,6 @@ from llama_index.vector_stores.loading import load_vector_store
 from llama_index.vector_stores.types import (
     ExactMatchFilter,
     MetadataFilters,
-    NodeWithEmbedding,
     VectorStoreQuery,
     VectorStoreQueryMode,
 )
@@ -101,64 +100,52 @@ def pg_hybrid(db: None) -> Any:
 
 
 @pytest.fixture(scope="session")
-def node_embeddings() -> List[NodeWithEmbedding]:
+def node_embeddings() -> List[TextNode]:
     return [
-        NodeWithEmbedding(
+        TextNode(
+            text="lorem ipsum",
+            id_="aaa",
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="aaa")},
             embedding=_get_sample_vector(1.0),
-            node=TextNode(
-                text="lorem ipsum",
-                id_="aaa",
-                relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="aaa")},
-            ),
         ),
-        NodeWithEmbedding(
+        TextNode(
+            text="dolor sit amet",
+            id_="bbb",
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="bbb")},
+            extra_info={"test_key": "test_value"},
             embedding=_get_sample_vector(0.1),
-            node=TextNode(
-                text="dolor sit amet",
-                id_="bbb",
-                relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="bbb")},
-                extra_info={"test_key": "test_value"},
-            ),
         ),
     ]
 
 
 @pytest.fixture(scope="session")
-def hybrid_node_embeddings() -> List[NodeWithEmbedding]:
+def hybrid_node_embeddings() -> List[TextNode]:
     return [
-        NodeWithEmbedding(
+        TextNode(
+            text="lorem ipsum",
+            id_="aaa",
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="aaa")},
             embedding=_get_sample_vector(0.1),
-            node=TextNode(
-                text="lorem ipsum",
-                id_="aaa",
-                relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="aaa")},
-            ),
         ),
-        NodeWithEmbedding(
+        TextNode(
+            text="dolor sit amet",
+            id_="bbb",
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="bbb")},
+            extra_info={"test_key": "test_value"},
             embedding=_get_sample_vector(1.0),
-            node=TextNode(
-                text="dolor sit amet",
-                id_="bbb",
-                relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="bbb")},
-                extra_info={"test_key": "test_value"},
-            ),
         ),
-        NodeWithEmbedding(
+        TextNode(
+            text="The quick brown fox jumped over the lazy dog.",
+            id_="ccc",
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="ccc")},
             embedding=_get_sample_vector(5.0),
-            node=TextNode(
-                text="The quick brown fox jumped over the lazy dog.",
-                id_="ccc",
-                relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="ccc")},
-            ),
         ),
-        NodeWithEmbedding(
+        TextNode(
+            text="The fox and the hound",
+            id_="ddd",
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="ddd")},
+            extra_info={"test_key": "test_value"},
             embedding=_get_sample_vector(10.0),
-            node=TextNode(
-                text="The fox and the hound",
-                id_="ddd",
-                relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="ddd")},
-                extra_info={"test_key": "test_value"},
-            ),
         ),
     ]
 
@@ -179,7 +166,7 @@ async def test_instance_creation(db: None) -> None:
 @pytest.mark.asyncio
 @pytest.mark.parametrize("use_async", [True, False])
 async def test_add_to_db_and_query(
-    pg: PGVectorStore, node_embeddings: List[NodeWithEmbedding], use_async: bool
+    pg: PGVectorStore, node_embeddings: List[TextNode], use_async: bool
 ) -> None:
     if use_async:
         await pg.async_add(node_embeddings)
@@ -200,7 +187,7 @@ async def test_add_to_db_and_query(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("use_async", [True, False])
 async def test_add_to_db_and_query_with_metadata_filters(
-    pg: PGVectorStore, node_embeddings: List[NodeWithEmbedding], use_async: bool
+    pg: PGVectorStore, node_embeddings: List[TextNode], use_async: bool
 ) -> None:
     if use_async:
         await pg.async_add(node_embeddings)
@@ -226,7 +213,7 @@ async def test_add_to_db_and_query_with_metadata_filters(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("use_async", [True, False])
 async def test_add_to_db_query_and_delete(
-    pg: PGVectorStore, node_embeddings: List[NodeWithEmbedding], use_async: bool
+    pg: PGVectorStore, node_embeddings: List[TextNode], use_async: bool
 ) -> None:
     if use_async:
         await pg.async_add(node_embeddings)
@@ -249,7 +236,7 @@ async def test_add_to_db_query_and_delete(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("use_async", [(True,), (False,)])
 async def test_save_load(
-    pg: PGVectorStore, node_embeddings: List[NodeWithEmbedding], use_async: bool
+    pg: PGVectorStore, node_embeddings: List[TextNode], use_async: bool
 ) -> None:
     if use_async:
         await pg.async_add(node_embeddings)
@@ -291,7 +278,7 @@ async def test_save_load(
 @pytest.mark.parametrize("use_async", [True, False])
 async def test_sparse_query(
     pg_hybrid: PGVectorStore,
-    hybrid_node_embeddings: List[NodeWithEmbedding],
+    hybrid_node_embeddings: List[TextNode],
     use_async: bool,
 ) -> None:
     if use_async:
@@ -323,7 +310,7 @@ async def test_sparse_query(
 @pytest.mark.parametrize("use_async", [True, False])
 async def test_hybrid_query(
     pg_hybrid: PGVectorStore,
-    hybrid_node_embeddings: List[NodeWithEmbedding],
+    hybrid_node_embeddings: List[TextNode],
     use_async: bool,
 ) -> None:
     if use_async:
@@ -394,7 +381,7 @@ async def test_hybrid_query(
 @pytest.mark.parametrize("use_async", [True, False])
 async def test_add_to_db_and_hybrid_query_with_metadata_filters(
     pg_hybrid: PGVectorStore,
-    hybrid_node_embeddings: List[NodeWithEmbedding],
+    hybrid_node_embeddings: List[TextNode],
     use_async: bool,
 ) -> None:
     if use_async:
@@ -424,7 +411,7 @@ async def test_add_to_db_and_hybrid_query_with_metadata_filters(
 
 @pytest.mark.skipif(postgres_not_available, reason="postgres db is not available")
 def test_hybrid_query_fails_if_no_query_str_provided(
-    pg_hybrid: PGVectorStore, hybrid_node_embeddings: List[NodeWithEmbedding]
+    pg_hybrid: PGVectorStore, hybrid_node_embeddings: List[TextNode]
 ) -> None:
     q = VectorStoreQuery(
         query_embedding=_get_sample_vector(1.0),

--- a/tests/vector_stores/test_qdrant.py
+++ b/tests/vector_stores/test_qdrant.py
@@ -10,7 +10,6 @@ except ImportError:
 from llama_index.schema import NodeRelationship, RelatedNodeInfo, TextNode
 from llama_index.vector_stores import QdrantVectorStore
 from llama_index.vector_stores.types import (
-    NodeWithEmbedding,
     VectorStoreQuery,
     MetadataFilters,
     ExactMatchFilter,
@@ -18,41 +17,33 @@ from llama_index.vector_stores.types import (
 
 
 @pytest.fixture
-def node_embeddings() -> List[NodeWithEmbedding]:
+def node_embeddings() -> List[TextNode]:
     return [
-        NodeWithEmbedding(
+        TextNode(
+            text="lorem ipsum",
+            id_="c330d77f-90bd-4c51-9ed2-57d8d693b3b0",
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-0")},
+            metadata={
+                "author": "Stephen King",
+                "theme": "Friendship",
+            },
             embedding=[1.0, 0.0],
-            node=TextNode(
-                text="lorem ipsum",
-                id_="c330d77f-90bd-4c51-9ed2-57d8d693b3b0",
-                relationships={
-                    NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-0")
-                },
-                metadata={
-                    "author": "Stephen King",
-                    "theme": "Friendship",
-                },
-            ),
         ),
-        NodeWithEmbedding(
+        TextNode(
+            text="lorem ipsum",
+            id_="c3d1e1dd-8fb4-4b8f-b7ea-7fa96038d39d",
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-1")},
+            metadata={
+                "director": "Francis Ford Coppola",
+                "theme": "Mafia",
+            },
             embedding=[0.0, 1.0],
-            node=TextNode(
-                text="lorem ipsum",
-                id_="c3d1e1dd-8fb4-4b8f-b7ea-7fa96038d39d",
-                relationships={
-                    NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-1")
-                },
-                metadata={
-                    "director": "Francis Ford Coppola",
-                    "theme": "Mafia",
-                },
-            ),
         ),
     ]
 
 
 @pytest.mark.skipif(qdrant_client is None, reason="qdrant-client not installed")
-def test_add_stores_data(node_embeddings: List[NodeWithEmbedding]) -> None:
+def test_add_stores_data(node_embeddings: List[TextNode]) -> None:
     client = qdrant_client.QdrantClient(":memory:")
     qdrant_vector_store = QdrantVectorStore(collection_name="test", client=client)
 

--- a/tests/vector_stores/test_rockset.py
+++ b/tests/vector_stores/test_rockset.py
@@ -24,7 +24,6 @@ from llama_index.vector_stores import RocksetVectorStore
 from llama_index.vector_stores.types import (
     ExactMatchFilter,
     MetadataFilters,
-    NodeWithEmbedding,
     VectorStoreQuery,
 )
 from llama_index.schema import TextNode
@@ -48,25 +47,19 @@ def vector_store() -> Generator[RocksetVectorStore, None, None]:
     store = RocksetVectorStore(collection="test")
     store.add(
         [
-            NodeWithEmbedding(
-                node=TextNode(
-                    text="Apples are blue",
-                    metadata={"type": "fruit"},  # type: ignore[call-arg]
-                ),
+            TextNode(
+                text="Apples are blue",
+                metadata={"type": "fruit"},  # type: ignore[call-arg]
                 embedding=[0.9, 0.1],
             ),
-            NodeWithEmbedding(
-                node=TextNode(
-                    text="Tomatoes are black",
-                    metadata={"type": "veggie"},  # type: ignore[call-arg]
-                ),
+            TextNode(
+                text="Tomatoes are black",
+                metadata={"type": "veggie"},  # type: ignore[call-arg]
                 embedding=[0.5, 0.5],
             ),
-            NodeWithEmbedding(
-                node=TextNode(
-                    text="Brownies are orange",
-                    metadata={"type": "dessert"},  # type: ignore[call-arg]
-                ),
+            TextNode(
+                text="Brownies are orange",
+                metadata={"type": "dessert"},  # type: ignore[call-arg]
                 embedding=[0.1, 0.9],
             ),
         ]

--- a/tests/vector_stores/test_tair.py
+++ b/tests/vector_stores/test_tair.py
@@ -13,46 +13,33 @@ from llama_index.vector_stores import TairVectorStore
 from llama_index.vector_stores.types import (
     ExactMatchFilter,
     MetadataFilters,
-    NodeWithEmbedding,
     VectorStoreQuery,
 )
 
 
 @pytest.fixture
-def node_embeddings() -> List[NodeWithEmbedding]:
+def node_embeddings() -> List[TextNode]:
     return [
-        NodeWithEmbedding(
+        TextNode(
+            text="lorem ipsum",
+            id_="AF3BE6C4-5F43-4D74-B075-6B0E07900DE8",
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-0")},
+            metadata={"weight": 1.0, "rank": "a"},
             embedding=[1.0, 0.0],
-            node=TextNode(
-                text="lorem ipsum",
-                id_="AF3BE6C4-5F43-4D74-B075-6B0E07900DE8",
-                relationships={
-                    NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-0")
-                },
-                metadata={"weight": 1.0, "rank": "a"},
-            ),
         ),
-        NodeWithEmbedding(
+        TextNode(
+            text="lorem ipsum",
+            id_="7D9CD555-846C-445C-A9DD-F8924A01411D",
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-1")},
+            metadata={"weight": 2.0, "rank": "c"},
             embedding=[0.0, 1.0],
-            node=TextNode(
-                text="lorem ipsum",
-                id_="7D9CD555-846C-445C-A9DD-F8924A01411D",
-                relationships={
-                    NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-1")
-                },
-                metadata={"weight": 2.0, "rank": "c"},
-            ),
         ),
-        NodeWithEmbedding(
+        TextNode(
+            text="lorem ipsum",
+            id_="452D24AB-F185-414C-A352-590B4B9EE51B",
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-2")},
+            metadata={"weight": 3.0, "rank": "b"},
             embedding=[1.0, 1.0],
-            node=TextNode(
-                text="lorem ipsum",
-                id_="452D24AB-F185-414C-A352-590B4B9EE51B",
-                relationships={
-                    NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-2")
-                },
-                metadata={"weight": 3.0, "rank": "b"},
-            ),
         ),
     ]
 
@@ -62,7 +49,7 @@ def get_tair_url() -> str:
 
 
 @pytest.mark.skipif(Tair is None, reason="tair-py not installed")
-def test_add_stores_data(node_embeddings: List[NodeWithEmbedding]) -> None:
+def test_add_stores_data(node_embeddings: List[TextNode]) -> None:
     tair_url = get_tair_url()
     tair_vector_store = TairVectorStore(tair_url=tair_url, index_name="test_index")
 

--- a/tests/vector_stores/test_weaviate.py
+++ b/tests/vector_stores/test_weaviate.py
@@ -2,7 +2,6 @@ import sys
 from unittest.mock import MagicMock
 
 from llama_index.schema import NodeRelationship, RelatedNodeInfo, TextNode
-from llama_index.vector_stores.types import NodeWithEmbedding
 
 from llama_index.vector_stores.weaviate import WeaviateVectorStore
 
@@ -18,14 +17,12 @@ def test_weaviate_add() -> None:
 
     vector_store.add(
         [
-            NodeWithEmbedding(
-                node=TextNode(
-                    text="test node text",
-                    id_="test node id",
-                    relationships={
-                        NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test doc id")
-                    },
-                ),
+            TextNode(
+                text="test node text",
+                id_="test node id",
+                relationships={
+                    NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test doc id")
+                },
                 embedding=[0.5, 0.5],
             )
         ]


### PR DESCRIPTION
# Description

Clean up vector store interface to use `BaseNode` instead of `NodeWithEmbedding`

```
class VectorStore(Protocol):
    ...

    def add(
        self,
        nodes: List[BaseNode],
    ) -> List[str]:
        """Add nodes with embedding to vector store."""
        ...

```
Embeddings are now always stored in the `BaseNode` object in a consistent way.

# Impact
This should be a no-op change. Minimally impacting users who are directly operating on `VectorStore` and constructing their own `NodeWithEmbedding` objects.