### PR TITLE
Pass down kwargs from AutoRetriever to IndexRetriever

### DIFF
--- a/llama_index/indices/vector_store/retrievers/auto_retriever/auto_retriever.py
+++ b/llama_index/indices/vector_store/retrievers/auto_retriever/auto_retriever.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional, cast
+from typing import Any, List, Optional, cast
 
 from llama_index.constants import DEFAULT_SIMILARITY_TOP_K
 from llama_index.indices.base_retriever import BaseRetriever
@@ -59,6 +59,7 @@ class VectorIndexAutoRetriever(BaseRetriever):
         max_top_k: int = 10,
         similarity_top_k: int = DEFAULT_SIMILARITY_TOP_K,
         vector_store_query_mode: VectorStoreQueryMode = VectorStoreQueryMode.DEFAULT,
+        **kwargs: Any,
     ) -> None:
         self._index = index
         self._vector_store_info = vector_store_info
@@ -78,6 +79,7 @@ class VectorIndexAutoRetriever(BaseRetriever):
         self._max_top_k = max_top_k
         self._similarity_top_k = similarity_top_k
         self._vector_store_query_mode = vector_store_query_mode
+        self._kwargs = kwargs
 
     def _retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
         # prepare input
@@ -125,5 +127,6 @@ class VectorIndexAutoRetriever(BaseRetriever):
             filters=MetadataFilters(filters=query_spec.filters),
             similarity_top_k=similarity_top_k,
             vector_store_query_mode=self._vector_store_query_mode,
+            **self._kwargs,
         )
         return retriever.retrieve(query_spec.query)


### PR DESCRIPTION
# Description

Kwargs should be passed down. For example, a user may want to pass down vector_store_kwargs.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
