### PR TITLE
Enable notebooks to run evaluators that were recently made async

### DIFF
--- a/docs/examples/evaluation/RetryQuery.ipynb
+++ b/docs/examples/evaluation/RetryQuery.ipynb
@@ -220,13 +220,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 6,
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "from llama_index.evaluation.guideline_eval import GuidelineEvaluator, DEFAULT_GUIDELINES\n",
+    "from llama_index.evaluation.guideline import GuidelineEvaluator, DEFAULT_GUIDELINES\n",
     "from llama_index.response.schema import Response\n",
     "from llama_index.indices.query.query_transform.feedback_transform import (\n",
     "    FeedbackQueryTransformation,\n",
@@ -251,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 7,
    "metadata": {
     "tags": []
    },
@@ -260,15 +260,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Guideline eval evaluation result: The response is too long and should be summarized. It should also include specific numbers or statistics when possible.\n",
+      "Guideline eval evaluation result: The response partially answers the query but lacks specific statistics or numbers. It provides some details about the author's activities growing up, such as writing short stories and programming on different computers, but it could be more concise and focused. Additionally, the response does not mention any statistics or numbers to support the author's experiences.\n",
       "Transformed query: Here is a previous bad answer.\n",
-      "\n",
-      "The author grew up writing essays, learning Italian, exploring Florence, painting people, learning about computers, attending RISD, living in a rent-stabilized apartment, building an online store builder, editing Lisp expressions, publishing essays online, writing essays, painting still life, working on spam filters, cooking for groups, and buying a building in Cambridge.\n",
+      "The author worked on writing and programming outside of school before college. They wrote short stories and tried writing programs on an IBM 1401 computer using an early version of Fortran. They later got a microcomputer and started programming on it, writing simple games and a word processor. They also mentioned their interest in philosophy and AI.\n",
       "Here is some feedback from the evaluator about the response given.\n",
-      "The response is too long and should be summarized. It should also include specific numbers or statistics when possible.\n",
+      "The response partially answers the query but lacks specific statistics or numbers. It provides some details about the author's activities growing up, such as writing short stories and programming on different computers, but it could be more concise and focused. Additionally, the response does not mention any statistics or numbers to support the author's experiences.\n",
       "Now answer the question.\n",
-      "\n",
-      "What experiences did the author have growing up?\n"
+      "What were the author's activities and interests during their childhood and adolescence?\n"
      ]
     }
    ],
@@ -293,7 +291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 8,
    "metadata": {
     "tags": []
    },
@@ -302,8 +300,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "The author gained a wide range of skills and experiences growing up, from creative pursuits such as painting and writing, to technical skills such as coding and launching software. They also gained an understanding of Italian language and culture, explored the city of Florence, and gained experience living in a rent-stabilized apartment. These experiences enabled the author to develop the skills necessary to launch a successful online store builder and publish essays online, which allowed them to reach a wider audience and gain recognition for their work. Specifically, they gained an understanding of the web infrastructure, the ability to write code in Lisp, and the ability to market their products and services. They also developed an understanding of the importance of working on projects that weren't prestigious, as well as the ability to cook for large groups of people. Finally, they gained the confidence to take risks and pursue their passions, which ultimately led to their success.\n"
+      "During their childhood and adolescence, the author worked on writing short stories and programming. They mentioned that their short stories were not very good, lacking plot but focusing on characters with strong feelings. In terms of programming, they tried writing programs on the IBM 1401 computer in 9th grade using an early version of Fortran. However, they mentioned being puzzled by the 1401 and not being able to do much with it due to the limited input options. They also mentioned getting a microcomputer, a TRS-80, and starting to write simple games, a program to predict rocket heights, and a word processor.\n"
      ]
     }
    ],

--- a/docs/examples/evaluation/RetryQuery.ipynb
+++ b/docs/examples/evaluation/RetryQuery.ipynb
@@ -67,7 +67,11 @@
    "outputs": [],
    "source": [
     "from llama_index.indices.vector_store.base import VectorStoreIndex\n",
-    "from llama_index.readers.file.base import SimpleDirectoryReader"
+    "from llama_index.readers.file.base import SimpleDirectoryReader\n",
+    "\n",
+    "# Needed for running async functions in Jupyter Notebook\n",
+    "import nest_asyncio\n",
+    "nest_asyncio.apply()"
    ]
   },
   {
@@ -101,8 +105,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "The author grew up writing essays, learning Italian, exploring Florence, painting people, learning about computers, attending RISD, living in a rent-stabilized apartment, building an online store builder, editing Lisp expressions, publishing essays online, writing essays, painting still life, working on spam filters, cooking for groups, and buying a building in Cambridge.\n"
+      "The author worked on writing and programming outside of school before college. They wrote short stories and tried writing programs on an IBM 1401 computer using an early version of Fortran. They later got a microcomputer and started programming on it, writing simple games and a word processor. They also mentioned their interest in philosophy and AI.\n"
      ]
     }
    ],
