### PR TITLE
llms/openai: fix Azure OpenAI by considering `prompt_filter_results` field

### DIFF
--- a/llama_index/llms/openai.py
+++ b/llama_index/llms/openai.py
@@ -226,7 +226,10 @@ class OpenAI(LLM):
                 stream=True,
                 **all_kwargs,
             ):
-                if len(response["choices"]) == 0 and response.get("prompt_annotations"):
+                if len(response["choices"]) == 0 and (
+                    response.get("prompt_annotations")
+                    or response.get("prompt_filter_results")
+                ):
                     # When asking a stream response from the Azure OpenAI API
                     # you first get an empty message with the content filtering
                     # results. Ignore this message


### PR DESCRIPTION
# Description

Functions in OpenAI are only supported in preview API versions for now, and as such things might actually change. What before was `prompt_annotations` now seems to be `prompt_filter_results`.

Without this patch you get essentially the same problem explained in #7677

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
