### PR TITLE
Fixed issue with GPTTreeIndex example retrieving answer from root node

### DIFF
--- a/examples/paul_graham_essay/TestEssay.ipynb
+++ b/examples/paul_graham_essay/TestEssay.ipynb
@@ -341,7 +341,7 @@
    "source": [
     "# directly retrieve response from root nodes instead of traversing tree\n",
     "query_engine = index_with_query.as_query_engine(retriever_mode=\"root\")\n",
-    "response = index_with_query.query(query_str)"
+    "response = query_engine.query(query_str)"
    ]
   },
   {


### PR DESCRIPTION
# Description

The TestEssay notebook in the paul_graham_essay example had one part broken which caused it to fail. It was a simple fix - the wrong variable was being referenced in one of the statements.

## Type of Change

Please delete options that are not relevant.

- [ X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually. It is a simple one line change. Notebook was not working without the fix - verified it works properly post fix.
