### PR TITLE
empty response when nodes are empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Allow users to set the embedding dimensions in azure cognitive  vector store (#7734)
 
 ### Bug Fixes / Nits
+- Fixed response synthesizers with empty nodes (#7773)
 - Fix `NotImplementedError` in auto vector retriever (#7764)
 - Pass service context to index for dataset generator (#7748)
 

--- a/llama_index/response_synthesizers/base.py
+++ b/llama_index/response_synthesizers/base.py
@@ -116,6 +116,9 @@ class BaseSynthesizer(ABC):
         nodes: List[NodeWithScore],
         additional_source_nodes: Optional[Sequence[NodeWithScore]] = None,
     ) -> RESPONSE_TYPE:
+        if len(nodes) == 0:
+            return Response("Empty Response")
+
         if isinstance(query, str):
             query = QueryBundle(query_str=query)
 
@@ -144,6 +147,9 @@ class BaseSynthesizer(ABC):
         nodes: List[NodeWithScore],
         additional_source_nodes: Optional[Sequence[NodeWithScore]] = None,
     ) -> RESPONSE_TYPE:
+        if len(nodes) == 0:
+            return Response("Empty Response")
+
         if isinstance(query, str):
             query = QueryBundle(query_str=query)
 

--- a/tests/indices/query/test_compose.py
+++ b/tests/indices/query/test_compose.py
@@ -138,7 +138,7 @@ def test_recursive_query_table_list(
     query_str = "World?"
     query_engine = graph.as_query_engine()
     response = query_engine.query(query_str)
-    assert str(response) == ("World?:World?:Hello world.:None")
+    assert str(response) == ("World?:World?:Hello world.:Empty Response")
 
     query_str = "Test?"
     response = query_engine.query(query_str)


### PR DESCRIPTION
# Description

Sometimes retrievers will not return any nodes. This causes some response synthesizers to freak out. We should just return an empty response in the base class.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

