### PR TITLE
Fix warnings shown when running pytests

### DIFF
--- a/llama_index/indices/knowledge_graph/retrievers.py
+++ b/llama_index/indices/knowledge_graph/retrievers.py
@@ -225,7 +225,7 @@ class KGTableRetriever(BaseRetriever):
                 for node_id in node_ids:
                     chunk_indices_count[node_id] += 1
         elif len(self._index_struct.embedding_dict) == 0:
-            logger.warn(
+            logger.warning(
                 "Index was not constructed with embeddings, skipping embedding usage..."
             )
 

--- a/tests/indices/tree/test_index.py
+++ b/tests/indices/tree/test_index.py
@@ -1,5 +1,7 @@
 """Test tree index."""
 
+import pytest
+
 from typing import Any, Dict, List, Optional
 from unittest.mock import patch
 
@@ -89,6 +91,7 @@ OUTPUTS = [
 ]
 
 
+@pytest.mark.filterwarnings("ignore:coroutine .* was never awaited")
 @patch("llama_index.indices.common_tree.base.run_async_tasks", side_effect=[OUTPUTS])
 def test_build_tree_async(
     _mock_run_async_tasks: Any,

--- a/tests/indices/tree/test_index.py
+++ b/tests/indices/tree/test_index.py
@@ -1,7 +1,5 @@
 """Test tree index."""
 
-import pytest
-
 from typing import Any, Dict, List, Optional
 from unittest.mock import patch
 
@@ -91,7 +89,6 @@ OUTPUTS = [
 ]
 
 
-@pytest.mark.filterwarnings("ignore:coroutine .* was never awaited")
 @patch("llama_index.indices.common_tree.base.run_async_tasks", side_effect=[OUTPUTS])
 def test_build_tree_async(
     _mock_run_async_tasks: Any,

--- a/tests/llms/test_custom.py
+++ b/tests/llms/test_custom.py
@@ -9,6 +9,8 @@ from llama_index.llms.custom import CustomLLM
 
 
 class TestLLM(CustomLLM):
+    __test__ = False
+
     def __init__(self) -> None:
         super().__init__(callback_manager=None)
 

--- a/tests/objects/test_node_mapping.py
+++ b/tests/objects/test_node_mapping.py
@@ -10,6 +10,8 @@ from llama_index.tools.function_tool import FunctionTool
 class TestObject(BaseModel):
     """Test object for node mapping."""
 
+    __test__ = False
+
     name: str
 
     def __hash__(self) -> int:

--- a/tests/output_parsers/test_pydantic.py
+++ b/tests/output_parsers/test_pydantic.py
@@ -13,6 +13,7 @@ class AttrDict(BaseModel):
 
 
 class TestModel(BaseModel):
+    __test__ = False
     title: str
     attr_dict: AttrDict
 

--- a/tests/program/test_llm_program.py
+++ b/tests/program/test_llm_program.py
@@ -18,6 +18,7 @@ class MockLLM(MagicMock):
 
 
 class TestModel(BaseModel):
+    __test__ = False
     hello: str
 
 

--- a/tests/prompts/test_guidance_utils.py
+++ b/tests/prompts/test_guidance_utils.py
@@ -16,6 +16,7 @@ def test_convert_to_handlebars() -> None:
 
 
 class TestSimpleModel(BaseModel):
+    __test__ = False
     attr0: str
     attr1: str
 
@@ -29,6 +30,7 @@ EXPECTED_SIMPLE_STR = """\
 
 
 class TestNestedModel(BaseModel):
+    __test__ = False
     attr2: List[TestSimpleModel]
 
 


### PR DESCRIPTION
# Description

This PR is to fix all the warnings when we run `pytest tests` as shown in 
<img width="1085" alt="Screenshot 2023-09-29 at 4 08 36 PM" src="https://github.com/jerryjliu/llama_index/assets/15270819/4bfde4c8-8e35-47d1-b59c-7b5f6b7f3799">. 

3 types of warning are observed, 
- `pytest` throws warnings when class names start with `Test` but have `__ini__` in them because that's how `pytest` discovers test cases. In the llama_index code base, for example `TestLLM` in `llms/test_custom.py` is just a dummy class to support the tests instead of a test class needed to be discovered and run by `pytest`. According to [this SO](https://stackoverflow.com/questions/62460557/cannot-collect-test-class-testmain-because-it-has-a-init-constructor-from), I added a `__test__ = False` to those dummy classes to remove those warnings.
- `logger.warn` is deprecated and I replace it with `logger.warning`
- the last one is a bit tricky. In `tests/indices/tree/test_index.py`, there is a test case of `test_build_tree_async` which has a mock on `llama_index.indices.common_tree.base.run_async_tasks`. We have a mock function `patch_llmpredictor_apredict` which is invoked and becomes a coroutine before passed into `run_async_tasks`. Because `run_async_tasks` was mocked and there is no `await` is invoked on that coroutine, `pytest` warns us that that coroutine was never `awaited`. The simplest approach in my 2cents is to suppress the warning and after fiddling with `pytest.mark.filterwarning` for a while, I still could not fully resolve it. For the time being, I will leave that untouched then. 

After those changes, here is the only warning shown
<img width="1085" alt="Screenshot 2023-09-29 at 4 24 40 PM" src="https://github.com/jerryjliu/llama_index/assets/15270819/37eb76ec-88be-47f9-af25-dba652794deb">

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
