### PR TITLE
Text Splitters Refactor: Separate Markdown splitter from Markdown Reader

### DIFF
--- a/llama_index/readers/file/markdown_reader.py
+++ b/llama_index/readers/file/markdown_reader.py
@@ -5,7 +5,7 @@ Contains parser for md files.
 """
 import re
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Dict, List, Optional
 
 from llama_index.readers.base import BaseReader
 from llama_index.schema import Document
@@ -31,45 +31,6 @@ class MarkdownReader(BaseReader):
         self._remove_hyperlinks = remove_hyperlinks
         self._remove_images = remove_images
 
-    def markdown_to_tups(self, markdown_text: str) -> List[Tuple[Optional[str], str]]:
-        """Convert a markdown file to a dictionary.
-
-        The keys are the headers and the values are the text under each header.
-
-        """
-        markdown_tups: List[Tuple[Optional[str], str]] = []
-        lines = markdown_text.split("\n")
-
-        current_header = None
-        current_text = ""
-
-        for line in lines:
-            header_match = re.match(r"^#+\s", line)
-            if header_match:
-                if current_header is not None:
-                    if current_text == "" or None:
-                        continue
-                    markdown_tups.append((current_header, current_text))
-
-                current_header = line
-                current_text = ""
-            else:
-                current_text += line + "\n"
-        markdown_tups.append((current_header, current_text))
-
-        if current_header is not None:
-            # pass linting, assert keys are defined
-            markdown_tups = [
-                (re.sub(r"#", "", cast(str, key)).strip(), re.sub(r"<.*?>", "", value))
-                for key, value in markdown_tups
-            ]
-        else:
-            markdown_tups = [
-                (key, re.sub("<.*?>", "", value)) for key, value in markdown_tups
-            ]
-
-        return markdown_tups
-
     def remove_images(self, content: str) -> str:
         """Get a dictionary of a markdown file from its path."""
         pattern = r"!{1}\[\[(.*)\]\]"
@@ -86,9 +47,7 @@ class MarkdownReader(BaseReader):
         """Initialize the parser with the config."""
         return {}
 
-    def parse_tups(
-        self, filepath: Path, errors: str = "ignore"
-    ) -> List[Tuple[Optional[str], str]]:
+    def parse_file(self, filepath: Path, errors: str = "ignore") -> str:
         """Parse file into tuples."""
         with open(filepath, "r", encoding="utf-8") as f:
             content = f.read()
@@ -96,21 +55,11 @@ class MarkdownReader(BaseReader):
             content = self.remove_hyperlinks(content)
         if self._remove_images:
             content = self.remove_images(content)
-        markdown_tups = self.markdown_to_tups(content)
-        return markdown_tups
+        return content
 
     def load_data(
         self, file: Path, extra_info: Optional[Dict] = None
     ) -> List[Document]:
         """Parse file into string."""
-        tups = self.parse_tups(file)
-        results = []
-        # TODO: don't include headers right now
-        for header, value in tups:
-            if header is None:
-                results.append(Document(text=value, metadata=extra_info or {}))
-            else:
-                results.append(
-                    Document(text=f"\n\n{header}\n{value}", metadata=extra_info or {})
-                )
-        return results
+        content = self.parse_file(file)
+        return [Document(text=content, metadata=extra_info or {})]

--- a/llama_index/readers/file/markdown_reader.py
+++ b/llama_index/readers/file/markdown_reader.py
@@ -5,7 +5,7 @@ Contains parser for md files.
 """
 import re
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 from llama_index.readers.base import BaseReader
 from llama_index.schema import Document
@@ -31,6 +31,45 @@ class MarkdownReader(BaseReader):
         self._remove_hyperlinks = remove_hyperlinks
         self._remove_images = remove_images
 
+    def markdown_to_tups(self, markdown_text: str) -> List[Tuple[Optional[str], str]]:
+        """Convert a markdown file to a dictionary.
+
+        The keys are the headers and the values are the text under each header.
+
+        """
+        markdown_tups: List[Tuple[Optional[str], str]] = []
+        lines = markdown_text.split("\n")
+
+        current_header = None
+        current_text = ""
+
+        for line in lines:
+            header_match = re.match(r"^#+\s", line)
+            if header_match:
+                if current_header is not None:
+                    if current_text == "" or None:
+                        continue
+                    markdown_tups.append((current_header, current_text))
+
+                current_header = line
+                current_text = ""
+            else:
+                current_text += line + "\n"
+        markdown_tups.append((current_header, current_text))
+
+        if current_header is not None:
+            # pass linting, assert keys are defined
+            markdown_tups = [
+                (re.sub(r"#", "", cast(str, key)).strip(), re.sub(r"<.*?>", "", value))
+                for key, value in markdown_tups
+            ]
+        else:
+            markdown_tups = [
+                (key, re.sub("<.*?>", "", value)) for key, value in markdown_tups
+            ]
+
+        return markdown_tups
+
     def remove_images(self, content: str) -> str:
         """Get a dictionary of a markdown file from its path."""
         pattern = r"!{1}\[\[(.*)\]\]"
