### PR TITLE
Remove newlines from OpenAI embeddings again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 ### Bug Fixes / Nits
 - Fixed small `_index` bug in `ElasticSearchReader` (#7570)
 - Fixed bug with prompt helper settings in global service contexts (#7576)
+- Remove newlines from openai embeddings again (#7588)
+- Fixed small bug with setting `query_wrapper_prompt` in the service context (#7585)
 
 ## [0.8.21] - 2023-09-06
 

--- a/llama_index/embeddings/openai.py
+++ b/llama_index/embeddings/openai.py
@@ -115,13 +115,8 @@ def get_embedding(
     like matplotlib, plotly, scipy, sklearn.
 
     """
-    if (
-        engine is not None
-        and engine.endswith("001")
-        and not engine.endswith("code-001")
-    ):
-        # replace newlines, which can negatively affect performance on text-001 models.
-        text = text.replace("\n", " ")
+    text = text.replace("\n", " ")
+
     return openai.Embedding.create(input=[text], model=engine, **kwargs)["data"][0][
         "embedding"
     ]
@@ -143,13 +138,7 @@ async def aget_embedding(
     like matplotlib, plotly, scipy, sklearn.
 
     """
-    if (
-        engine is not None
-        and engine.endswith("001")
-        and not engine.endswith("code-001")
-    ):
-        # replace newlines, which can negatively affect performance on text-001 models.
-        text = text.replace("\n", " ")
+    text = text.replace("\n", " ")
 
     return (await openai.Embedding.acreate(input=[text], model=engine, **kwargs))[
         "data"
@@ -174,13 +163,7 @@ def get_embeddings(
     """
     assert len(list_of_text) <= 2048, "The batch size should not be larger than 2048."
 
-    if (
-        engine is not None
-        and engine.endswith("001")
-        and not engine.endswith("code-001")
-    ):
-        # replace newlines, which can negatively affect performance on text-001 models.
-        list_of_text = [text.replace("\n", " ") for text in list_of_text]
+    list_of_text = [text.replace("\n", " ") for text in list_of_text]
 
     data = openai.Embedding.create(input=list_of_text, model=engine, **kwargs).data
     return [d["embedding"] for d in data]
@@ -204,13 +187,7 @@ async def aget_embeddings(
     """
     assert len(list_of_text) <= 2048, "The batch size should not be larger than 2048."
 
-    if (
-        engine is not None
-        and engine.endswith("001")
-        and not engine.endswith("code-001")
-    ):
-        # replace newlines, which can negatively affect performance on text-001 models.
-        list_of_text = [text.replace("\n", " ") for text in list_of_text]
+    list_of_text = [text.replace("\n", " ") for text in list_of_text]
 
     data = (
         await openai.Embedding.acreate(input=list_of_text, model=engine, **kwargs)


### PR DESCRIPTION
# Description

Some initial testing is showing that this change was actually hurting embeddings and retrieval. Removing newlines seems like the right thing to do, at least right now.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
