### PR TITLE
Nice-ified `JSONDecodeError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Simplify NL SQL response to SQL parsing, with expanded NL SQL prompt (#7868)
 - Improve vector store retrieval speed for vectordb integrations (#7876)
 - Added replacing {{ and }}, and fixed JSON parsing recursion (#7888)
+- Nice-ified JSON decoding error (#7891)
 
 ## [0.8.36] - 2023-09-27
 

--- a/llama_index/output_parsers/selection.py
+++ b/llama_index/output_parsers/selection.py
@@ -82,8 +82,13 @@ class SelectionOutputParser(BaseOutputParser):
         return output_json
 
     def parse(self, output: str) -> Any:
-        output = _marshal_llm_to_json(output)
-        json_output = json.loads(output)
+        json_output = _marshal_llm_to_json(output)
+        try:
+            json_output = json.loads(json_output)
+        except json.decoder.JSONDecodeError as exc:
+            raise ValueError(
+                f"Failed to convert LLM output {output!r} to JSON."
+            ) from exc
         if isinstance(json_output, dict):
             json_output = [json_output]
 

--- a/llama_index/output_parsers/selection.py
+++ b/llama_index/output_parsers/selection.py
@@ -82,9 +82,8 @@ class SelectionOutputParser(BaseOutputParser):
         return output_json
 
     def parse(self, output: str) -> Any:
-        json_output = _marshal_llm_to_json(output)
         try:
-            json_output = json.loads(json_output)
+            json_output = json.loads(s=_marshal_llm_to_json(output))
         except json.decoder.JSONDecodeError as exc:
             raise ValueError(
                 f"Failed to convert LLM output {output!r} to JSON."

--- a/tests/output_parsers/test_selection.py
+++ b/tests/output_parsers/test_selection.py
@@ -1,3 +1,5 @@
+import json.decoder
+
 import pytest
 
 from llama_index.output_parsers.base import StructuredOutput
@@ -35,6 +37,11 @@ def test_format(output_parser: SelectionOutputParser) -> None:
             id="double_curly",
         ),
         pytest.param(
+            '\nOutput:\n[\n  {\n    "choice": 1,\n    "reason": "just because"\n  }\n]',
+            1,
+            id="https://github.com/jerryjliu/llama_index/issues/3135",
+        ),
+        pytest.param(
             """ Based on the given choices, the <shortened> question "<redacted>?" is:
 (1) Useful for <redacted>
 The reason for this choice is <redacted>. Therefore, option (1) is the most <shortened>
@@ -70,22 +77,13 @@ def test_parse(
     assert parsed.parsed_output[0].reason == "just because"
 
 
-def test_parse_non_json_friendly_llm_output(
-    output_parser: SelectionOutputParser,
-) -> None:
-    # https://github.com/jerryjliu/llama_index/issues/3135
-    output = """
-    Output:
-    [
-      {
-        "choice": 1,
-        "reason": "Useful for questions"
-      }
-    ]
-    """
-    parsed = output_parser.parse(output)
-    assert isinstance(parsed, StructuredOutput)
-    assert isinstance(parsed.parsed_output, list)
-    assert len(parsed.parsed_output) == 1
-    assert parsed.parsed_output[0].choice == 1
-    assert parsed.parsed_output[0].reason == "Useful for questions"
+def test_failed_parse(output_parser: SelectionOutputParser) -> None:
+    no_json_in_response = (
+        " Based on the given choices, the most relevant choice for the question"
+        " 'What are the <redacted>?' is:\n\n(1) <redacted>.\n\nThe reason for"
+        " this choice is that <redacted>. Therefore, choosing option (1) would"
+        " provide the most relevant information for finding the <redacted>."
+    )
+    with pytest.raises(ValueError, match="Failed to convert") as exc_info:
+        output_parser.parse(output=no_json_in_response)
+    assert isinstance(exc_info.value.__cause__, json.decoder.JSONDecodeError)


### PR DESCRIPTION
# Description

- Nice-ified `JSONDecodeError` for LLM responses that didn't listen
- Combined two test cases into one (extra parameterized case

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense
