### PR TITLE
Only truncate responses if there are responses during dataset generation

### DIFF
--- a/llama_index/evaluation/dataset_generation.py
+++ b/llama_index/evaluation/dataset_generation.py
@@ -248,9 +248,10 @@ class DatasetGenerator:
             query_ids = query_ids[:num]
             # truncate queries, responses to the subset of query ids
             queries = {query_id: queries[query_id] for query_id in query_ids}
-            responses_dict = {
-                query_id: responses_dict[query_id] for query_id in query_ids
-            }
+            if generate_response:
+                responses_dict = {
+                    query_id: responses_dict[query_id] for query_id in query_ids
+                }
 
         return QueryResponseDataset(queries=queries, responses=responses_dict)
 


### PR DESCRIPTION
# Description

I was running into a [crash bug](https://gist.github.com/seldo/ba532e53a60200d382396ae20857a674) when attempting to replicate [this notebook](https://gpt-index.readthedocs.io/en/stable/examples/finetuning/openai_fine_tuning.html).

In `dataset_generation` the method `generate_dataset_from_nodes` calls `_agenerate_dataset` with `generate_response` set to `True` and everything works fine. `generate_questions_from_nodes` calls it with that variable set to `False`.

When `generate_response` is false, the code attempts to truncate the `responses_dict` to the exact set of keys in `queries`, but since there are no responses the dict is empty and you get a KeyError. The fix is to only attempt this truncation if `generate_responses` is True.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
