### PR TITLE
Add CustomQueryEngine class

### DIFF
--- a/docs/core_modules/query_modules/query_engine/modules.md
+++ b/docs/core_modules/query_modules/query_engine/modules.md
@@ -2,10 +2,16 @@
 
 
 ## Basic
+
+First, check out our [module guide on Indexes](/core_modules/data_modules/index/modules.md) for in-depth guides for each index (vector index, summary index, knowledge graph index). Each index corresponds to a default query engine for that index.
+
+Then check out the rest of the sections below.
+
 ```{toctree}
 ---
 maxdepth: 1
 ---
+Custom Query Engine </examples/query_engine/custom_query_engine.ipynb>
 Retriever Query Engine </examples/query_engine/CustomRetrievers.ipynb>
 ```
 

--- a/docs/core_modules/query_modules/query_engine/usage_pattern.md
+++ b/docs/core_modules/query_modules/query_engine/usage_pattern.md
@@ -94,3 +94,28 @@ streaming_response.print_response_stream()
 * Read the full [streaming guide](/core_modules/query_modules/query_engine/streaming.md)
 * See an [end-to-end example](/examples/customization/streaming/SimpleIndexDemo-streaming.ipynb)
 
+
+
+## Defining a Custom Query Engine
+
+You can also define a custom query engine. Simply subclass the `CustomQueryEngine` class, define any attributes you'd want to have (similar to defining a Pydantic class), and implement a `custom_query` function that returns either a `Response` object or a string.
+
+```python
+from llama_index.query_engine import CustomQueryEngine
+from llama_index.retrievers import BaseRetriever
+from llama_index.response_synthesizers import get_response_synthesizer, BaseSynthesizer
+
+class RAGQueryEngine(CustomQueryEngine):
+    """RAG Query Engine."""
+
+    retriever: BaseRetriever
+    response_synthesizer: BaseSynthesizer
+
+    def custom_query(self, query_str: str):
+        nodes = self.retriever.retrieve(query_str)
+        response_obj = self.response_synthesizer.synthesize(query_str, nodes)
+        return response_obj
+
+```
+
+See the [Custom Query Engine guide](/examples/query_engine/custom_query_engine.ipynb) for more details.

--- a/docs/examples/query_engine/custom_query_engine.ipynb
+++ b/docs/examples/query_engine/custom_query_engine.ipynb
@@ -143,6 +143,7 @@
     "    \"Answer: \"\n",
     ")\n",
     "\n",
+    "\n",
     "class RAGStringQueryEngine(CustomQueryEngine):\n",
     "    \"\"\"RAG String Query Engine.\"\"\"\n",
     "\n",
@@ -155,8 +156,10 @@
     "        nodes = self.retriever.retrieve(query_str)\n",
     "\n",
     "        context_str = \"\\n\\n\".join([n.node.get_content() for n in nodes])\n",
-    "        response = self.llm.complete(qa_prompt.format(context_str=context_str, query_str=query_str))\n",
-    "        \n",
+    "        response = self.llm.complete(\n",
+    "            qa_prompt.format(context_str=context_str, query_str=query_str)\n",
+    "        )\n",
+    "\n",
     "        return str(response)"
    ]
   },
@@ -245,10 +248,7 @@
     "llm = OpenAI(model=\"gpt-3.5-turbo\")\n",
     "\n",
     "query_engine = RAGStringQueryEngine(\n",
-    "    retriever=retriever, \n",
-    "    response_synthesizer=synthesizer,\n",
-    "    llm=llm,\n",
-    "    qa_prompt=qa_prompt\n",
+    "    retriever=retriever, response_synthesizer=synthesizer, llm=llm, qa_prompt=qa_prompt\n",
     ")"
    ]
   },

