### PR TITLE
Filtering out answers not present in data does not happen

### DIFF
--- a/docs/examples/finetuning/knowledge/finetune_knowledge.ipynb
+++ b/docs/examples/finetuning/knowledge/finetune_knowledge.ipynb
@@ -290,7 +290,7 @@
     "        )\n",
     "\n",
     "        print(f\"[{idx}] QA Pair: {qa_pair} \\n Eval: {eval}\")\n",
-    "        if \"NO\" in eval:\n",
+    "        if \"NO\" in str(eval):\n",
     "            continue\n",
     "        else:\n",
     "            # new_lines.append(line)\n",


### PR DESCRIPTION
# Description

The notebook attempts to filter out of the training data any questions not actually answered by the context, but the test `if "NO" in eval` is always false because eval is not a string, it's type `llama_index.llms.base.CompletionResponse`. This casts to a string and makes the filtering work.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [x] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
