### PR TITLE
share callback_manager between agent and its llm when callback_manager is None

### DIFF
--- a/llama_index/agent/openai_agent.py
+++ b/llama_index/agent/openai_agent.py
@@ -122,7 +122,7 @@ class BaseOpenAIAgent(BaseAgent):
         self._max_function_calls = max_function_calls
         self.prefix_messages = prefix_messages
         self.memory = memory
-        self.callback_manager = callback_manager or CallbackManager([])
+        self.callback_manager = callback_manager or self._llm.callback_manager
         self.sources: List[ToolOutput] = []
 
     @property

--- a/llama_index/agent/react/base.py
+++ b/llama_index/agent/react/base.py
@@ -60,7 +60,7 @@ class ReActAgent(BaseAgent):
             tools=tools
         )
         self._output_parser = output_parser or ReActOutputParser()
-        self.callback_manager = callback_manager or CallbackManager([])
+        self.callback_manager = callback_manager or self._llm.callback_manager
         self._verbose = verbose
 
     @classmethod


### PR DESCRIPTION
# Description

At agent initialization, if the `callback_manager` argument is None, initialize the agent's `callback_manager` to be the same as the one belonging to the agent's LLM, instead of constructing a brand new one.

Fixes #7843

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
