### PR TITLE
add debug_truncate_chunk parameter in refine response kwargs

### DIFF
--- a/llama_index/response_synthesizers/refine.py
+++ b/llama_index/response_synthesizers/refine.py
@@ -77,6 +77,7 @@ class Refine(BaseSynthesizer):
         refine_template: Optional[BasePromptTemplate] = None,
         streaming: bool = False,
         verbose: bool = False,
+        debug_truncate_chunk: Optional[int] = None,
         structured_answer_filtering: bool = False,
         program_factory: Optional[
             Callable[[BasePromptTemplate], BasePydanticProgram]
@@ -86,6 +87,7 @@ class Refine(BaseSynthesizer):
         self._text_qa_template = text_qa_template or DEFAULT_TEXT_QA_PROMPT_SEL
         self._refine_template = refine_template or DEFAULT_REFINE_PROMPT_SEL
         self._verbose = verbose
+        self._debug_truncate_chunk = debug_truncate_chunk
         self._structured_answer_filtering = structured_answer_filtering
 
         if self._streaming and self._structured_answer_filtering:
@@ -116,6 +118,7 @@ class Refine(BaseSynthesizer):
                 response = self._give_response_single(
                     query_str,
                     text_chunk,
+
                 )
             else:
                 # refine response if possible
@@ -214,7 +217,7 @@ class Refine(BaseSynthesizer):
             response = get_response_text(response)
 
         fmt_text_chunk = truncate_text(
-            text_chunk, response_kwargs.get("debug_truncate_chunk", 50)
+            text_chunk, self._debug_truncate_chunk or 50
         )
         logger.debug(f"> Refine context: {fmt_text_chunk}")
         if self._verbose:
@@ -319,7 +322,7 @@ class Refine(BaseSynthesizer):
             response = get_response_text(response)
 
         fmt_text_chunk = text(
-            text_chunk, response_kwargs.get("debug_truncate_chunk", 50)
+            text_chunk, self._debug_truncate_chunk or 50
         )
         logger.debug(f"> Refine context: {fmt_text_chunk}")
 

--- a/llama_index/response_synthesizers/refine.py
+++ b/llama_index/response_synthesizers/refine.py
@@ -213,7 +213,9 @@ class Refine(BaseSynthesizer):
         if isinstance(response, Generator):
             response = get_response_text(response)
 
-        fmt_text_chunk = truncate_text(text_chunk, 50)
+        fmt_text_chunk = truncate_text(
+            text_chunk, response_kwargs.get("debug_truncate_chunk", 50)
+        )
         logger.debug(f"> Refine context: {fmt_text_chunk}")
         if self._verbose:
             print(f"> Refine context: {fmt_text_chunk}")
@@ -316,7 +318,9 @@ class Refine(BaseSynthesizer):
         if isinstance(response, Generator):
             response = get_response_text(response)
 
-        fmt_text_chunk = truncate_text(text_chunk, 50)
+        fmt_text_chunk = text(
+            text_chunk, response_kwargs.get("debug_truncate_chunk", 50)
+        )
         logger.debug(f"> Refine context: {fmt_text_chunk}")
 
         # NOTE: partial format refine template with query_str and existing_answer here


### PR DESCRIPTION
Useful for debugging refine prompts when chunks are larger than 50 chars.
Name of parameter is arbitrary, and should probably be changed.

# Description

Add on option to set the truncate length for a chunk when logging intermediate refine results.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
