### PR TITLE
upgrade our evaluation batch runner

### DIFF
--- a/docs/examples/retrievers/auto_merging_retriever.ipynb
+++ b/docs/examples/retrievers/auto_merging_retriever.ipynb
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "7ee0e185-408a-4c9c-a361-b6af96129b0d",
    "metadata": {},
    "outputs": [],
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "5f9c5d99-bd0e-4b26-b816-9f5ad29df3c8",
    "metadata": {},
    "outputs": [],
@@ -803,7 +803,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 130,
    "id": "f6814643-bdb2-47cd-a8a5-69a1bdfdda30",
    "metadata": {},
    "outputs": [],
@@ -825,103 +825,335 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
-   "id": "2407d8a0-a3d1-42f1-9796-e96a2acd591b",
+   "execution_count": 131,
+   "id": "ae472816-5927-4f67-9105-fd0ba0c60f49",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from tqdm import tqdm\n",
-    "from tqdm.asyncio import tqdm_asyncio\n",
-    "\n",
-    "\n",
-    "async def get_predicted_answers(questions, query_engine):\n",
-    "    tasks = []\n",
-    "    for question in questions:\n",
-    "        tasks.append(query_engine.aquery(question))\n",
-    "    responses = await tqdm_asyncio.gather(*tasks)\n",
-    "    return responses"
+    "from llama_index.evaluation.eval_utils import get_responses, avg_eval_score, aavg_eval_score\n",
+    "from llama_index.evaluation import BatchEvalRunner"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 132,
    "id": "fdfd6d5b-7c73-40a5-9636-8db6a248ac00",
    "metadata": {},
    "outputs": [],
    "source": [
     "eval_qs = eval_dataset.questions\n",
-    "qr_pairs = eval_dataset.qr_pairs"
+    "qr_pairs = eval_dataset.qr_pairs\n",
+    "ref_response_strs = [r for (_, r) in qr_pairs]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "4414487d-cd0f-4e17-9f0a-c186e378dd49",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 44,
+   "id": "a7302e7b-6b3e-4d25-874b-94ffe944b527",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  0%|                                                                                                                                   | 0/60 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> Merging 3 nodes into parent node.\n",
+      "> Parent node id: 815c6387-9b7e-4852-866e-3ea1921d9521.\n",
+      "> Parent node text: As a result, Llama 2 models\n",
+      "should be used carefully and deployed only after significant safety t...\n",
+      "\n",
+      "> Merging 4 nodes into parent node.\n",
+      "> Parent node id: da01520e-8f29-4102-b95b-81b989384a75.\n",
+      "> Parent node text: • Popular Aggregated Benchmarks. We report the overall results for MMLU (5 shot) (Hendrycks\n",
+      "et al...\n",
+      "\n",
+      "> Merging 1 nodes into parent node.\n",
+      "> Parent node id: 4a64d215-3e85-4cb1-8196-e9c703c23781.\n",
+      "> Parent node text: Most of them were\n",
+      "initially developed for pretrained LLMs, and there are certain limitations to c...\n",
+      "\n",
+      "> Merging 3 nodes into parent node.\n",
+      "> Parent node id: c4c2be20-f459-4366-b4ef-dcec4b93a709.\n",
+      "> Parent node text: This\n",
+      "approach not only fosters real collaboration with diverse stakeholders—those beyond the wall...\n",
+      "\n",
+      "> Filling in node. Node id: baf43e7d-bc88-46bd-b636-c505519cbfd5> Node text: Bender et al. (2021b) and Weidinger et al. (2021) underscore various hazards\n",
+      "like bias, toxicity,...\n",
+      "\n",
+      "> Merging 3 nodes into parent node.\n",
+      "> Parent node id: 8608737f-de2f-47cc-86bb-397b5cc4afc1.\n",
+      "> Parent node text: Ouyang et al. (2022) demonstrates that a combination of instruction fine-tuning and RLHF can help...\n",
+      "\n",
+      "> Merging 3 nodes into parent node.\n",
+      "> Parent node id: a3182d1f-e1d2-4722-9f9e-388132d0cc63.\n",
+      "> Parent node text: These\n",
+      "findings are similar in spirit to Zhou et al. (2023), which also finds that a limited set o...\n",
+      "\n",
+      "> Filling in node. Node id: 6ec0d7b9-65c6-42e9-b1be-bc927939b4de> Node text: Rico Sennrich, Barry Haddow, and Alexandra Birch. Neural machine translation of rare words with s...\n",
+      "\n",
+      "> Merging 4 nodes into parent node.\n",
+      "> Parent node id: 461ce818-45e6-487c-a551-acd86d4eaa1b.\n",
+      "> Parent node text: Thomas Scialom, Paul-Alexis Dray, Sylvain Lamprier, Benjamin Piwowarski, and Jacopo Staiano. Disc...\n",
+      "\n",
+      "> Merging 1 nodes into parent node.\n",
+      "> Parent node id: a9ec4637-80fa-4640-88dc-60eb14084349.\n",
+      "> Parent node text: On the dangers of\n",
+      "stochastic parrots: Can language models be too big? In Proceedings of the 2021 ...\n",
+      "\n",
+      "> Merging 3 nodes into parent node.\n",
+      "> Parent node id: 29812b8d-a222-4816-a1df-56015198ac21.\n",
+      "> Parent node text: each variant, we use the safety and helpfulness reward models to score model generations correspo...\n",
+      "\n",
+      "> Merging 4 nodes into parent node.\n",
+      "> Parent node id: c7bc5041-bbb5-4dda-9197-0030c8e38269.\n",
+      "> Parent node text: 0\n",
+      "0.2\n",
+      "0.4\n",
+      "0.6\n",
+      "0.8\n",
+      "1\n",
+      "0\n",
+      "1\n",
+      "2\n",
+      "3\n",
+      "4\n",
+      "5\n",
+      "6\n",
+      "Model\n",
+      "Base\n",
+      "+ Generic Preprompt\n",
+      "+ Preprompt w/ Answer Template\n",
+      "S...\n",
+      "\n",
+      "> Filling in node. Node id: e5abd3c6-5705-410d-aa37-24ee84e04770> Node text: As shown in Table 3, Llama 2 models outperform Llama 1 models. In particular, Llama 2 70B improve...\n",
+      "\n",
+      "> Merging 5 nodes into parent node.\n",
+      "> Parent node id: da01520e-8f29-4102-b95b-81b989384a75.\n",
+      "> Parent node text: • Popular Aggregated Benchmarks. We report the overall results for MMLU (5 shot) (Hendrycks\n",
+      "et al...\n",
+      "\n",
+      "> Merging 4 nodes into parent node.\n",
+      "> Parent node id: c7bc5041-bbb5-4dda-9197-0030c8e38269.\n",
+      "> Parent node text: 0\n",
+      "0.2\n",
+      "0.4\n",
+      "0.6\n",
+      "0.8\n",
+      "1\n",
+      "0\n",
+      "1\n",
+      "2\n",
+      "3\n",
+      "4\n",
+      "5\n",
+      "6\n",
+      "Model\n",
+      "Base\n",
+      "+ Generic Preprompt\n",
+      "+ Preprompt w/ Answer Template\n",
+      "S...\n",
+      "\n",
+      "> Filling in node. Node id: b12da3f3-2219-40ce-a59b-bb2e6a054451> Node text: It is important to note that our calculations\n",
+      "do not account for further power demands, such as t...\n",
+      "\n",
+      "> Merging 5 nodes into parent node.\n",
+      "> Parent node id: 92ceb343-f0d9-4410-9301-7c37459ecaf1.\n",
+      "> Parent node text: Time\n",
+      "(GPU hours)\n",
+      "Power\n",
+      "Consumption (W)\n",
+      "Carbon Emitted\n",
+      "(tCO2eq)\n",
+      "Llama 2\n",
+      "7B\n",
+      "184320\n",
+      "400\n",
+      "31.22\n",
+      "13B\n",
+      "36...\n",
+      "\n",
+      "> Filling in node. Node id: f74400c2-5ecc-4c33-a94b-e96bd946dd7a> Node text: The fine-tuning data includes publicly available instruction datasets, as\n",
+      "well as over one millio...\n",
+      "\n",
+      "> Merging 3 nodes into parent node.\n",
+      "> Parent node id: d91fc3c4-b38c-4c2e-a116-6c1b53f34eef.\n",
+      "> Parent node text: Carbon Footprint\n",
+      "Pretraining utilized a cumulative 3.3M GPU hours of computation on hardware\n",
+      "of t...\n",
+      "\n",
+      "> Merging 3 nodes into parent node.\n",
+      "> Parent node id: b60dc904-e24e-4730-bfbd-cbe9b5d11ea3.\n",
+      "> Parent node text: 5\n",
+      "Discussion\n",
+      "Here, we discuss the interesting properties we have observed with RLHF (Section 5.1)...\n",
+      "\n",
+      "> Merging 1 nodes into parent node.\n",
+      "> Parent node id: feea8b1c-78e8-4c51-9d10-62afb9ca75a1.\n",
+      "> Parent node text: A.5.4\n",
+      "Annotator Selection\n",
+      "To select the annotators who could work on our different data collectio...\n",
+      "\n",
+      "> Merging 1 nodes into parent node.\n",
+      "> Parent node id: 13679983-dda5-43bb-91bd-d81fb850b209.\n",
+      "> Parent node text: Thus, we have decided to keep them in our data mixture, as they could enable better\n",
+      "generalizatio...\n",
+      "\n",
+      "> Merging 1 nodes into parent node.\n",
+      "> Parent node id: a9ec4637-80fa-4640-88dc-60eb14084349.\n",
+      "> Parent node text: On the dangers of\n",
+      "stochastic parrots: Can language models be too big? In Proceedings of the 2021 ...\n",
+      "\n",
+      "> Merging 1 nodes into parent node.\n",
+      "> Parent node id: f4e91713-5b40-442f-a11c-ef6e135dde57.\n",
+      "> Parent node text: Red teaming language models to reduce harms:\n",
+      "Methods, scaling behaviors, and lessons learned. arX...\n",
+      "\n",
+      "> Merging 2 nodes into parent node.\n",
+      "> Parent node id: 9365f510-8274-4cfd-94bf-7c6f1b898dca.\n",
+      "> Parent node text: 100\n",
+      "101\n",
+      "N Samples\n",
+      "0.54\n",
+      "0.56\n",
+      "0.58\n",
+      "0.60\n",
+      "0.62\n",
+      "0.64\n",
+      "0.66\n",
+      "Reward Score\n",
+      "Max of the rewards\n",
+      "Median of th...\n",
+      "\n",
+      "> Merging 1 nodes into parent node.\n",
+      "> Parent node id: 658a40a9-7b15-4649-a487-ec8e6c2668e9.\n",
+      "> Parent node text: For each\n",
+      "PPO iteration we use a batch size of 512, a PPO clip threshold of 0.2, a mini-batch size...\n",
+      "\n",
+      "> Merging 2 nodes into parent node.\n",
+      "> Parent node id: 2cc16b23-a40f-48c4-96ac-4114f28cb078.\n",
+      "> Parent node text: • Our partnerships team including Ash Jhaveri, Alex Boesenberg, Sy Choudhury, Mayumi Matsuno,\n",
+      "Ric...\n",
+      "\n",
+      "> Merging 3 nodes into parent node.\n",
+      "> Parent node id: 48c11151-ca20-44a0-b3d1-1008db533d3d.\n",
+      "> Parent node text: It is\n",
+      "the city of\n",
+      "Shakespeare and Dick\n",
+      "ens, of\n",
+      "the great univers\n",
+      "ities, of\n",
+      "the museums\n",
+      "and galler...\n",
+      "\n",
+      "> Merging 3 nodes into parent node.\n",
+      "> Parent node id: e47f0f8b-422b-42c9-8cf5-7111e671cdac.\n",
+      "> Parent node text: In response, on subsequent iterations, we modified our strategy, incorporating top-performing sam...\n",
+      "\n",
+      "> Filling in node. Node id: 633d480c-b14f-451c-81f4-48c118e21fc1> Node text: This can be observed in the\n",
+      "Self-BLEU slope, which mirrors a pattern comparable to that of the SF...\n",
+      "\n",
+      "> Merging 3 nodes into parent node.\n",
+      "> Parent node id: 8afbb089-cdbe-4ff4-9a2a-35e81bfcc048.\n",
+      "> Parent node text: Drawing a parallel, while we may not all be accomplished\n",
+      "artists, our ability to appreciate and c...\n",
+      "\n",
+      "> Merging 2 nodes into parent node.\n",
+      "> Parent node id: 42604361-97f2-45a4-80ed-2cc4c4e91ce3.\n",
+      "> Parent node text: Falcon-40b-instruct).\n",
+      "Limitations of human evaluations.\n",
+      "While our results indicate that Llama 2-C...\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 60/60 [00:31<00:00,  1.88it/s]\n"
+     ]
+    }
+   ],
    "source": [
-    "pred_responses = await get_predicted_answers(eval_qs, query_engine)\n",
-    "base_pred_responses = await get_predicted_answers(eval_qs, base_query_engine)"
+    "pred_responses = get_responses(eval_qs, query_engine, show_progress=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
-   "id": "19bbd64c-1344-44ba-bcdc-f9848e436f08",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from tqdm.asyncio import tqdm_asyncio\n",
-    "import numpy as np\n",
-    "\n",
-    "\n",
-    "async def avg_eval_score(qr_pairs, pred_responses, evaluator):\n",
-    "    tasks = []\n",
-    "    for idx, (question, reference) in tqdm(enumerate(qr_pairs)):\n",
-    "        pred_response = pred_responses[idx]\n",
-    "        task = evaluator.aevaluate_response(\n",
-    "            query=question,\n",
-    "            response=pred_response,\n",
-    "            reference=reference,\n",
-    "        )\n",
-    "        tasks.append(task)\n",
-    "    results = await tqdm_asyncio.gather(*tasks)\n",
-    "    scores = np.array([r.score for r in results])\n",
-    "    return scores.mean()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 33,
-   "id": "c565d771-ada6-4ace-8705-cbf4c41628e5",
+   "execution_count": 34,
+   "id": "0bce562f-6c42-446a-b991-f208ca9f55cb",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "60it [00:00, 822412.55it/s]\n",
-      "100%|██████████████████████████████████████████████████████████████████████| 60/60 [00:01<00:00, 55.66it/s]\n"
+      "100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 60/60 [00:22<00:00,  2.66it/s]\n"
      ]
     }
    ],
    "source": [
-    "avg_score = await avg_eval_score(qr_pairs, pred_responses, evaluator)"
+    "base_pred_responses = get_responses(eval_qs, base_query_engine, show_progress=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 133,
+   "id": "b0a86029-bf5e-4f26-afdf-a9406bada315",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_runner = BatchEvalRunner({\"evaluator\": evaluator}, workers=10, show_progress=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 134,
+   "id": "3428afe0-b5e4-4604-b7ce-270f449766cb",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "pred_response_strs = [str(p) for p in pred_responses]\n",
+    "base_pred_response_strs = [str(p) for p in base_pred_responses]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9abccb17-cf7d-4f59-b849-a4d5581df7a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eval_results = await batch_runner.aevaluate_response_strs(\n",
+    "    eval_qs, response_strs=pred_response_strs, reference=ref_response_strs\n",
+    ")\n",
+    "avg_score = np.array([r.score for r in eval_results[\"evaluator\"]]).mean()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 136,
    "id": "337d28d9-d640-4119-9b33-2c12f2c81d01",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.9193331063079818"
+       "0.9184167226162029"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 136,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -932,36 +1164,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "id": "7c5df1ec-408a-4012-93c7-a0151fa92b9e",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "60it [00:00, 461758.24it/s]\n",
-      "100%|██████████████████████████████████████████████████████████████████████| 60/60 [00:00<00:00, 68.06it/s]\n"
-     ]
-    }
-   ],
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
    "source": [
-    "base_avg_score = await avg_eval_score(qr_pairs, base_pred_responses, evaluator)"
+    "base_eval_results = await batch_runner.aevaluate_response_strs(\n",
+    "    eval_qs, response_strs=base_pred_response_strs, reference=ref_response_strs\n",
+    ")\n",
+    "base_avg_score = np.array([r.score for r in base_eval_results[\"evaluator\"]]).mean()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 139,
    "id": "10d3dc58-9415-4a2c-9400-2c4363d14d8f",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.9220138432235365"
+       "0.9230301912354162"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 139,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -984,72 +1212,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
-   "id": "7dd67fae-5b94-40d0-ab84-dbda6eea4a40",
+   "execution_count": 141,
+   "id": "91126247-b68d-43a9-b64f-f6764b0c2357",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from tqdm.asyncio import tqdm_asyncio\n",
-    "import numpy as np\n",
-    "\n",
-    "\n",
-    "async def avg_eval_score_pairwise(\n",
-    "    queries, ref_responses, candidate_responses, evaluator\n",
-    "):\n",
-    "    tasks = []\n",
-    "    for idx, question in enumerate(queries):\n",
-    "        ref_response = ref_responses[idx]\n",
-    "        candidate_response = candidate_responses[idx]\n",
-    "        task = evaluator.aevaluate_response(\n",
-    "            query=question,\n",
-    "            response=candidate_response,\n",
-    "            reference=ref_response,\n",
-    "        )\n",
-    "        tasks.append(task)\n",
-    "    results = await tqdm_asyncio.gather(*tasks)\n",
-    "    scores = np.array([r.score for r in results])\n",
-    "    return scores.mean()"
+    "batch_runner = BatchEvalRunner({\"pairwise\": pairwise_evaluator}, workers=10, show_progress=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
-   "id": "15b07bc8-ec9b-46be-a55f-c5d698ed3748",
+   "execution_count": null,
+   "id": "4426a26a-c26e-4560-b176-f2a7894adda7",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████████████████████████████████████████████████████████████████| 60/60 [00:10<00:00,  5.61it/s]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "base_avg_score = await avg_eval_score_pairwise(\n",
-    "    eval_qs, base_pred_responses, pred_responses, pairwise_evaluator\n",
-    ")"
+    "pairwise_eval_results = await batch_runner.aevaluate_response_strs(\n",
+    "    eval_qs, response_strs=pred_response_strs, reference=base_pred_response_strs\n",
+    ")\n",
+    "pairwise_score = np.array([r.score for r in pairwise_eval_results[\"pairwise\"]]).mean()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 145,
    "id": "0460557e-f80d-4dcb-a8ec-b08c61ed3129",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.65"
+       "0.5833333333333334"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 145,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "base_avg_score"
+    "pairwise_score"
    ]
   },
   {

--- a/docs/examples/retrievers/auto_merging_retriever.ipynb
+++ b/docs/examples/retrievers/auto_merging_retriever.ipynb
@@ -830,7 +830,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_index.evaluation.eval_utils import get_responses, avg_eval_score, aavg_eval_score\n",
+    "from llama_index.evaluation.eval_utils import (\n",
+    "    get_responses,\n",
+    "    avg_eval_score,\n",
+    "    aavg_eval_score,\n",
+    ")\n",
     "from llama_index.evaluation import BatchEvalRunner"
    ]
   },
