### PR TITLE
Add missing dependency of tree_sitter_languages and update the CONTRIBUTING.md to install data_requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -317,6 +317,7 @@ For bigger changes, you'll want to create a unit test. Our tests are in the `tes
 We use `pytest` for unit testing. To run all unit tests, run the following in the root dir:
 
 ```bash
+pip install -r data_requirements.txt
 pytest tests
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ install_requires = [
     "beautifulsoup4",  # hotfix for langchain 0.0.212 bug
     "nest_asyncio",
     "nltk",
+    "tree_sitter_languages",
 ]
 
 setup(


### PR DESCRIPTION
Disclaimer: first time contributing to llama_index and if I miss or misunderstand something, please correct me. 🙏 

# Description

- Update the `CONTRIBUTING.md` to install dependencies specified in `data_requirements.txt`. Otherwise, `pytest tests` would fail with following error, ![Screenshot 2023-09-27 at 4 59 39 PM](https://github.com/jerryjliu/llama_index/assets/97481652/0225d946-f596-4d55-a9d1-1add4a67c22e)
- Add missing dependency of `tree_sitter_languages` which is required by `CodeSpliter` and I found this issue because `pytest tests` failed with the following errors ![Screenshot 2023-09-27 at 5 00 37 PM](https://github.com/jerryjliu/llama_index/assets/97481652/9fe182ae-0781-4c2d-9105-381258459ff6)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I was able to successfully run `pytest tests` without errors. To reproduce, 

- checkout the main branch as of Sep 27
- `pip install -r requirements.txt`
- `pytest tests` which should fail with the errors as ![Screenshot 2023-09-27 at 4 59 39 PM](https://github.com/jerryjliu/llama_index/assets/97481652/0225d946-f596-4d55-a9d1-1add4a67c22e)

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes