### PR TITLE
avoid raising error in auto retriever parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## Unreleased
+
+### Bug Fixes / Nits
+- Fix `NotImplementedError` in auto vector retriever (#7764)
+
 ## [0.8.30] - 2023-09-21
 
 ### New Features

--- a/llama_index/indices/vector_store/retrievers/auto_retriever/output_parser.py
+++ b/llama_index/indices/vector_store/retrievers/auto_retriever/output_parser.py
@@ -14,5 +14,4 @@ class VectorStoreQueryOutputParser(BaseOutputParser):
         return StructuredOutput(raw_output=output, parsed_output=query_and_filters)
 
     def format(self, prompt_template: str) -> str:
-        del prompt_template
-        raise NotImplementedError()
+        return prompt_template


### PR DESCRIPTION
# Description

There was a small issue with the auto vector query engine where the output parser was raising a `NotImplementedError()` in the `format()` function.

Couldn't track down what caused this to happen, but changing the function to just return the input seems to be a good fix.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
