### PR TITLE
extend DatasetGenerator to generate queries and responses, add `QueryResponseDataset` module 

### DIFF
--- a/llama_index/evaluation/__init__.py
+++ b/llama_index/evaluation/__init__.py
@@ -3,7 +3,10 @@
 from llama_index.evaluation.base import BaseEvaluator, EvaluationResult
 from llama_index.evaluation.batch_runner import BatchEvalRunner
 from llama_index.evaluation.correctness import CorrectnessEvaluator
-from llama_index.evaluation.dataset_generation import DatasetGenerator
+from llama_index.evaluation.dataset_generation import (
+    DatasetGenerator,
+    QueryResponseDataset,
+)
 from llama_index.evaluation.faithfulness import FaithfulnessEvaluator, ResponseEvaluator
 from llama_index.evaluation.semantic_similarity import SemanticSimilarityEvaluator
 from llama_index.evaluation.guideline import GuidelineEvaluator
@@ -38,6 +41,7 @@ __all__ = [
     "RelevancyEvaluator",
     "RelevanceEvaluator",
     "DatasetGenerator",
+    "QueryResponseDataset",
     "GuidelineEvaluator",
     "CorrectnessEvaluator",
     "SemanticSimilarityEvaluator",


### PR DESCRIPTION
before dataset generator beyond only generating questions.

now we feed (question, context) into LLM to generate a "ground-truth" response too. 

Add a `QueryResponseDataset` to store queries and responses.

Shouldn't affect existing functionality (`dataset_generator.generate_questions_from_nodes`) 