@@ -135,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 4,
    "metadata": {
     "tags": []
    },
@@ -144,8 +147,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "The author grew up writing essays, learning Italian, exploring Florence, painting people, working with computers, attending RISD, living in a rent-controlled apartment, building an online store builder, editing code, launching software, publishing essays online, writing essays, painting still life, working on spam filters, cooking for groups, and buying a building in Cambridge.\n"
+      "The author worked on writing and programming outside of school before college. They wrote short stories and tried writing programs on an IBM 1401 computer using an early version of Fortran. They later got a microcomputer, a TRS-80, and started programming more extensively, including writing simple games and a word processor.\n"
      ]
     }
    ],
@@ -177,7 +179,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 5,
    "metadata": {
     "tags": []
    },
@@ -186,8 +188,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "The author grew up writing essays, learning Italian, exploring Florence, painting people, working with computers, attending RISD, living in a rent-stabilized apartment, building an online store builder, editing Lisp expressions, publishing essays online, writing essays, painting still life, working on spam filters, cooking for groups, and buying a building in Cambridge.\n"
+      "The author worked on writing and programming outside of school before college. They wrote short stories and tried writing programs on an IBM 1401 computer using an early version of Fortran. They later got a microcomputer and started programming on it, writing simple games and a word processor. They also mentioned their interest in philosophy and AI.\n"
      ]
     }
    ],

--- a/docs/examples/evaluation/RetryQuery.ipynb
+++ b/docs/examples/evaluation/RetryQuery.ipynb
@@ -71,6 +71,7 @@
     "\n",
     "# Needed for running async functions in Jupyter Notebook\n",
     "import nest_asyncio\n",
+    "\n",
     "nest_asyncio.apply()"
    ]
   },

--- a/docs/examples/evaluation/guideline_eval.ipynb
+++ b/docs/examples/evaluation/guideline_eval.ipynb
@@ -33,6 +33,7 @@
     "\n",
     "# Needed for running async functions in Jupyter Notebook\n",
     "import nest_asyncio\n",
+    "\n",
     "nest_asyncio.apply()"
    ]
   },

--- a/docs/examples/evaluation/guideline_eval.ipynb
+++ b/docs/examples/evaluation/guideline_eval.ipynb
@@ -29,7 +29,11 @@
    "source": [
     "from llama_index.evaluation import GuidelineEvaluator\n",
     "from llama_index import ServiceContext\n",
-    "from llama_index.llms import OpenAI"
+    "from llama_index.llms import OpenAI\n",
+    "\n",
+    "# Needed for running async functions in Jupyter Notebook\n",
+    "import nest_asyncio\n",
+    "nest_asyncio.apply()"
    ]
   },
   {
@@ -100,7 +104,7 @@
       "=====\n",
       "Guideline: The response should fully answer the query.\n",
       "Pass: False\n",
-      "Feedback: The response does not fully answer the query. While it does provide a brief overview of global warming, it does not delve into the specifics such as the causes, effects, and potential solutions to global warming. The response could be improved by providing more detailed information.\n",
+      "Feedback: The response does not fully answer the query. While it does provide a brief overview of global warming, it does not delve into the specifics of the causes, effects, or potential solutions to the problem. The response should be more detailed and comprehensive to fully answer the query.\n",
       "=====\n",
       "Guideline: The response should avoid being vague or ambiguous.\n",
       "Pass: False\n",
@@ -108,7 +112,7 @@
       "=====\n",
       "Guideline: The response should be specific and use statistics or numbers when possible.\n",
       "Pass: False\n",
-      "Feedback: The response, while accurate, is not specific enough and does not include any statistics or numbers. It would be more effective if it included specific examples of human activities that contribute to global warming, as well as specific examples of the adverse effects. Additionally, including data or statistics about the rate of temperature increase or the projected impacts of global warming would make the response more informative and impactful.\n"
+      "Feedback: The response is too general and lacks specific details or statistics about global warming. It would be more informative if it included data such as the rate at which the Earth's temperature is rising, the main human activities contributing to global warming, or the specific adverse effects on the planet.\n"
      ]
     }
    ],
@@ -128,7 +132,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f13e658-982f-4b20-ba08-e639cd7fe1c4",
+   "id": "1cde8f5d",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -150,7 +154,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Description

- Fixes two notebooks that stopped working after async evaluators were added in #7692. Jupyter Notebook runs an event loop behind the scenes, and it was interfering with `asyncio`'s event loop, causing runtime errors. 

    ```bash
    ---> 33: raise RuntimeError(
    34:     "asyncio.run() cannot be called from a running event loop"
    )
    ```

- Updates an import statement to work with the `guideline` module which was renamed in #7661. 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
