### PR TITLE
Fix handling of empy queries

### DIFF
--- a/llama_index/indices/query/schema.py
+++ b/llama_index/indices/query/schema.py
@@ -34,6 +34,8 @@ class QueryBundle(DataClassJsonMixin):
     def embedding_strs(self) -> List[str]:
         """Use custom embedding strs if specified, otherwise use query str."""
         if self.custom_embedding_strs is None:
+            if len(self.query_str) == 0:
+                return []
             return [self.query_str]
         else:
             return self.custom_embedding_strs

--- a/llama_index/indices/vector_store/retrievers/retriever.py
+++ b/llama_index/indices/vector_store/retrievers/retriever.py
@@ -78,7 +78,7 @@ class VectorIndexRetriever(BaseRetriever):
         query_bundle: QueryBundle,
     ) -> List[NodeWithScore]:
         if self._vector_store.is_embedding_query:
-            if query_bundle.embedding is None:
+            if query_bundle.embedding is None and len(query_bundle.embedding_strs) > 0:
                 query_bundle.embedding = (
                     self._service_context.embed_model.get_agg_embedding_from_queries(
                         query_bundle.embedding_strs
@@ -88,7 +88,7 @@ class VectorIndexRetriever(BaseRetriever):
 
     async def _aretrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
         if self._vector_store.is_embedding_query:
-            if query_bundle.embedding is None:
+            if query_bundle.embedding is None and len(query_bundle.embedding_strs) > 0:
                 embed_model = self._service_context.embed_model
                 query_bundle.embedding = (
                     await embed_model.aget_agg_embedding_from_queries(


### PR DESCRIPTION
# Description

Sometimes the retriever will get an empty query. For example, the AutoRetriever may decide to query only the metadata. Before this commit, that caused an exception due to trying to get an embedding on an empty string. This commit fixes things so that the embedding step is skipped when the query string is empty.


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
