### PR TITLE
Multiple kwargs values in "KnowledgeGraphQueryEngine" bug-fix

### DIFF
--- a/llama_index/indices/knowledge_graph/retrievers.py
+++ b/llama_index/indices/knowledge_graph/retrievers.py
@@ -437,10 +437,16 @@ class KnowledgeGraphRAGRetriever(BaseRetriever):
                 "graph_query_synthesis_prompt",
                 None,
             )
+            if graph_query_synthesis_prompt is not None:
+                del kwargs["graph_query_synthesis_prompt"]
+
             graph_response_answer_prompt = kwargs.get(
                 "graph_response_answer_prompt",
                 None,
             )
+            if graph_query_synthesis_prompt is not None:
+                del kwargs["graph_response_answer_prompt"]
+
             refresh_schema = kwargs.get("refresh_schema", False)
             response_synthesizer = kwargs.get("response_synthesizer", None)
             self._kg_query_engine = KnowledgeGraphQueryEngine(

--- a/llama_index/indices/knowledge_graph/retrievers.py
+++ b/llama_index/indices/knowledge_graph/retrievers.py
@@ -444,7 +444,7 @@ class KnowledgeGraphRAGRetriever(BaseRetriever):
                 "graph_response_answer_prompt",
                 None,
             )
-            if graph_query_synthesis_prompt is not None:
+            if graph_response_answer_prompt is not None:
                 del kwargs["graph_response_answer_prompt"]
 
             refresh_schema = kwargs.get("refresh_schema", False)


### PR DESCRIPTION
# Description

In `KnowledgeGraphRAGRetriever` code, it will get the `graph_query_synthesis_prompt` into `KnowledgeGraphQueryEngine` from `kwargs` but will also leave it in the `kwargs`. 

Thus result in `TypeError: llama_index.query_engine.knowledge_graph_query_engine.KnowledgeGraphQueryEngine() got multiple values for keyword argument 'graph_query_synthesis_prompt'`

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
I've run e2e flow of `KnowledgeGraphRAGRetriever`

- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:
- [X] My changes generate no new warnings
