### PR TITLE
eval fixes: fix dataset response generation, add score to evaluators

### DIFF
--- a/llama_index/evaluation/correctness.py
+++ b/llama_index/evaluation/correctness.py
@@ -33,6 +33,12 @@ you should give a score of 1.
 you should give a score between 2 and 3.
 - If the generated answer is relevant and fully correct, \
 you should give a score between 4 and 5.
+
+Example Response:
+4.0
+The generated answer has the exact same metrics as the reference answer, \
+    but it is not as concise.
+
 """
 
 DEFAULT_USER_TEMPLATE = """

--- a/llama_index/evaluation/dataset_generation.py
+++ b/llama_index/evaluation/dataset_generation.py
@@ -189,6 +189,7 @@ class DatasetGenerator:
         else:
             async_module = asyncio
 
+        summary_indices: List[SummaryIndex] = []
         for node in nodes:
             if num is not None and len(queries) >= num:
                 break
@@ -211,9 +212,10 @@ class DatasetGenerator:
                 self.question_gen_query,
             )
             query_tasks.append(task)
+            summary_indices.append(index)
 
         responses = await async_module.gather(*query_tasks)
-        for response in responses:
+        for idx, response in enumerate(responses):
             result = str(response).strip().split("\n")
             cleaned_questions = [
                 re.sub(r"^\d+[\).\s]", "", question).strip() for question in result
@@ -227,6 +229,7 @@ class DatasetGenerator:
             queries.update(cur_queries)
 
             if generate_response:
+                index = summary_indices[idx]
                 qr_tasks = []
                 cur_query_items = list(cur_queries.items())
                 cur_query_keys = [query_id for query_id, _ in cur_query_items]

--- a/llama_index/evaluation/eval_utils.py
+++ b/llama_index/evaluation/eval_utils.py
@@ -50,16 +50,23 @@ def get_responses(
 
 
 def get_results_df(
-    eval_results_list: List[EvaluationResult], 
-    names: List[str], 
-    metric_keys: List[str]
+    eval_results_list: List[EvaluationResult], names: List[str], metric_keys: List[str]
 ) -> pd.DataFrame:
+    """Get results df.
+
+    Args:
+        eval_results_list (List[EvaluationResult]):
+            List of evaluation results.
+        names (List[str]):
+            Names of the evaluation results.
+        metric_keys (List[str]):
+            List of metric keys to get.
+
+    """
     metric_dict = defaultdict(list)
     metric_dict["names"] = names
     for metric_key in metric_keys:
         for eval_results in eval_results_list:
-            mean_score = np.array(
-                [r.score for r in eval_results[metric_key]]
-            ).mean()
+            mean_score = np.array([r.score for r in eval_results[metric_key]]).mean()
             metric_dict[metric_key].append(mean_score)
     return pd.DataFrame(metric_dict)

--- a/llama_index/evaluation/eval_utils.py
+++ b/llama_index/evaluation/eval_utils.py
@@ -5,8 +5,12 @@ NOTE: These are beta functions, might change.
 """
 
 from llama_index.indices.query.base import BaseQueryEngine
+from llama_index.evaluation.base import EvaluationResult
+import pandas as pd
+import numpy as np
 from typing import List, Any
 import asyncio
+from collections import defaultdict
 
 
 def asyncio_module(show_progress: bool = False) -> Any:
@@ -43,3 +47,19 @@ def get_responses(
     """
     responses = asyncio.run(aget_responses(*args, **kwargs))
     return responses
+
+
+def get_results_df(
+    eval_results_list: List[EvaluationResult], 
+    names: List[str], 
+    metric_keys: List[str]
+) -> pd.DataFrame:
+    metric_dict = defaultdict(list)
+    metric_dict["names"] = names
+    for metric_key in metric_keys:
+        for eval_results in eval_results_list:
+            mean_score = np.array(
+                [r.score for r in eval_results[metric_key]]
+            ).mean()
+            metric_dict[metric_key].append(mean_score)
+    return pd.DataFrame(metric_dict)

--- a/llama_index/evaluation/faithfulness.py
+++ b/llama_index/evaluation/faithfulness.py
@@ -131,6 +131,7 @@ class FaithfulnessEvaluator(BaseEvaluator):
             response=response,
             contexts=contexts,
             passing=passing,
+            score=1.0 if passing else 0.0,
             feedback=raw_response_txt,
         )
 

--- a/llama_index/evaluation/guideline.py
+++ b/llama_index/evaluation/guideline.py
@@ -98,5 +98,6 @@ class GuidelineEvaluator(BaseEvaluator):
             query=query,
             response=response,
             passing=eval_data.passing,
+            score=1.0 if eval_data.passing else 0.0,
             feedback=eval_data.feedback,
         )

