### PR TITLE
use json.loads() with ast.literal_eval() as fallback option for the output_parser of the ReAct agent

### DIFF
--- a/llama_index/agent/react/output_parser.py
+++ b/llama_index/agent/react/output_parser.py
@@ -10,6 +10,7 @@ from llama_index.agent.react.types import (
     ActionReasoningStep,
 )
 import ast
+import json
 
 import re
 
@@ -77,10 +78,11 @@ class ReActOutputParser(BaseOutputParser):
             thought, action, action_input = extract_tool_use(output)
             json_str = extract_json_str(action_input)
 
-            # NOTE: we found that json.loads does not reliably parse
-            # json with single quotes, so we use ast instead
-            # action_input_dict = json.loads(json_str)
-            action_input_dict = ast.literal_eval(json_str)
+            # First we try json, if this fails we use ast
+            try:
+                action_input_dict = json.loads(json_str)
+            except json.JSONDecodeError:
+                action_input_dict = ast.literal_eval(json_str)
 
             return ActionReasoningStep(
                 thought=thought, action=action, action_input=action_input_dict


### PR DESCRIPTION
At the moment ast.literal_eval is used to decode a JSON string. However, if a tool uses booleans, ast fails because in the JSON format the boolean keywords are lowercase. 

To fix this, we switch to json.loads as primary decoder and we use ast as fallback option when json.loads failes.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
