### PR TITLE
Fix azure streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes / Nits
 - Allowed `simple` mode to work with `as_chat_engine()` (#7637)
+- Fixed index error in azure streaming (#7646)
 
 ## [0.8.24] - 2023-09-11
 

--- a/llama_index/llms/azure_openai.py
+++ b/llama_index/llms/azure_openai.py
@@ -6,7 +6,6 @@ from llama_index.callbacks import CallbackManager
 from llama_index.llms.openai import OpenAI
 
 AZURE_OPENAI_API_TYPE = "azure"
-AZURE_OPENAI_VERSION = "2023-08-01-preview"
 
 
 class AzureOpenAI(OpenAI):
@@ -47,7 +46,7 @@ class AzureOpenAI(OpenAI):
         api_key: Optional[str] = None,
         api_type: Optional[str] = AZURE_OPENAI_API_TYPE,
         api_base: Optional[str] = None,
-        api_version: Optional[str] = AZURE_OPENAI_VERSION,
+        api_version: Optional[str] = None,
         callback_manager: Optional[CallbackManager] = None,
         **kwargs: Any,
     ) -> None:

--- a/llama_index/llms/openai.py
+++ b/llama_index/llms/openai.py
@@ -226,7 +226,10 @@ class OpenAI(LLM):
                 stream=True,
                 **all_kwargs,
             ):
-                delta = response["choices"][0]["delta"]
+                if len(response["choices"]) > 0:
+                    delta = response["choices"][0]["delta"]
+                else:
+                    delta = ""
                 role = delta.get("role", "assistant")
                 content_delta = delta.get("content", "") or ""
                 content += content_delta
@@ -302,7 +305,10 @@ class OpenAI(LLM):
                 stream=True,
                 **all_kwargs,
             ):
-                delta = response["choices"][0]["text"]
+                if len(response["choices"]) > 0:
+                    delta = response["choices"][0]["text"]
+                else:
+                    delta = ""
                 text += delta
                 yield CompletionResponse(
                     delta=delta,
@@ -439,7 +445,10 @@ class OpenAI(LLM):
                 stream=True,
                 **all_kwargs,
             ):
-                delta = response["choices"][0]["delta"]
+                if len(response["choices"]) > 0:
+                    delta = response["choices"][0]["delta"]
+                else:
+                    delta = ""
                 role = delta.get("role", "assistant")
                 content_delta = delta.get("content", "") or ""
                 content += content_delta
@@ -517,7 +526,10 @@ class OpenAI(LLM):
                 stream=True,
                 **all_kwargs,
             ):
-                delta = response["choices"][0]["text"]
+                if len(response["choices"]) > 0:
+                    delta = response["choices"][0]["text"]
+                else:
+                    delta = ""
                 text += delta
                 yield CompletionResponse(
                     delta=delta,


### PR DESCRIPTION
# Description

In newer versions of the azure api, the first response when streaming has no content, only filtering/safety information. This PR fixes the index error that occurs because of this.

Furthermore, I removed the default API version, as it is inconsistent with our docs and also breaks users who are specifying the API the old way.

Fixes https://github.com/jerryjliu/llama_index/issues/7640

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

