### PR TITLE
`LlamaCPP` overrides via `model_kwargs`

### DIFF
--- a/llama_index/llms/llama_cpp.py
+++ b/llama_index/llms/llama_cpp.py
@@ -29,16 +29,14 @@ DEFAULT_LLAMA_CPP_GGML_MODEL = (
     "https://huggingface.co/TheBloke/Llama-2-13B-chat-GGML/resolve"
     "/main/llama-2-13b-chat.ggmlv3.q4_0.bin"
 )
-
 DEFAULT_LLAMA_CPP_GGUF_MODEL = (
     "https://huggingface.co/TheBloke/Llama-2-13B-chat-GGUF/resolve"
     "/main/llama-2-13b-chat.Q4_0.gguf"
 )
+DEFAULT_LLAMA_CPP_MODEL_VERBOSITY = True
 
 
 class LlamaCPP(CustomLLM):
-    DEFAULT_VERBOSITY = True
-
     model_url: Optional[str] = Field(
         description="The URL llama-cpp model to download and use."
     )
@@ -64,7 +62,8 @@ class LlamaCPP(CustomLLM):
         default_factory=dict, description="Kwargs used for model initialization."
     )
     verbose: bool = Field(
-        default=DEFAULT_VERBOSITY, description="Whether to print verbose output."
+        default=DEFAULT_LLAMA_CPP_MODEL_VERBOSITY,
+        description="Whether to print verbose output.",
     )
 
     _model: Any = PrivateAttr()
@@ -81,7 +80,7 @@ class LlamaCPP(CustomLLM):
         callback_manager: Optional[CallbackManager] = None,
         generate_kwargs: Optional[Dict[str, Any]] = None,
         model_kwargs: Optional[Dict[str, Any]] = None,
-        verbose: bool = DEFAULT_VERBOSITY,
+        verbose: bool = DEFAULT_LLAMA_CPP_MODEL_VERBOSITY,
     ) -> None:
         try:
             from llama_cpp import Llama

--- a/llama_index/llms/llama_cpp.py
+++ b/llama_index/llms/llama_cpp.py
@@ -131,12 +131,14 @@ class LlamaCPP(CustomLLM):
             model_path=model_path,
             model_url=model_url,
             temperature=temperature,
+            context_window=context_window,
             max_new_tokens=max_new_tokens,
             messages_to_prompt=messages_to_prompt,
             completion_to_prompt=completion_to_prompt,
             callback_manager=callback_manager,
             generate_kwargs=generate_kwargs,
             model_kwargs=model_kwargs,
+            verbose=verbose,
         )
 
     @classmethod


### PR DESCRIPTION
# Description

I find it awkward to pass some `Llama` configurations via `model_kwargs` and some via pass throughs like `verbose`/`context_window`.  This PR makes it so you can just use `model_kwargs` like a true wrapper

- Removes statefulness of wrapped `Llama` vs `LlamaCPP` object
    - Not passing `verbose`/`context_window` to `super()`, since it's not used by a super class (please confirm here)
- Defined defaults in `pydantic` model

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
