### PR TITLE
Improve usability of `NodeWithScore`

### DIFF
--- a/llama_index/schema.py
+++ b/llama_index/schema.py
@@ -508,6 +508,15 @@ class Document(TextNode):
         """Get document ID."""
         return self.id_
 
+    def __str__(self) -> str:
+        source_text_truncated = truncate_text(
+            self.get_content().strip(), TRUNCATE_LENGTH
+        )
+        source_text_wrapped = textwrap.fill(
+            f"Text: {source_text_truncated}\n", width=WRAP_WIDTH
+        )
+        return f"Doc ID: {self.doc_id}\n{source_text_wrapped}"    
+
     def get_doc_id(self) -> str:
         """TODO: Deprecated: Get document ID."""
         return self.id_

--- a/llama_index/schema.py
+++ b/llama_index/schema.py
@@ -515,7 +515,7 @@ class Document(TextNode):
         source_text_wrapped = textwrap.fill(
             f"Text: {source_text_truncated}\n", width=WRAP_WIDTH
         )
-        return f"Doc ID: {self.doc_id}\n{source_text_wrapped}"    
+        return f"Doc ID: {self.doc_id}\n{source_text_wrapped}"
 
     def get_doc_id(self) -> str:
         """TODO: Deprecated: Get document ID."""

--- a/llama_index/schema.py
+++ b/llama_index/schema.py
@@ -239,20 +239,15 @@ class BaseNode(BaseComponent):
     def extra_info(self) -> Dict[str, Any]:
         """TODO: DEPRECATED: Extra info."""
         return self.metadata
-    
+
     def __str__(self) -> str:
         source_text_truncated = truncate_text(
             self.get_content().strip(), TRUNCATE_LENGTH
         )
         source_text_wrapped = textwrap.fill(
-            f"Text: {source_text_truncated}\n", 
-            width=WRAP_WIDTH
+            f"Text: {source_text_truncated}\n", width=WRAP_WIDTH
         )