@@ -47,7 +86,9 @@ class MarkdownReader(BaseReader):
         """Initialize the parser with the config."""
         return {}
 
-    def parse_file(self, filepath: Path, errors: str = "ignore") -> str:
+    def parse_tups(
+        self, filepath: Path, errors: str = "ignore"
+    ) -> List[Tuple[Optional[str], str]]:
         """Parse file into tuples."""
         with open(filepath, "r", encoding="utf-8") as f:
             content = f.read()
@@ -55,11 +96,21 @@ class MarkdownReader(BaseReader):
             content = self.remove_hyperlinks(content)
         if self._remove_images:
             content = self.remove_images(content)
-        return content
+        markdown_tups = self.markdown_to_tups(content)
+        return markdown_tups
 
     def load_data(
         self, file: Path, extra_info: Optional[Dict] = None
     ) -> List[Document]:
         """Parse file into string."""
-        content = self.parse_file(file)
-        return [Document(text=content, metadata=extra_info or {})]
+        tups = self.parse_tups(file)
+        results = []
+        # TODO: don't include headers right now
+        for header, value in tups:
+            if header is None:
+                results.append(Document(text=value, metadata=extra_info or {}))
+            else:
+                results.append(
+                    Document(text=f"\n\n{header}\n{value}", metadata=extra_info or {})
+                )
+        return results

--- a/llama_index/text_splitter/markdown_splitter.py
+++ b/llama_index/text_splitter/markdown_splitter.py
@@ -1,0 +1,58 @@
+"""Markdown splitter."""
+from typing import List, Optional
+from llama_index.bridge.pydantic import Field
+
+from llama_index.callbacks.base import CallbackManager
+from llama_index.callbacks.schema import CBEventType, EventPayload
+from llama_index.text_splitter.types import TextSplitter
+import re
+
+
+class MarkdownSplitter(TextSplitter):
+    """Implementation of splitting text for Markdown files."""
+
+    callback_manager: CallbackManager = Field(
+        default_factory=CallbackManager, exclude=True
+    )
+
+    def __init__(
+        self,
+        callback_manager: Optional[CallbackManager] = None,
+    ):
+        callback_manager = callback_manager or CallbackManager([])
+        super().__init__(
+            callback_manager=callback_manager,
+        )
+
+    @classmethod
+    def class_name(cls) -> str:
+        """Get class name."""
+        return "MarkdownSplitter"
+
+    def split_text(self, text: str) -> List[str]:
+        if text == "":
+            return []
+
+        with self.callback_manager.event(
+            CBEventType.CHUNKING, payload={EventPayload.CHUNKS: [text]}
+        ):
+            return self._split_text(text)
+
+    def _split_text(self, text: str) -> List[str]:
+        markdown_sections = []
+        lines = text.split("\n")
+
+        current_section = ""
+
+        for line in lines:
+            header_match = re.match(r"^(#+)\s(.*)", line)
+            if header_match:
+                if current_section != "":
+                    markdown_sections.append(current_section.strip())
+                current_section = f"{header_match.group(2)}\n"
+            else:
+                current_section += line + "\n"
+
+        markdown_sections.append(current_section.strip())
+
+        return markdown_sections

--- a/tests/text_splitter/test_markdown_splitter.py
+++ b/tests/text_splitter/test_markdown_splitter.py
@@ -1,0 +1,46 @@
+from llama_index.text_splitter.markdown_splitter import MarkdownSplitter
+
+
+def test_header_splits() -> None:
+    markdown_splitter = MarkdownSplitter()
+
+    splits = markdown_splitter.split_text(
+        """# Header 1
+
+Header 1 content
+
+# Header 2
+Header 2 content
+    """
+    )
+    print(splits)
+    assert len(splits) == 2
+
+
+def test_non_header_splits() -> None:
+    markdown_splitter = MarkdownSplitter()
+
+    splits = markdown_splitter.split_text(
+        """# Header 1
+
+#Not a header
+Also # not a header
+    # Still not a header
+    """
+    )
+    assert len(splits) == 1
+
+
+def test_pre_header_content() -> None:
+    markdown_splitter = MarkdownSplitter()
+
+    splits = markdown_splitter.split_text(
+        """
+pre-header content
+
+# Header 1
+Content
+## Sub-header
+    """
+    )
+    assert len(splits) == 3


### PR DESCRIPTION
# Description

- Separate the text splitting logic from MarkdownReader

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
