### PR TITLE
Fix typo in usage_documents.md (fixes #7896)

### DIFF
--- a/docs/core_modules/data_modules/documents_and_nodes/usage_documents.md
+++ b/docs/core_modules/data_modules/documents_and_nodes/usage_documents.md
@@ -36,7 +36,7 @@ This section covers various ways to customize `Document` objects. Since the `Doc
 
 Documents also offer the chance to include useful metadata. Using the `metadata` dictionary on each document, additional information can be included to help inform responses and track down sources for query responses. This information can be anything, such as filenames or categories. If you are intergrating with a vector database, keep in mind that some vector databases require that the keys must be strings, and the values must be flat (either `str`, `float`, or `int`).
 
-Any information set in the `metadata` dictionary of each document will show up in the `metadata` of each source node created from the document. Additionaly, this information is included in the nodes, enabling the index to utilize it on queries and responses. By default, the metadata is injected into the text for both embedding and LLM model calls.
+Any information set in the `metadata` dictionary of each document will show up in the `metadata` of each source node created from the document. Additionally, this information is included in the nodes, enabling the index to utilize it on queries and responses. By default, the metadata is injected into the text for both embedding and LLM model calls.
 
 There are a few ways to set up this dictionary:
 

--- a/docs/examples/low_level/router.ipynb
+++ b/docs/examples/low_level/router.ipynb
@@ -209,7 +209,7 @@
    "id": "cb39f574-af06-495a-83e0-50866aca9caf",
    "metadata": {},
    "source": [
-    "**Observation**: While the response corresopnds to the correct choice, it can be hacky to parse into a structured output (e.g. a single integer). We'd need to do some string parsing on the choices to extract out a single number, and make it robust to failure modes."
+    "**Observation**: While the response corresoponds to the correct choice, it can be hacky to parse into a structured output (e.g. a single integer). We'd need to do some string parsing on the choices to extract out a single number, and make it robust to failure modes."
    ]
   },
   {


### PR DESCRIPTION
Fixes #7896 and #7874

I found the issue and fixed the typo in the documentation. This resolves issue #7896 and issue #7874

# Description

I found the issue and fixed the typo in the documentation. This resolves issue #7896
Fixed typo in router.ipynb. This resolves issue #7874 

Fixes # (7896)
Fixes # (7874)

## Type of Change

Please delete options that are not relevant.

- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:


- [x] I have made corresponding changes to the documentation
