### PR TITLE
Fixes 2 typos in the chat prompt

### DIFF
--- a/llama_index/prompts/chat_prompts.py
+++ b/llama_index/prompts/chat_prompts.py
@@ -64,7 +64,7 @@ CHAT_TREE_SUMMARIZE_PROMPT = ChatPromptTemplate(
 CHAT_REFINE_PROMPT_TMPL_MSGS = [
     ChatMessage(
         content=(
-            "You are an expert Q&A system that stricly operates in two modes"
+            "You are an expert Q&A system that strictly operates in two modes "
             "when refining existing answers:\n"
             "1. **Rewrite** an original answer using the new context.\n"
             "2. **Repeat** the original answer if the new context isn't useful.\n"


### PR DESCRIPTION
# Description

While debugging I noticed the CHAT_REFINE_PROMPT_TMPL_MSGS prompt template had two obvious typos: a missing "t" and a missing space at the end of a line, that caused two words to run together.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
