### PR TITLE
default delta should be a dict

### DIFF
--- a/llama_index/llms/openai.py
+++ b/llama_index/llms/openai.py
@@ -229,7 +229,7 @@ class OpenAI(LLM):
                 if len(response["choices"]) > 0:
                     delta = response["choices"][0]["delta"]
                 else:
-                    delta = ""
+                    delta = {}
                 role = delta.get("role", "assistant")
                 content_delta = delta.get("content", "") or ""
                 content += content_delta
@@ -448,7 +448,7 @@ class OpenAI(LLM):
                 if len(response["choices"]) > 0:
                     delta = response["choices"][0]["delta"]
                 else:
-                    delta = ""
+                    delta = {}
                 role = delta.get("role", "assistant")
                 content_delta = delta.get("content", "") or ""
                 content += content_delta


### PR DESCRIPTION
# Description

Small fix -- default delta should be a dict, not a string

Fixes https://github.com/jerryjliu/llama_index/issues/7657

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

