### PR TITLE
Fix KeyError in delete method of `SimpleVectorStore` related to metadata filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Normalize scores returned from ElasticSearch vector store (#7792)
 - Fixed `refresh_ref_docs()` bug with order of operations (#7664)
 - Delay postgresql connection for `PGVectorStore` until actually needed (#7793)
+- Fix KeyError in delete method of `SimpleVectorStore` related to metadata filters (#7829)
 
 ## [0.8.33] - 2023-09-25
 

--- a/llama_index/vector_stores/simple.py
+++ b/llama_index/vector_stores/simple.py
@@ -156,8 +156,11 @@ class SimpleVectorStore(VectorStore):
 
         for text_id in text_ids_to_delete:
             del self._data.embedding_dict[text_id]
-            del self._data.metadata_dict[text_id]
             del self._data.text_id_to_ref_doc_id[text_id]
+            # Handle metadata_dict not being present in stores that were persisted without metadata.
+            # Or not being present for nodes stored prior to metadata functionality.
+            if self._data.metadata_dict is not None:
+                self._data.metadata_dict.pop(text_id, None)
 
     def query(
         self,

--- a/llama_index/vector_stores/simple.py
+++ b/llama_index/vector_stores/simple.py
@@ -157,8 +157,9 @@ class SimpleVectorStore(VectorStore):
         for text_id in text_ids_to_delete:
             del self._data.embedding_dict[text_id]
             del self._data.text_id_to_ref_doc_id[text_id]
-            # Handle metadata_dict not being present in stores that were persisted without metadata.
-            # Or not being present for nodes stored prior to metadata functionality.
+            # Handle metadata_dict not being present in stores that were persisted
+            # without metadata, or, not being present for nodes stored
+            # prior to metadata functionality.
             if self._data.metadata_dict is not None:
                 self._data.metadata_dict.pop(text_id, None)
 


### PR DESCRIPTION
# Description

Details in #7829, KeyError when trying to delete metadata that doesn't exist in indexes older than when metadata was introduced. This adds some safety. 

Fixes #7829 

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Tested locally on an index older than llama-index 0.8.29 that originally had the issue. Run unit tests on vector_store. 

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
