### PR TITLE
Fix broken link to example notebook in query_transformations.md

### DIFF
--- a/docs/core_modules/query_modules/query_engine/advanced/query_transformations.md
+++ b/docs/core_modules/query_modules/query_engine/advanced/query_transformations.md
@@ -43,7 +43,7 @@ print(response)
 
 ```
 
-Check out our [example notebook](../../../examples/query_transformations/HyDEQueryTransformDemo.ipynb) for a full walkthrough.
+Check out our [example notebook](https://github.com/jerryjliu/llama_index/blob/main/docs/examples/query_transformations/HyDEQueryTransformDemo.ipynb) for a full walkthrough.
 
 
 ### Single-Step Query Decomposition


### PR DESCRIPTION
# Description

Fix broken link to example notebook in query_transformations.md.

I used an absolute link like the other notebook links in this md doc.

Fixes # None - can file one if needed

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Not tested, but it's just a broken link so it can't get any worse.

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
