### PR TITLE
If results directory doesn't exist evaluate_st should create it

### DIFF
--- a/docs/examples/finetuning/embeddings/finetune_embedding.ipynb
+++ b/docs/examples/finetuning/embeddings/finetune_embedding.ipynb
@@ -532,6 +532,7 @@
     "from sentence_transformers import SentenceTransformer\n",
     "from pathlib import Path\n",
     "\n",
+    "\n",
     "def evaluate_st(\n",
     "    dataset,\n",
     "    model_id,\n",
@@ -543,7 +544,7 @@
     "\n",
     "    evaluator = InformationRetrievalEvaluator(queries, corpus, relevant_docs, name=name)\n",
     "    model = SentenceTransformer(model_id)\n",
-    "    output_path=\"results/\"\n",
+    "    output_path = \"results/\"\n",
     "    Path(output_path).mkdir(exist_ok=True, parents=True)\n",
     "    return evaluator(model, output_path=output_path)"
    ]

--- a/docs/examples/finetuning/embeddings/finetune_embedding.ipynb
+++ b/docs/examples/finetuning/embeddings/finetune_embedding.ipynb
@@ -530,7 +530,7 @@
    "source": [
     "from sentence_transformers.evaluation import InformationRetrievalEvaluator\n",
     "from sentence_transformers import SentenceTransformer\n",
-    "\n",
+    "from pathlib import Path\n",
     "\n",
     "def evaluate_st(\n",
     "    dataset,\n",
@@ -543,7 +543,9 @@
     "\n",
     "    evaluator = InformationRetrievalEvaluator(queries, corpus, relevant_docs, name=name)\n",
     "    model = SentenceTransformer(model_id)\n",
-    "    return evaluator(model, output_path=\"results/\")"
+    "    output_path=\"results/\"\n",
+    "    Path(output_path).mkdir(exist_ok=True, parents=True)\n",
+    "    return evaluator(model, output_path=output_path)"
    ]
   },
   {


### PR DESCRIPTION
# Description

The notebook currently contains a [stack trace](https://gpt-index.readthedocs.io/en/stable/examples/finetuning/embeddings/finetune_embedding.html#baai-bge-small-en) caused by the "results" folder not existing when InformationRetrievalEvaluator. This adds code to create the folder if it's missing.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
