### PR TITLE
Fix relationships in hierarchical node parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 - Make sure context and system prompt is included in prompt for first chat for llama2 (#7597)
+- Fix relationships for small documents in hierarchical node parser (#7611)
 
 ### Breaking Changes
 - Update milvus vector store to support filters and dynamic schemas (#7286)

--- a/llama_index/node_parser/hierarchical.py
+++ b/llama_index/node_parser/hierarchical.py
@@ -162,11 +162,14 @@ class HierarchicalNodeParser(NodeParser):
             )
             # add parent relationship from sub node to parent node
             # add child relationship from parent node to sub node
-            for sub_node in cur_sub_nodes:
-                _add_parent_child_relationship(
-                    parent_node=node,
-                    child_node=sub_node,
-                )
+            # NOTE: Only add relationships if level > 0, since we don't want to add
+            # relationships for the top-level document objects that we are splitting
+            if level > 0:
+                for sub_node in cur_sub_nodes:
+                    _add_parent_child_relationship(
+                        parent_node=node,
+                        child_node=sub_node,
+                    )
 
             sub_nodes.extend(cur_sub_nodes)
 


### PR DESCRIPTION
# Description

If the input document is shorter than all hierarchical chunk sizes, there is a strong possibility of merging all the way up the hierarchy.

However, since we create references to parent nodes that are never inserted (i.e. the input documents themselves), this leads to key errors.

This PR fixes that.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