--- a/llama_index/evaluation/relevancy.py
+++ b/llama_index/evaluation/relevancy.py
@@ -113,6 +113,7 @@ class RelevancyEvaluator(BaseEvaluator):
             query=query,
             response=response,
             passing=passing,
+            score=1.0 if passing else 0.0,
             feedback=raw_response_txt,
         )
 

--- a/tests/evaluation/test_dataset_generation.py
+++ b/tests/evaluation/test_dataset_generation.py
@@ -6,17 +6,16 @@ from llama_index.prompts.base import PromptTemplate
 from llama_index.prompts.prompt_type import PromptType
 from llama_index.schema import TextNode
 
+
 def test_dataset_generation(
     mock_service_context: ServiceContext,
 ) -> None:
     """Test dataset generation."""
-    
-    test_nodes = [
-        TextNode(text="hello_world"),
-        TextNode(text="foo_bar")
-    ]
 
-    question_gen_prompt = PromptTemplate("""\
+    test_nodes = [TextNode(text="hello_world"), TextNode(text="foo_bar")]
+
+    question_gen_prompt = PromptTemplate(
+        """\
 Context information is below.
 ---------------------
 {context_str}
@@ -24,13 +23,15 @@ Context information is below.
 Given the context information and not prior knowledge.
 generate only questions based on the below query.
 {query_str}
-""", prompt_type=PromptType.QUESTION_ANSWER)
+""",
+        prompt_type=PromptType.QUESTION_ANSWER,
+    )
 
     dataset_generator = DatasetGenerator(
         test_nodes,
         service_context=mock_service_context,
         text_question_template=question_gen_prompt,
-        question_gen_query="gen_question"
+        question_gen_query="gen_question",
     )
     eval_dataset = dataset_generator.generate_dataset_from_nodes()
     qr_pairs = eval_dataset.qr_pairs
@@ -42,6 +43,3 @@ generate only questions based on the below query.
     assert qr_pairs[0][1] == "gen_question:hello_world:hello_world"
     assert qr_pairs[1][0] == "gen_question:foo_bar"
     assert qr_pairs[1][1] == "gen_question:foo_bar:foo_bar"
-        
-        
-        

--- a/tests/evaluation/test_dataset_generation.py
+++ b/tests/evaluation/test_dataset_generation.py
@@ -1,0 +1,47 @@
+"""Test dataset generation."""
+
+from llama_index.evaluation.dataset_generation import DatasetGenerator
+from llama_index.indices.service_context import ServiceContext
+from llama_index.prompts.base import PromptTemplate
+from llama_index.prompts.prompt_type import PromptType
+from llama_index.schema import TextNode
+
+def test_dataset_generation(
+    mock_service_context: ServiceContext,
+) -> None:
+    """Test dataset generation."""
+    
+    test_nodes = [
+        TextNode(text="hello_world"),
+        TextNode(text="foo_bar")
+    ]
+
+    question_gen_prompt = PromptTemplate("""\
+Context information is below.
+---------------------
+{context_str}
+---------------------
+Given the context information and not prior knowledge.
+generate only questions based on the below query.
+{query_str}
+""", prompt_type=PromptType.QUESTION_ANSWER)
+
+    dataset_generator = DatasetGenerator(
+        test_nodes,
+        service_context=mock_service_context,
+        text_question_template=question_gen_prompt,
+        question_gen_query="gen_question"
+    )
+    eval_dataset = dataset_generator.generate_dataset_from_nodes()
+    qr_pairs = eval_dataset.qr_pairs
+    assert len(qr_pairs) == 2
+    # the mock LLM concatenates query with context with ":"
+    # the first call is to generate the question
+    assert qr_pairs[0][0] == "gen_question:hello_world"
+    # the second call is to generate the answer
+    assert qr_pairs[0][1] == "gen_question:hello_world:hello_world"
+    assert qr_pairs[1][0] == "gen_question:foo_bar"
+    assert qr_pairs[1][1] == "gen_question:foo_bar:foo_bar"
+        
+        
+        


### PR DESCRIPTION
- the query/response generation in the `DatasetGenerator` was broken. The synthetic ground-truth response was always getting generated from the last piece of sample context (Which led to a lot of "the answer was not found in the context" issues). 
- added a score to other evaluator classes