### PR TITLE
fix output parsers for selector templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Bug Fixes / Nits
 - Fix `NotImplementedError` in auto vector retriever (#7764)
 - Pass service context to index for dataset generator (#7748)
+- Fix output parsers for selector templates (#7774)
 
 ## [0.8.30] - 2023-09-21
 

--- a/llama_index/prompts/base.py
+++ b/llama_index/prompts/base.py
@@ -206,13 +206,19 @@ class SelectorPromptTemplate(BasePromptTemplate):
         )
 
     def _select(self, llm: Optional[LLM] = None) -> BasePromptTemplate:
+        # ensure output parser is up to date
+        self.default_template.output_parser = self.output_parser
+
         if llm is None:
             return self.default_template
 
         if self.conditionals is not None:
             for condition, prompt in self.conditionals:
                 if condition(llm):
+                    # ensure output parser is up to date
+                    prompt.output_parser = self.output_parser
                     return prompt
+
         return self.default_template
 
     def partial_format(self, **kwargs: Any) -> "SelectorPromptTemplate":


### PR DESCRIPTION
# Description

If the output parser is set on a selector template like `prompt_tempalte.output_parser = ...` it does not get inherited properly.

Instead, we can inherit during prompt selection time

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

