### PR TITLE
Addressing PyYAML import error

### DIFF
--- a/llama_index/output_parsers/utils.py
+++ b/llama_index/output_parsers/utils.py
@@ -1,8 +1,10 @@
+import contextlib
 import json
 import re
 from typing import Any
 
-import yaml
+with contextlib.suppress(ImportError):
+    import yaml
 
 from llama_index.output_parsers.base import OutputParserException
 
@@ -54,6 +56,8 @@ def parse_json_markdown(text: str) -> Any:
                 f"Got invalid JSON object. Error: {e_json} {e_yaml}. "
                 f"Got JSON string: {json_string}"
             )
+        except NameError as exc:
+            raise ImportError("Please pip install PyYAML.") from exc
 
     return json_obj
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ rake_nltk==1.0.6
 ipython==8.10.0
 
 # linting stubs
+types-PyYAML
 types-requests==2.28.11.8
 types-setuptools==67.1.0.0
 


### PR DESCRIPTION
# Description

https://github.com/jerryjliu/llama_index/pull/6246/files#diff-c241e91b7a68e1709456d4c87e62b00948d218cd4f8d483c26667ecfc58a8651R4 added `yaml`, but it's not reflected in `setup.py`.  Thus, it's possible to get `ImportError`.

This PR fixes that potential pitfall, and also adds PyYAML's type stub.  Imo it's not worth requiring all LlamaIndex users to install PyYAML just to enable one helper function.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense
