### PR TITLE
Fix  #7649: Make model_url optional llama-cpp

### DIFF
--- a/llama_index/llms/llama_cpp.py
+++ b/llama_index/llms/llama_cpp.py
@@ -2,11 +2,9 @@ import os
 from typing import Any, Callable, Dict, Optional, Sequence
 
 import requests
-
-from llama_index.bridge.pydantic import Field, PrivateAttr
-
 from tqdm import tqdm
 
+from llama_index.bridge.pydantic import Field, PrivateAttr
 from llama_index.callbacks import CallbackManager
 from llama_index.constants import DEFAULT_CONTEXT_WINDOW, DEFAULT_NUM_OUTPUTS
 from llama_index.llms.base import (
@@ -39,7 +37,9 @@ DEFAULT_LLAMA_CPP_GGUF_MODEL = (
 
 
 class LlamaCPP(CustomLLM):
-    model_url: str = Field(description="The URL llama-cpp model to download and use.")
+    model_url: Optional[str] = Field(
+        description="The URL llama-cpp model to download and use."
+    )
     model_path: Optional[str] = Field(
         description="The path to the llama-cpp model to use."
     )


### PR DESCRIPTION
# Description

Quick fix for #7649. Make `model_url` optional when initialising `LlamaCPP`.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
