### PR TITLE
Fix text splitter ids for hierarchical node parsers

### DIFF
--- a/llama_index/node_parser/hierarchical.py
+++ b/llama_index/node_parser/hierarchical.py
@@ -103,7 +103,9 @@ class HierarchicalNodeParser(NodeParser):
             if chunk_sizes is None:
                 chunk_sizes = [2048, 512, 128]
 
-            text_splitter_ids = ["2048", "512", "128"]
+            text_splitter_ids = [
+                f"chunk_size_{chunk_size}" for chunk_size in chunk_sizes
+            ]
             text_splitter_map = {}
             for chunk_size, text_splitter_id in zip(chunk_sizes, text_splitter_ids):
                 text_splitter_map[text_splitter_id] = get_default_text_splitter(


### PR DESCRIPTION
# Description

Quick patch for setting up the text-splitter-ids to match the chunk sizes in `HierarchicalNodeParser`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
