### PR TITLE
Add agent step callback type

### DIFF
--- a/llama_index/agent/openai_agent.py
+++ b/llama_index/agent/openai_agent.py
@@ -337,10 +337,15 @@ class BaseOpenAIAgent(BaseAgent):
         chat_history: Optional[List[ChatMessage]] = None,
         function_call: Union[str, dict] = "auto",
     ) -> AgentChatResponse:
-        chat_response = self._chat(
-            message, chat_history, function_call, mode=ChatResponseMode.WAIT
-        )
-        assert isinstance(chat_response, AgentChatResponse)
+        with self.callback_manager.event(
+            CBEventType.AGENT_STEP,
+            payload={EventPayload.MESSAGES: [message]},
+        ) as e:
+            chat_response = self._chat(
+                message, chat_history, function_call, mode=ChatResponseMode.WAIT
+            )
+            assert isinstance(chat_response, AgentChatResponse)
+            e.on_end(payload={EventPayload.RESPONSE: chat_response})
         return chat_response
 
     @trace_method("chat")
@@ -350,10 +355,15 @@ class BaseOpenAIAgent(BaseAgent):
         chat_history: Optional[List[ChatMessage]] = None,
         function_call: Union[str, dict] = "auto",
     ) -> AgentChatResponse:
-        chat_response = await self._achat(
-            message, chat_history, function_call, mode=ChatResponseMode.WAIT
-        )
-        assert isinstance(chat_response, AgentChatResponse)
+        with self.callback_manager.event(
+            CBEventType.AGENT_STEP,
+            payload={EventPayload.MESSAGES: [message]},
+        ) as e:
+            chat_response = await self._achat(
+                message, chat_history, function_call, mode=ChatResponseMode.WAIT
+            )
+            assert isinstance(chat_response, AgentChatResponse)
+            e.on_end(payload={EventPayload.RESPONSE: chat_response})
         return chat_response
 
     @trace_method("chat")
@@ -363,10 +373,15 @@ class BaseOpenAIAgent(BaseAgent):
         chat_history: Optional[List[ChatMessage]] = None,
         function_call: Union[str, dict] = "auto",
     ) -> StreamingAgentChatResponse:
-        chat_response = self._chat(
-            message, chat_history, function_call, mode=ChatResponseMode.STREAM
-        )
-        assert isinstance(chat_response, StreamingAgentChatResponse)
+        with self.callback_manager.event(
+            CBEventType.AGENT_STEP,
+            payload={EventPayload.MESSAGES: [message]},
+        ) as e:
+            chat_response = self._chat(
+                message, chat_history, function_call, mode=ChatResponseMode.STREAM
+            )
+            assert isinstance(chat_response, StreamingAgentChatResponse)
+            e.on_end(payload={EventPayload.RESPONSE: chat_response})
         return chat_response
 
     @trace_method("chat")
@@ -376,10 +391,15 @@ class BaseOpenAIAgent(BaseAgent):
         chat_history: Optional[List[ChatMessage]] = None,
         function_call: Union[str, dict] = "auto",
     ) -> StreamingAgentChatResponse:
-        chat_response = await self._achat(
-            message, chat_history, function_call, mode=ChatResponseMode.STREAM
-        )
-        assert isinstance(chat_response, StreamingAgentChatResponse)
+        with self.callback_manager.event(
+            CBEventType.AGENT_STEP,
+            payload={EventPayload.MESSAGES: [message]},
+        ) as e:
+            chat_response = await self._achat(
+                message, chat_history, function_call, mode=ChatResponseMode.STREAM
+            )
+            assert isinstance(chat_response, StreamingAgentChatResponse)
+            e.on_end(payload={EventPayload.RESPONSE: chat_response})
         return chat_response
 
 

--- a/llama_index/callbacks/schema.py
+++ b/llama_index/callbacks/schema.py
@@ -40,6 +40,7 @@ class CBEventType(str, Enum):
     FUNCTION_CALL = "function_call"
     RERANKING = "reranking"
     EXCEPTION = "exception"
+    AGENT_STEP = "agent_step"
 
 
 class EventPayload(str, Enum):

--- a/llama_index/callbacks/wandb_callback.py
+++ b/llama_index/callbacks/wandb_callback.py
@@ -387,6 +387,8 @@ class WandbCallbackHandler(BaseCallbackHandler):
             span_kind = self._trace_tree.SpanKind.LLM
         elif event_type == CBEventType.QUERY:
             span_kind = self._trace_tree.SpanKind.AGENT
+        elif event_type == CBEventType.AGENT_STEP:
+            span_kind = self._trace_tree.SpanKind.AGENT
         elif event_type == CBEventType.RETRIEVE:
             span_kind = self._trace_tree.SpanKind.TOOL
         elif event_type == CBEventType.SYNTHESIZE:


### PR DESCRIPTION
# Description

Agent steps did not have a proper event type. This PR adds that.

Fixes https://github.com/jerryjliu/llama_index/issues/7639

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense
- [x] Test script

```python
from llama_index.agent import OpenAIAgent
from llama_index.tools import FunctionTool
from llama_index.callbacks import LlamaDebugHandler, CallbackManager
from llama_index.llms import OpenAI


def multiply(a: int, b: int) -> int:
    """Multiple two integers and returns the result integer"""
    return a * b


multiply_tool = FunctionTool.from_defaults(fn=multiply)


def add(a: int, b: int) -> int:
    """Add two integers and returns the result integer"""
    return a + b


add_tool = FunctionTool.from_defaults(fn=add)
llm = OpenAI(model="gpt-3.5-turbo-0613")
cb_handler = LlamaDebugHandler(print_trace_on_end=True)
callback_manager = CallbackManager(handlers=[cb_handler])
agent = OpenAIAgent.from_tools(
    [multiply_tool, add_tool], llm=llm, verbose=True, callback_manager=callback_manager
)
agent.chat("What is 2 * 3 + 1?")
```

Output:
```
**********
Trace: chat
    |_CBEventType.AGENT_STEP ->  2.914991 seconds
      |_CBEventType.LLM ->  1.083966 seconds
      |_CBEventType.FUNCTION_CALL ->  0.000165 seconds
      |_CBEventType.LLM ->  1.03474 seconds
      |_CBEventType.FUNCTION_CALL ->  0.000186 seconds
      |_CBEventType.LLM ->  0.793178 seconds
**********
```