### PR TITLE
ElasticsearchStore: Update User-Agent + Add example docker compose

### DIFF
--- a/tests/vector_stores/docker-compose/elasticsearch.yml
+++ b/tests/vector_stores/docker-compose/elasticsearch.yml
@@ -1,0 +1,20 @@
+version: "3"
+
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.10.0 # https://www.docker.elastic.co/r/elasticsearch/elasticsearch
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false # security has been disabled, so no login or password is required.
+      - xpack.security.http.ssl.enabled=false
+      - xpack.license.self_generated.type=trial
+    ports:
+      - "9200:9200"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl --silent --fail http://localhost:9200/_cluster/health || exit 1",
+        ]
+      interval: 10s
+      retries: 60


### PR DESCRIPTION
# Description

This updates the user agent for Elasticsearch client when used for llama-index.

I've also added an example docker compose file so tests can be run against this local elasticsearch instance. 

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Added new unit/integration tests

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
