### PR TITLE
properly calculate score between 0 and 1

### DIFF
--- a/llama_index/vector_stores/chroma.py
+++ b/llama_index/vector_stores/chroma.py
@@ -222,7 +222,7 @@ class ChromaVectorStore(BasePydanticVectorStore):
 
             nodes.append(node)
 
-            similarity_score = 1.0 - math.exp(-distance)
+            similarity_score = math.exp(-distance)
             similarities.append(similarity_score)
 
             logger.debug(


### PR DESCRIPTION
# Description

Small fix for the score calculation in chromadb. It's not perfect, the scores seem a little low, but they do make sense. Previously the calculation meant lower scores were more similar instead of higher scores.

Fixes https://github.com/jerryjliu/llama_index/issues/7007

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