--- a/docs/examples/query_engine/custom_query_engine.ipynb
+++ b/docs/examples/query_engine/custom_query_engine.ipynb
@@ -1,0 +1,305 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c2598b32-dfc1-48bf-8ccc-719873aeb05f",
+   "metadata": {},
+   "source": [
+    "# Defining a Custom Query Engine\n",
+    "\n",
+    "You can (and should) define your custom query engines in order to plug into your downstream LlamaIndex workflows, whether you're building RAG, agents, or other applications.\n",
+    "\n",
+    "We provide a `CustomQueryEngine` that makes it easy to define your own queries."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f47027d5-19b4-4850-bc14-3f054899f472",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "We first load some sample data and index it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "1b6e547e-af15-4506-9a4f-ec28c4bf3ce8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index import (\n",
+    "    VectorStoreIndex,\n",
+    "    SimpleDirectoryReader,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "4a3b2e77-fbea-451a-b714-696f2c9eb396",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load documents\n",
+    "documents = SimpleDirectoryReader(\n",
+    "    \"../../../examples/paul_graham_essay/data\"\n",
+    ").load_data()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b94287a5-4ae8-4369-a245-4a8c53790b17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "index = VectorStoreIndex.from_documents(documents)\n",
+    "retriever = index.as_retriever()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0697f50b-5238-4b96-a925-68dfc70138fb",
+   "metadata": {},
+   "source": [
+    "## Building a Custom Query Engine\n",
+    "\n",
+    "We build a custom query engine that simulates a RAG pipeline. First perform retrieval, and then synthesis.\n",
+    "\n",
+    "To define a `CustomQueryEngine`, you just have to define some initialization parameters as attributes and implement the `custom_query` function.\n",
+    "\n",
+    "By default, the `custom_query` can return a `Response` object (which the response synthesizer returns), but it can also just return a string. These are options 1 and 2 respectively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "d3d9c2af-bf04-4ce6-b2ed-b6dd12c7176c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.query_engine import CustomQueryEngine\n",
+    "from llama_index.retrievers import BaseRetriever\n",
+    "from llama_index.response_synthesizers import get_response_synthesizer, BaseSynthesizer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "480d6dde-84af-4185-a505-78c95dbf884d",
+   "metadata": {},
+   "source": [
+    "### Option 1 (`RAGQueryEngine`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8fd6c9cb-2240-40da-8e69-1bb3d60913dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class RAGQueryEngine(CustomQueryEngine):\n",
+    "    \"\"\"RAG Query Engine.\"\"\"\n",
+    "\n",
+    "    retriever: BaseRetriever\n",
+    "    response_synthesizer: BaseSynthesizer\n",
+    "\n",
+    "    def custom_query(self, query_str: str):\n",
+    "        nodes = self.retriever.retrieve(query_str)\n",
+    "        response_obj = self.response_synthesizer.synthesize(query_str, nodes)\n",
+    "        return response_obj"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de9b50c1-8c0f-4ca1-9ca0-aa984d7270ae",
+   "metadata": {},
+   "source": [
+    "### Option 2 (`RAGStringQueryEngine`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "ef7b34bb-f14a-4e6e-a677-8213cb53f4b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Option 2: return a string (we use a raw LLM call for illustration)\n",
+    "\n",
+    "from llama_index.llms import OpenAI\n",
+    "from llama_index.prompts import PromptTemplate\n",
+    "\n",
+    "qa_prompt = PromptTemplate(\n",
+    "    \"Context information is below.\\n\"\n",
+    "    \"---------------------\\n\"\n",
+    "    \"{context_str}\\n\"\n",
+    "    \"---------------------\\n\"\n",
+    "    \"Given the context information and not prior knowledge, \"\n",
+    "    \"answer the query.\\n\"\n",
+    "    \"Query: {query_str}\\n\"\n",
+    "    \"Answer: \"\n",
+    ")\n",
+    "\n",
+    "class RAGStringQueryEngine(CustomQueryEngine):\n",
+    "    \"\"\"RAG String Query Engine.\"\"\"\n",
+    "\n",
+    "    retriever: BaseRetriever\n",
+    "    response_synthesizer: BaseSynthesizer\n",
+    "    llm: OpenAI\n",
+    "    qa_prompt: PromptTemplate\n",
+    "\n",
+    "    def custom_query(self, query_str: str):\n",
+    "        nodes = self.retriever.retrieve(query_str)\n",
+    "\n",
+    "        context_str = \"\\n\\n\".join([n.node.get_content() for n in nodes])\n",
+    "        response = self.llm.complete(qa_prompt.format(context_str=context_str, query_str=query_str))\n",
+    "        \n",
+    "        return str(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cb13986c-0431-4f29-9bc3-924424832373",
+   "metadata": {},
+   "source": [
+    "## Trying it out\n",
+    "\n",
+    "We now try it out on our sample data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "022d0ae1-74e8-4cae-a460-8f895ed3b293",
+   "metadata": {},
+   "source": [
+    "### Trying Option 1 (`RAGQueryEngine`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "e2b22e9b-fd1d-40ff-ad66-1718384cb5ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "synthesizer = get_response_synthesizer(response_mode=\"compact\")\n",
+    "query_engine = RAGQueryEngine(retriever=retriever, response_synthesizer=synthesizer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "26fd76a0-451c-4796-97f8-4524af499c3a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = query_engine.query(\"What did the author do growing up?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "71d885de-10fc-4c85-b782-108a7c33805e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The author worked on writing and programming outside of school before college. They wrote short stories and tried writing programs on an IBM 1401 computer using an early version of Fortran. They also mentioned getting a microcomputer, building it themselves, and writing simple games and programs on it.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(str(response))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4da52b0-77a6-43dc-9860-d1a52cee907d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(response.source_nodes[0].get_content())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0c7c860-06c4-445c-95a7-858240053648",
+   "metadata": {},
+   "source": [
+    "### Trying Option 2 (`RAGStringQueryEngine`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "09bdd1c9-7bd2-4de0-a807-3eb20f6ede46",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "llm = OpenAI(model=\"gpt-3.5-turbo\")\n",
+    "\n",
+    "query_engine = RAGStringQueryEngine(\n",
+    "    retriever=retriever, \n",
+    "    response_synthesizer=synthesizer,\n",
+    "    llm=llm,\n",
+    "    qa_prompt=qa_prompt\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "370a3d91-e16f-4424-b839-5a57b28f21a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = query_engine.query(\"What did the author do growing up?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "307831fa-2c8d-4ab2-9d95-78e6c0c61a97",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The author worked on writing and programming before college. They wrote short stories and started programming on the IBM 1401 computer in 9th grade. They later got a microcomputer and continued programming, writing simple games and a word processor.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(str(response))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "llama_index_v2",
+   "language": "python",
+   "name": "llama_index_v2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/vector_stores/SimpleIndexDemo.ipynb
+++ b/docs/examples/vector_stores/SimpleIndexDemo.ipynb
@@ -399,7 +399,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/docs/examples/vector_stores/SimpleIndexDemo.ipynb
+++ b/docs/examples/vector_stores/SimpleIndexDemo.ipynb
@@ -399,7 +399,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,

--- a/llama_index/query_engine/__init__.py
+++ b/llama_index/query_engine/__init__.py
@@ -47,5 +47,5 @@ __all__ = [
     "PandasQueryEngine",
     "KnowledgeGraphQueryEngine",
     "BaseQueryEngine",
-    "CustomQueryEngine"
+    "CustomQueryEngine",
 ]

--- a/llama_index/query_engine/__init__.py
+++ b/llama_index/query_engine/__init__.py
@@ -25,6 +25,7 @@ from llama_index.query_engine.sub_question_query_engine import (
 )
 from llama_index.query_engine.transform_query_engine import TransformQueryEngine
 from llama_index.indices.query.base import BaseQueryEngine
+from llama_index.query_engine.custom import CustomQueryEngine
 
 __all__ = [
     "CitationQueryEngine",
@@ -46,4 +47,5 @@ __all__ = [
     "PandasQueryEngine",
     "KnowledgeGraphQueryEngine",
     "BaseQueryEngine",
+    "CustomQueryEngine"
 ]

--- a/llama_index/query_engine/custom.py
+++ b/llama_index/query_engine/custom.py
@@ -1,0 +1,58 @@
+"""Custom query engine."""
+
+from llama_index.indices.query.base import BaseQueryEngine
+from typing import Optional, Any
+from pydantic import BaseModel
+from llama_index.callbacks.base import CallbackManager
+from llama_index.response.schema import Response
+from llama_index.indices.query.schema import QueryBundle, QueryType
+from llama_index.response.schema import RESPONSE_TYPE
+from llama_index.bridge.pydantic import Field
+from abc import abstractmethod
+
+
+class CustomQueryEngine(BaseModel, BaseQueryEngine):
+    """Custom query engine.
+    
+    """
+
+    callback_manager: Optional[CallbackManager] = Field(
+        default_factory=lambda: CallbackManager([]), exclude=True
+    )
+
+    class Config:
+        arbitrary_types_allowed = True
+  
+    def query(self, str_or_query_bundle: QueryType) -> RESPONSE_TYPE:
+        with self.callback_manager.as_trace("query"):
+            # if query bundle, just run the query
+            if isinstance(str_or_query_bundle, QueryBundle):
+                query_str = str_or_query_bundle.query_str
+            else:
+                query_str = str_or_query_bundle
+            response = self.custom_query(query_str)
+            return response
+
+    async def aquery(self, str_or_query_bundle: QueryType) -> RESPONSE_TYPE:
+        with self.callback_manager.as_trace("query"):
+            if isinstance(str_or_query_bundle, QueryBundle):
+                query_str = str_or_query_bundle.query_str
+            else:
+                query_str = str_or_query_bundle
+            response = await self.acustom_query(query_str)
+            return response
+
+    @abstractmethod
+    def custom_query(self, query_str: str) -> Response:
+        """Run a custom query."""
+
+    async def acustom_query(self, query_str: str) -> Response:
+        """Run a custom query asynchronously."""
+        # by default, just run the synchronous version
+        return self.custom_query(query_str)
+
+    def _query(self, query_bundle: QueryBundle) -> RESPONSE_TYPE:
+        pass
+
+    async def _aquery(self, query_bundle: QueryBundle) -> RESPONSE_TYPE:
+        pass


### PR DESCRIPTION
unlike #7695 this PR makes the customqueryengine a pydantic object, meaning it's easy for users to define new fields without the hacky `init_params` initialization

we should probably just make the base class a pydantic object, but that's a TODO for a later PR 