### PR TITLE
add simple chat engine to as_chat_engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## Unreleased
+
+### Bug Fixes / Nits
+- Allowed `simple` mode to work with `as_chat_engine()` (#7637)
+
 ## [0.8.24] - 2023-09-11
 
 ## New Features

--- a/llama_index/indices/base.py
+++ b/llama_index/indices/base.py
@@ -404,9 +404,7 @@ class BaseIndex(Generic[IS], ABC):
         elif chat_mode == ChatMode.SIMPLE:
             from llama_index.chat_engine import SimpleChatEngine
 
-            service_context = cast(ServiceContext, kwargs["service_context"])
             return SimpleChatEngine.from_defaults(
-                service_context=service_context,
                 **kwargs,
             )
         else:

--- a/llama_index/indices/base.py
+++ b/llama_index/indices/base.py
@@ -401,6 +401,14 @@ class BaseIndex(Generic[IS], ABC):
                 )
             else:
                 raise ValueError(f"Unknown chat mode: {chat_mode}")
+        elif chat_mode == ChatMode.SIMPLE:
+            from llama_index.chat_engine import SimpleChatEngine
+
+            service_context = cast(ServiceContext, kwargs["service_context"])
+            return SimpleChatEngine.from_defaults(
+                service_context=service_context,
+                **kwargs,
+            )
         else:
             raise ValueError(f"Unknown chat mode: {chat_mode}")
 


### PR DESCRIPTION
# Description

While it doesn't make total sense to include this in `as_chat_engine()`, it does make it easier to instantiate the chat engine itself, and lines up with expectations from our docs.

Fixes https://github.com/jerryjliu/llama_index/issues/7622

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

