### PR TITLE
docs fix typo in example ondemand_loader_tool

### DIFF
--- a/docs/core_modules/agent_modules/tools/llamahub_tools_guide.md
+++ b/docs/core_modules/agent_modules/tools/llamahub_tools_guide.md
@@ -29,7 +29,7 @@ A usage example is given below:
 
 ```python
 from llama_hub.wikipedia.base import WikipediaReader
-from llama_index.tools.on_demand_loader_tool import OnDemandLoaderTool
+from llama_index.tools.ondemand_loader_tool import OnDemandLoaderTool
 
 tool = OnDemandLoaderTool.from_defaults(
 	reader,


### PR DESCRIPTION
Fixed typo in an example code in docs: `on_demand_loader_tool` -> `ondemand_loader_tool` to make it work