### PR TITLE
Fix dropping textnodes in recursive retriever

### DIFF
--- a/llama_index/retrievers/recursive_retriever.py
+++ b/llama_index/retrievers/recursive_retriever.py
@@ -84,7 +84,7 @@ class RecursiveRetriever(BaseRetriever):
                     new_nodes_with_score.append(node_with_score)
             else:
                 new_nodes_with_score.append(node_with_score)
-            
+
         nodes_with_score = new_nodes_with_score
 
         # recursively retrieve

--- a/llama_index/retrievers/recursive_retriever.py
+++ b/llama_index/retrievers/recursive_retriever.py
@@ -8,7 +8,6 @@ from llama_index.schema import TextNode, IndexNode, NodeWithScore, BaseNode
 from llama_index.bridge.langchain import print_text
 from llama_index.indices.base_retriever import BaseRetriever
 
-
 DEFAULT_QUERY_RESPONSE_TMPL = "Query: {query_str}\nResponse: {response}"
 
 
@@ -83,6 +82,9 @@ class RecursiveRetriever(BaseRetriever):
                 if node.index_id not in visited_ids:
                     visited_ids.add(node.index_id)
                     new_nodes_with_score.append(node_with_score)
+            else:
+                new_nodes_with_score.append(node_with_score)
+            
         nodes_with_score = new_nodes_with_score
 
         # recursively retrieve


### PR DESCRIPTION
# Description

The RecursiveRetriever was dropping text nodes on the floor during a filter pass to avoid repeating index nodes.

Fixes #7749

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