-        return (
-            f"Node ID: {self.node_id}\n"
-            f"{source_text_wrapped}\n"
-        )
-        
+        return f"Node ID: {self.node_id}\n{source_text_wrapped}"
 
     def get_embedding(self) -> List[float]:
         """Get embedding.
@@ -430,10 +425,7 @@ class NodeWithScore(BaseComponent):
     score: Optional[float] = None
 
     def __str__(self) -> str:
-        return (
-            f"{self.node}"
-            f"Score: {self.score: 0.3f}\n"
-        )
+        return f"{self.node}\nScore: {self.score: 0.3f}\n"
 
     def get_score(self, raise_error: bool = False) -> float:
         """Get score."""
@@ -449,23 +441,31 @@ class NodeWithScore(BaseComponent):
     def class_name(cls) -> str:
         """Get class name."""
         return "NodeWithScore"
-    
+
     ##### pass through methods to BaseNode #####
     @property
     def node_id(self) -> str:
         return self.node.node_id
-    
+
+    @property
+    def id_(self) -> str:
+        return self.node.id_
+
     @property
     def text(self) -> str:
         if isinstance(self.node, TextNode):
             return self.node.text
         else:
             raise ValueError("Node must be a TextNode to get text.")
-        
+
     @property
     def metadata(self) -> Dict[str, Any]:
         return self.node.metadata
     
+    @property
+    def embedding(self) -> Optional[List[float]]:
+        return self.node.embedding
+
     def get_text(self) -> str:
         if isinstance(self.node, TextNode):
             return self.node.get_text()
@@ -474,7 +474,7 @@ class NodeWithScore(BaseComponent):
 
     def get_content(self, metadata_mode: MetadataMode = MetadataMode.NONE) -> str:
         return self.node.get_content(metadata_mode=metadata_mode)
-    
+
     def get_embedding(self) -> List[float]:
         return self.node.get_embedding()
 

--- a/llama_index/schema.py
+++ b/llama_index/schema.py
@@ -449,6 +449,34 @@ class NodeWithScore(BaseComponent):
     def class_name(cls) -> str:
         """Get class name."""
         return "NodeWithScore"
+    
+    ##### pass through methods to BaseNode #####
+    @property
+    def node_id(self) -> str:
+        return self.node.node_id
+    
+    @property
+    def text(self) -> str:
+        if isinstance(self.node, TextNode):
+            return self.node.text
+        else:
+            raise ValueError("Node must be a TextNode to get text.")
+        
+    @property
+    def metadata(self) -> Dict[str, Any]:
+        return self.node.metadata
+    
+    def get_text(self) -> str:
+        if isinstance(self.node, TextNode):
+            return self.node.get_text()
+        else:
+            raise ValueError("Node must be a TextNode to get text.")
+
+    def get_content(self, metadata_mode: MetadataMode = MetadataMode.NONE) -> str:
+        return self.node.get_content(metadata_mode=metadata_mode)
+    
+    def get_embedding(self) -> List[float]:
+        return self.node.get_embedding()
 
 
 # Document Classes for Readers

--- a/llama_index/schema.py
+++ b/llama_index/schema.py
@@ -461,7 +461,7 @@ class NodeWithScore(BaseComponent):
     @property
     def metadata(self) -> Dict[str, Any]:
         return self.node.metadata
-    
+
     @property
     def embedding(self) -> Optional[List[float]]:
         return self.node.embedding

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,31 @@
+
+import pytest
+from llama_index.schema import TextNode, NodeWithScore
+
+@pytest.fixture
+def text_node() -> TextNode:
+    return TextNode(
+        text='hello world',
+        metadata={'foo': 'bar'},
+        embedding=[0.1, 0.2, 0.3],
+    )
+
+@pytest.fixture
+def node_with_score(text_node: TextNode) -> NodeWithScore:
+    return NodeWithScore(
+        node=text_node,
+        score=0.5,
+    )
+
+def test_node_with_score_passthrough(node_with_score: NodeWithScore) -> None:
+    _ = node_with_score.id_
+    _ = node_with_score.node_id
+    _ = node_with_score.text
+    _ = node_with_score.metadata
+    _ = node_with_score.embedding
+    _ = node_with_score.get_text()
+    _ = node_with_score.get_content()
+    _ = node_with_score.get_embedding()
+
+
+

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,14 +1,15 @@
-
 import pytest
 from llama_index.schema import TextNode, NodeWithScore
+
 
 @pytest.fixture
 def text_node() -> TextNode:
     return TextNode(
-        text='hello world',
-        metadata={'foo': 'bar'},
+        text="hello world",
+        metadata={"foo": "bar"},
         embedding=[0.1, 0.2, 0.3],
     )
+
 
 @pytest.fixture
 def node_with_score(text_node: TextNode) -> NodeWithScore:
@@ -16,6 +17,7 @@ def node_with_score(text_node: TextNode) -> NodeWithScore:
         node=text_node,
         score=0.5,
     )
+
 
 def test_node_with_score_passthrough(node_with_score: NodeWithScore) -> None:
     _ = node_with_score.id_
@@ -26,6 +28,3 @@ def test_node_with_score_passthrough(node_with_score: NodeWithScore) -> None:
     _ = node_with_score.get_text()
     _ = node_with_score.get_content()
     _ = node_with_score.get_embedding()
-
-
-


### PR DESCRIPTION
# Description

1. Add pass passthrough methods to access underlying `BaseNode`
```
node.text / node.get_text() / node.get_content()
node.node_id / node.id_
node.embedding / node.get_embedding()
node.metadata 
```



3. Make default `__str__` prettier (for BaseNode, NodeWithScore, Document)

```python
for node in response.source_nodes:
    print(node)
```

```
Node ID: 5f589d5f-8509-45d9-93b2-bfeccb2eb245
Text: That seemed unnatural to me, and on this point the rest of the
world is coming around to my way of thinking, but at the time it
caused a lot of friction.Toward the end of the year I spent much of my
time surreptitiously working on On Lisp, which I had by this time
gotten a contract to publish.The good part was that I got paid huge
amounts of mon...
Score:  0.818

Node ID: c7a2031d-f37e-4136-b3af-5caa53506e03
Text: There, right on the wall, was something you could make that
would last.Paintings didn't become obsolete.Some of the best ones were
hundreds of years old.And moreover this was something you could make a
living doing.Not as easily as you could by writing software, of
course, but I thought if you were really industrious and lived really
cheaply, it...
Score:  0.818
```