@@ -1217,7 +1221,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "batch_runner = BatchEvalRunner({\"pairwise\": pairwise_evaluator}, workers=10, show_progress=True)"
+    "batch_runner = BatchEvalRunner(\n",
+    "    {\"pairwise\": pairwise_evaluator}, workers=10, show_progress=True\n",
+    ")"
    ]
   },
   {

--- a/llama_index/evaluation/batch_runner.py
+++ b/llama_index/evaluation/batch_runner.py
@@ -1,71 +1,83 @@
 import asyncio
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Sequence
 
 from llama_index.evaluation.base import BaseEvaluator, EvaluationResult
 from llama_index.indices.query.base import BaseQueryEngine
 from llama_index.response.schema import Response, RESPONSE_TYPE
+from llama_index.evaluation.eval_utils import asyncio_module
+
+async def eval_response_worker(
+    semaphore: asyncio.Semaphore,
+    evaluator: BaseEvaluator,
+    evaluator_name: str,
+    query: Optional[str] = None,
+    response: Optional[Response] = None,
+    eval_kwargs: Optional[Dict[str, Any]] = None,
+) -> Tuple[str, EvaluationResult]:
+    """Get aevaluate_response tasks with semaphore."""
+    eval_kwargs = eval_kwargs or {}
+    async with semaphore: 
+        return (
+            evaluator_name,
+            await evaluator.aevaluate_response(
+                query=query, response=response, **eval_kwargs
+            ),
+        )
+
+async def eval_worker(
+    semaphore: asyncio.Semaphore,
+    evaluator: BaseEvaluator,
+    evaluator_name: str,
+    query: Optional[str] = None,
+    response_str: Optional[str] = None,
+    contexts: Optional[Sequence[str]] = None,
+    eval_kwargs: Optional[Dict[str, Any]] = None,
+) -> Tuple[str, EvaluationResult]:
+    """Get aevaluate tasks with semaphore."""
+    eval_kwargs = eval_kwargs or {}
+    async with semaphore:
+        return (
+            evaluator_name,
+            await evaluator.aevaluate(
+                query=query, response=response_str, contexts=contexts, **eval_kwargs
+            ),
+        )
+
+
+async def response_worker(
+    semaphore: asyncio.Semaphore,
+    query_engine: BaseQueryEngine,
+    query: str,
+) -> RESPONSE_TYPE:
+    """Get aquery tasks with semaphore."""
+    async with semaphore:
+        return await query_engine.aquery(query)
 
 
 class BatchEvalRunner:
+    """Batch evaluation runner.
+
+    Args:
+        evaluators (Dict[str, BaseEvaluator]): Dictionary of evaluators.
+        workers (int): Number of workers to use for parallelization.
+            Defaults to 2.
+        show_progress (bool): Whether to show progress bars. Defaults to False.
+    
+    """
     def __init__(
         self,
         evaluators: Dict[str, BaseEvaluator],
         workers: int = 2,
+        show_progress: bool = False,
     ):
         self.evaluators = evaluators
         self.workers = workers
+        self.semaphore = asyncio.Semaphore(self.workers)
+        self.show_progress = show_progress
+        self.asyncio_mod = asyncio_module(show_progress=self.show_progress)
 
-    async def aevaluate_queries(
-        self,
-        query_engine: BaseQueryEngine,
-        queries: Optional[List[str]] = None,
-        query_kwargs: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, List[EvaluationResult]]:
-        if queries is None:
-            raise ValueError("`queries` must be provided")
-        query_kwargs = query_kwargs or {}
-
-        semaphore = asyncio.Semaphore(self.workers)
-
-        async def response_worker(
-            query_engine: BaseQueryEngine,
-            query: str,
-        ) -> RESPONSE_TYPE:
-            async with semaphore:
-                return await query_engine.aquery(query)
-
-        async def eval_worker(
-            evaluator: BaseEvaluator,
-            evaluator_name: str,
-            query: str,
-            response: Response,
-            evaluator_kwargs: Dict[str, Any],
-        ) -> Tuple[str, EvaluationResult]:
-            async with semaphore:
-                return (
-                    evaluator_name,
-                    await evaluator.aevaluate_response(
-                        query=query, response=response, **evaluator_kwargs
-                    ),
-                )
-
-        # gather responses
-        response_jobs = []
-        for query in queries:
-            response_jobs.append(response_worker(query_engine, query))
-        responses = await asyncio.gather(*response_jobs)
-
-        # run evaluations
-        eval_jobs = []
-        for query, response in zip(queries, responses):
-            for name, evaluator in self.evaluators.items():
-                eval_jobs.append(
-                    eval_worker(
-                        evaluator, name, query, response, query_kwargs.get(query, {})
-                    )
-                )
-        results = await asyncio.gather(*eval_jobs)
-
+    def _format_results(self, results: List[EvaluationResult]) -> Dict[str, List[EvaluationResult]]:
+        """Format results."""
         # Format results
         results_dict: Dict[str, List[EvaluationResult]] = {
             name: [] for name in self.evaluators.keys()
@@ -75,14 +87,217 @@ class BatchEvalRunner:
 
         return results_dict
 
+    def _validate_and_clean_inputs(
+        self,
+        *inputs_list: List[Any],
+    ) -> List[Any]:
+        """Validate and clean input lists.
+
+        Enforce that at least one of the inputs is not None.
+        Make sure that all inputs have the same length.
+        Make sure that None inputs are replaced with [None] * len(inputs).
+        
+        """
+        # first, make sure at least one of queries or response_strs is not None
+        input_len: Optional[int] = None
+        for inputs in inputs_list:
+            if inputs is not None:
+                input_len = len(inputs)
+                break
+        if input_len is None:
+            raise ValueError("At least one item in inputs_list must be provided.")
+
+        new_inputs_list = []
+        for inputs in inputs_list:
+            if inputs is None:
+                new_inputs_list.append([None] * input_len)
+            else:
+                if len(inputs) != input_len:
+                    raise ValueError("All inputs must have the same length.")
+                new_inputs_list.append(inputs)
+        return new_inputs_list
+
+    def _get_eval_kwargs(
+        self, eval_kwargs_lists: Dict[str, Any], idx: int
+    ) -> Dict[str, Any]:
+        """Get eval kwargs from eval_kwargs_lists at a given idx.
+
+        Since eval_kwargs_lists is a dict of lists, we need to get the
+        value at idx for each key.
+        
+        """
+        return {k: v[idx] for k, v in eval_kwargs_lists.items()}
+
+    async def aevaluate_response_strs(
+        self, 
+        queries: Optional[List[str]] = None,
+        response_strs: Optional[List[str]] = None,
+        contexts_list: Optional[List[List[str]]] = None,
+        **eval_kwargs_lists: Dict[str, Any],
+    ) -> Dict[str, List[EvaluationResult]]:
+        """Evaluate query, response pairs.
+
+        This evaluates queries, responses, contexts as string inputs.
+        Can supply additional kwargs to the evaluator in eval_kwargs_lists.
+
+        Args:
+            queries (Optional[List[str]]): List of query strings. Defaults to None.
+            response_strs (Optional[List[str]]): List of response strings. Defaults to None.
+            contexts_list (Optional[List[List[str]]]): List of context lists. Defaults to None.
+            **eval_kwargs_lists (Dict[str, Any]): Dict of lists of kwargs to pass to evaluator. 
+                Defaults to None.
+        
+        """
+        queries, response_strs, contexts_list = self._validate_and_clean_inputs(
+            queries, response_strs, contexts_list
+        )
+        for k in eval_kwargs_lists.keys():
+            v = eval_kwargs_lists[k]
+            if not isinstance(v, list):
+                raise ValueError(f"Each value in eval_kwargs must be a list. Got {k}: {v}")
+            eval_kwargs_lists[k] = self._validate_and_clean_inputs(v)[0]
+        
+        # run evaluations
+        eval_jobs = []
+        for idx, query in enumerate(queries):
+            response_str = response_strs[idx]
+            contexts = contexts_list[idx]
+            eval_kwargs = self._get_eval_kwargs(eval_kwargs_lists, idx)
+            for name, evaluator in self.evaluators.items():
+                eval_jobs.append(
+                    eval_worker(
+                        self.semaphore, evaluator, name, query=query, 
+                        response_str=response_str, contexts=contexts, 
+                        eval_kwargs=eval_kwargs
+                    )
+                )
+        results = await self.asyncio_mod.gather(*eval_jobs)
+
+        # Format results
+        return self._format_results(results)
+
+    async def aevaluate_responses(
+        self, 
+        queries: Optional[List[str]] = None,
+        responses: Optional[List[Response]] = None,
+        **eval_kwargs_lists: Dict[str, Any],
+    ) -> Dict[str, List[EvaluationResult]]:
+        """Evaluate query, response pairs.
+
+        This evaluates queries and response objects.
+
+        Args:
+            queries (Optional[List[str]]): List of query strings. Defaults to None.
+            responses (Optional[List[Response]]): List of response objects. Defaults to None.
+            **eval_kwargs_lists (Dict[str, Any]): Dict of lists of kwargs to pass to evaluator. 
+                Defaults to None.
+        
+        """
+        queries, responses = self._validate_and_clean_inputs(
+            queries, responses
+        )
+        for k in eval_kwargs_lists.keys():
+            v = eval_kwargs_lists[k]
+            if not isinstance(v, list):
+                raise ValueError(f"Each value in eval_kwargs must be a list. Got {k}: {v}")
+            eval_kwargs_lists[k] = self._validate_and_clean_inputs(v)[0]
+            
+        # run evaluations
+        eval_jobs = []
+        for idx, query in enumerate(queries):
+            response = responses[idx]
+            eval_kwargs = self._get_eval_kwargs(eval_kwargs_lists, idx)
+            for name, evaluator in self.evaluators.items():
+                eval_jobs.append(
+                    eval_response_worker(
+                        self.semaphore, evaluator, name, query=query, response=response, eval_kwargs=eval_kwargs
+                    )
+                )
+        results = await self.asyncio_mod.gather(*eval_jobs)
+
+        # Format results
+        return self._format_results(results)
+        
+
+    async def aevaluate_queries(
+        self,
+        query_engine: BaseQueryEngine,
+        queries: Optional[List[str]] = None,
+        **eval_kwargs_lists: Dict[str, Any],
+    ) -> Dict[str, List[EvaluationResult]]:
+        """Evaluate queries.
+        
+        Args:
+            query_engine (BaseQueryEngine): Query engine.
+            queries (Optional[List[str]]): List of query strings. Defaults to None.
+            **eval_kwargs_lists (Dict[str, Any]): Dict of lists of kwargs to pass to evaluator. 
+                Defaults to None.
+        
+        """
+        if queries is None:
+            raise ValueError("`queries` must be provided")
+
+        # gather responses
+        response_jobs = []
+        for query in queries:
+            response_jobs.append(response_worker(self.semaphore, query_engine, query))
+        responses = await self.asyncio_mod.gather(*response_jobs)
+
+        return await self.aevaluate_responses(
+            queries=queries,
+            responses=responses,
+            **eval_kwargs_lists,
+        )
+
+    def evaluate_response_strs(
+        self,
+        queries: Optional[List[str]] = None,
+        response_strs: Optional[List[str]] = None,
+        contexts_list: Optional[List[List[str]]] = None,
+        **eval_kwargs_lists: Dict[str, Any],
+    ) -> Dict[str, List[EvaluationResult]]:
+        """Evaluate query, response pairs.
+
+        Sync version of aevaluate_response_strs.
+        
+        """
+        return asyncio.run(
+            self.aevaluate_response_strs(
+                queries=queries, response_strs=response_strs, contexts_list=contexts_list,
+                **eval_kwargs_lists
+            )
+        )
+
+    def evaluate_responses(
+        self,
+        queries: Optional[List[str]] = None,
+        responses: Optional[List[Response]] = None,
+        **eval_kwargs_lists: Dict[str, Any],
+    ) -> Dict[str, List[EvaluationResult]]:
+        """Evaluate query, response objs.
+
+        Sync version of aevaluate_responses.
+        
+        """
+        return asyncio.run(
+            self.aevaluate_responses(
+                queries=queries, responses=responses, **eval_kwargs_lists,
+            )
+        )
+
     def evaluate_queries(
         self,
         query_engine: BaseQueryEngine,
         queries: Optional[List[str]] = None,
-        query_kwargs: Optional[Dict[str, Any]] = None,
+        **eval_kwargs_lists: Dict[str, Any],
     ) -> Dict[str, List[EvaluationResult]]:
+        """Evaluate queries.
+
+        Sync version of aevaluate_queries.
+        
+        """
         return asyncio.run(
             self.aevaluate_queries(
-                query_engine=query_engine, queries=queries, query_kwargs=query_kwargs
+                query_engine=query_engine, queries=queries, **eval_kwargs_lists,
             )
         )

--- a/llama_index/evaluation/eval_utils.py
+++ b/llama_index/evaluation/eval_utils.py
@@ -5,16 +5,14 @@ NOTE: These are beta functions, might change.
 """
 
 from llama_index.indices.query.base import BaseQueryEngine
-from llama_index.evaluation.base import EvaluationResult, BaseEvaluator
-from llama_index.utils import get_tqdm_iterable
 from typing import List, Any
 import asyncio
-import numpy as np
 
 
 def asyncio_module(show_progress: bool = False) -> Any:
     if show_progress:
         from tqdm.asyncio import tqdm_asyncio
+
         module = tqdm_asyncio
     else:
         module = asyncio
@@ -23,16 +21,14 @@ def asyncio_module(show_progress: bool = False) -> Any:
 
 
 async def aget_responses(
-    questions: List[str], 
-    query_engine: BaseQueryEngine,
-    show_progress: bool = False
+    questions: List[str], query_engine: BaseQueryEngine, show_progress: bool = False
 ) -> List[str]:
     """Get responses."""
     tasks = []
     for question in questions:
         tasks.append(query_engine.aquery(question))
-    asyncio_module = asyncio_module(show_progress=show_progress)
-    responses = await asyncio_module.gather(*tasks)
+    asyncio_mod = asyncio_module(show_progress=show_progress)
+    responses = await asyncio_mod.gather(*tasks)
     return responses
 
 
@@ -43,7 +39,7 @@ def get_responses(
     """Get responses.
 
     Sync version of aget_responses.
-    
+
     """
     responses = asyncio.run(aget_responses(*args, **kwargs))
     return responses

--- a/llama_index/evaluation/eval_utils.py
+++ b/llama_index/evaluation/eval_utils.py
@@ -1,0 +1,49 @@
+"""Get evaluation utils.
+
+NOTE: These are beta functions, might change.
+
+"""
+
+from llama_index.indices.query.base import BaseQueryEngine
+from llama_index.evaluation.base import EvaluationResult, BaseEvaluator
+from llama_index.utils import get_tqdm_iterable
+from typing import List, Any
+import asyncio
+import numpy as np
+
+
+def asyncio_module(show_progress: bool = False) -> Any:
+    if show_progress:
+        from tqdm.asyncio import tqdm_asyncio
+        module = tqdm_asyncio
+    else:
+        module = asyncio
+
+    return module
+
+
+async def aget_responses(
+    questions: List[str], 
+    query_engine: BaseQueryEngine,
+    show_progress: bool = False
+) -> List[str]:
+    """Get responses."""
+    tasks = []
+    for question in questions:
+        tasks.append(query_engine.aquery(question))
+    asyncio_module = asyncio_module(show_progress=show_progress)
+    responses = await asyncio_module.gather(*tasks)
+    return responses
+
+
+def get_responses(
+    *args: Any,
+    **kwargs: Any,
+) -> List[str]:
+    """Get responses.
+
+    Sync version of aget_responses.
+    
+    """
+    responses = asyncio.run(aget_responses(*args, **kwargs))
+    return responses


### PR DESCRIPTION
# Description

This upgrades our eval batch runner to allow it to evaluate over queries, responses, rather than having to run through the full query engine (which loses the ability to cache things). 

Also made a mildly breaking change:
- i found query_kwargs confusing to use, so instead replaced it with an eval_kwargs_list. you basically specify an argument name in the batch eval similar to how you would specify the argument name for a single evaluator, but the values are a list instead of a single value. 

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
