### PR TITLE
Nice-ified SQL Alchemy `ProgrammingError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Improve vector store retrieval speed for vectordb integrations (#7876)
 - Added replacing {{ and }}, and fixed JSON parsing recursion (#7888)
 - Nice-ified JSON decoding error (#7891)
+- Nice-ified SQL error from LLM not providing SQL (#7900)
 
 ## [0.8.36] - 2023-09-27
 

--- a/tests/indices/struct_store/test_sql_query.py
+++ b/tests/indices/struct_store/test_sql_query.py
@@ -1,7 +1,9 @@
 import asyncio
 from typing import Any, Dict, Tuple
 
+import pytest
 from sqlalchemy import Column, Integer, MetaData, String, Table, create_engine
+from sqlalchemy.exc import OperationalError
 
 from llama_index.indices.service_context import ServiceContext
 from llama_index.indices.struct_store.base import default_output_parser
@@ -56,6 +58,10 @@ def test_sql_index_query(
     nl_table_engine = NLSQLTableQueryEngine(index.sql_database)
     response = nl_table_engine.query("test_table:user_id,foo")
     assert str(response) == "[(2, 'bar'), (8, 'hello')]"
+
+    with pytest.raises(NotImplementedError, match="invalid SQL") as exc_info:
+        sql_query_engine.query("LLM didn't provide SQL at all")
+    assert isinstance(exc_info.value.__cause__, OperationalError)
 
 
 def test_sql_index_async_query(


### PR DESCRIPTION
# Description

- Nice-ified SQL errors for LLM responses that didn't listen to prompt

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
