### PR TITLE
Update schema.py

### DIFF
--- a/llama_index/response/schema.py
+++ b/llama_index/response/schema.py
@@ -83,11 +83,13 @@ class StreamingResponse:
         else:
             print(self.response_txt)
 
-    def get_formatted_sources(self, length: int = 100) -> str:
+    def get_formatted_sources(self, length: int = 100, trim_text: int = True) -> str:
         """Get formatted sources text."""
         texts = []
         for source_node in self.source_nodes:
-            fmt_text_chunk = truncate_text(source_node.node.get_content(), length)
+            fmt_text_chunk = source_node.node.get_content()
+            if trim_text:
+                fmt_text_chunk = truncate_text(fmt_text_chunk, length)
             node_id = source_node.node.node_id or "None"
             source_text = f"> Source (Node id: {node_id}): {fmt_text_chunk}"
             texts.append(source_text)


### PR DESCRIPTION
There should be an option in get_formatted_sources to not truncate at all. I have updated the function. Please review.

# Description

When getting the get_formated_sources, the text is truncated by default. It should have an option to not truncate the text at all. 
Fixes # (issue)

## Type of Change
I have updated the get_formated_sources with an additional argument which does not change the functionality, since it is true by default, but can be false if someone does not want it. 




Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)


# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
